### PR TITLE
Roles+GroupManagement Adding API methods required to perform group management using the roles module

### DIFF
--- a/node_modules/oae-roles/lib/api.js
+++ b/node_modules/oae-roles/lib/api.js
@@ -13,15 +13,13 @@ var ObjectTypes = module.exports.ObjectTypes = { CONTENT: 'content', GROUP: 'gro
 /**
  * A stateful context object that is used to execute role checks on a principal.
  *
- * @param {String} tenantId The ID of the tenant to which the principal belongs
- * @param {String} principalType The type of principal, as specified by `PrincipalTypes`
- * @param {String} principalId The local ID of the principal (i.e., not globally unique);
+ * @param {Object} The `model.Principal` to which the `SecurityContext` is bound 
  * 
- * @return {Object} A securityContext object that may be used to execute role checks for the principal.
+ * @return {Object} A `SecurityContext` object that may be used to execute role checks for the principal.
  */
-var SecurityContext = module.exports.SecurityContext = function(tenantId, principalType, principalId) {
+var SecurityContext = module.exports.SecurityContext = function(principal) {
 
-    var rowKey = principalType+':'+tenantId+':'+principalId;
+    var rowKey = getPrincipalKey(principal);
     var that = {};
 
     /**
@@ -112,7 +110,7 @@ var SecurityContext = module.exports.SecurityContext = function(tenantId, princi
             return;
         }
 
-        var firstColumn = 0;
+        var firstColumnIndex = 0;
         var columnPrefix = objectType+':';
 
         if (start === null) {
@@ -124,22 +122,21 @@ var SecurityContext = module.exports.SecurityContext = function(tenantId, princi
             // increment the limit if the user specified the start point, because we skip the first entry to get the EXCLUSIVE
             // page range
             limit++;
-            firstColumn = 1;
+            firstColumnIndex = 1;
         }
 
-        // A '|' character is used as an assumption that it will always cause a slice to the end. This could become problematic
-        // if we have characters that go outside the range of ASCII, but AFAICT there is no better way to page the column range through
-        // CQL right now. Another option is to specify the empty string as the end range, which may always splice to the end (up to the
-        // limit-- in this case, we would have to search and slice the resulting array in memory to remove elements of other object types.
-        var end = columnPrefix+'|';
-
-        var cql = 'select first '+limit+' ? .. ? from Role where principal = ?';
-        OAE.runQuery(cql, [start, end, rowKey], function(err, rows) {
+        var cql = 'select first '+limit+' ? .. \'\' from Role where principal = ?';
+        OAE.runQuery(cql, [start, rowKey], function(err, rows) {
             if (!err) {
                 var entries = [];
-                for (var i = firstColumn; i < rows[0]._colCount; i++) {
-                    // add the column to the entries list, the object id will have the ObjectType prefix stripped away from it
+                for (var i = firstColumnIndex; i < rows[0]._colCount; i++) {
                     var col = rows[0].cols[i];
+
+                    // prevents us from overflowing into other object types
+                    if (col.name.indexOf(columnPrefix) !== 0)
+                        break;
+
+                    // add the column to the entries list, the object id will have the ObjectType prefix stripped away from it
                     var objectId = col.name.substring(columnPrefix.length); 
                     entries.push({ 'id': objectId, 'role': col.value });
                 }
@@ -186,4 +183,72 @@ var SecurityContext = module.exports.SecurityContext = function(tenantId, princi
 
     return that;
 };
+
+/**
+ * Get all principal associations to the `ObjectType` for all the principals in the array of `PrincipalTypes`. This is similar
+ * to `SecurityContext.getRolesForObjectType`, except it can be performed on multiple principals at once.
+ * 
+ * The structure of the resulting entries is simply a hash, indicating all object instance ids that were returned. For example:
+ *
+ * {
+ *   'group-a': true,
+ *   'group-b': true
+ * }
+ *
+ * The role is not returned to avoid a misleading anomaly that different users were associated to the same content in different
+ * roles. In which case, the role associated to the object instance is rather unpredictable. If you need to get specific roles,
+ * consider using `SecurityContext.getRolesForObjectType` instead.
+ *
+ * @param {Array} principals The array of `PrincipalTypes` to query for
+ * @param {String} objectType The object type to query for as determined by `ObjectTypes`
+ * @param {Number} limit The maximum number of object instances to return per user
+ * @param {Function} callback A `function(entries, err)` providing all the {object instance} -> {role} mappings aggregated
+ * for all the provided principals queried
+ *
+ * @see {SecurityContext.getRolesForObjectType}
+ */
+module.exports.getAssociationsForPrincipalsAndObjectType = function(principals, objectType, limit, callback) {
+    if (isNaN(limit)) {
+        callback(null, {why: '"limit" parameter must be a number when searching for active roles'});
+        return;
+    }
+
+    // we append a '|' to the `end` range, as | has a high ASCII alphabetical ordering. This may not suffice if object ids have
+    // multi-byte characters, which is technically possible. Unfortunately, I don't think there is a better way to do this with
+    // CQL.
+    var columnPrefix = objectType+':';
+    var start = columnPrefix;
+    var end = start+'|';
+
+    // aggregate the db-level rowKeys from the principals
+    var principalKeys = [];
+    for (var i = 0; i < principals.length; i++) {
+        principalKeys.push(getPrincipalKey(principals[i]));
+    }
+
+    var cql = 'select first '+limit+' ? .. ? from Role where principal in (?)';
+    OAE.runQuery(cql, [start, end, principalKeys], function(err, rows) {
+        if (!err) {
+            var entries = {};
+
+            // aggregate all object instances from all the rows (principals) into the entries hash
+            for (var r = 0; r < rows.rowCount(); r++) {
+                var row = rows[r];
+                for (var c = 0; c < row._colCount; c++) {
+                    var col = row.cols[c];
+                    var objectId = col.name.substring(columnPrefix.length);
+                    entries[objectId] = true;
+                }
+            }
+            
+            callback(entries);
+        } else {
+            callback(null, err);
+        }
+    });
+};
+
+function getPrincipalKey(principal) {
+    return principal.principalType+':'+principal.tenantId+':'+principal.principalId;
+}
 

--- a/node_modules/oae-roles/lib/dataload.js
+++ b/node_modules/oae-roles/lib/dataload.js
@@ -1,5 +1,6 @@
 var OAE = require('oae-util/lib/OAE');
 var api = require('oae-roles/lib/api');
+var model = require('oae-roles/lib/model');
 var schema = require('oae-roles/lib/schema');
 
 module.exports = (function() {
@@ -50,7 +51,7 @@ module.exports = (function() {
 
         var userId = baseUserId+'-'+numUserIdsPerTenant;
         var contentId = baseContentId+'-'+numUserIdsPerTenant;
-        var securityContext = new api.SecurityContext(tenantId, api.PrincipalTypes.USER, userId);
+        var securityContext = new api.SecurityContext(new model.Principal(tenantId, api.PrincipalTypes.USER, userId));
 
         loadContentRolesForUser(securityContext, baseContentId, numContentPerUserId, function() {
             loadUserIdsForTenant(tenantId, baseUserId, baseContentId, numUserIdsPerTenant-1, numContentPerUserId, callback);

--- a/node_modules/oae-roles/lib/model.js
+++ b/node_modules/oae-roles/lib/model.js
@@ -1,0 +1,10 @@
+
+module.exports.Principal = function(tenantId, principalType, principalId) {
+    var that = {};
+
+    that.tenantId = tenantId;
+    that.principalType = principalType;
+    that.principalId = principalId;
+
+    return that;
+}

--- a/node_modules/oae-roles/tests/roles.js
+++ b/node_modules/oae-roles/tests/roles.js
@@ -1,5 +1,6 @@
 var OAE = require('oae-util/lib/OAE');
 var api = require('oae-roles/lib/api');
+var model = require('oae-roles/lib/model');
 var schema = require('oae-roles/lib/schema');
 var PrincipalTypes = api.PrincipalTypes;
 var ObjectTypes = api.ObjectTypes;
@@ -7,10 +8,6 @@ var ObjectTypes = api.ObjectTypes;
 var KEYSPACE = 'oae';
 
 module.exports.setUp = function(callback) {
-
-    // TODO: Replace with a "refreshKeySpace" method from some utility method.
-
-    // we don't know if the keyspace existed before. lets make sure it is cleared
     OAE.initializeKeySpace(function() {
         schema.dropSchema(function(err) {
             if (err) throw err;
@@ -28,11 +25,14 @@ module.exports.tearDown = function(callback) {
   });
 }
 
+/**
+ * Verify that users with the same userid from different tenants maintain distinct role associations
+ */
 module.exports.testTenantSeparation = function(test) {
     test.expect(8);
 
-    var securityContextA = new api.SecurityContext('testTenantSeparationA', PrincipalTypes.USER, 'mrvisser');
-    var securityContextB = new api.SecurityContext('testTenantSeparationB', PrincipalTypes.USER, 'mrvisser');
+    var securityContextA = new api.SecurityContext(new model.Principal('testTenantSeparationA', PrincipalTypes.USER, 'mrvisser'));
+    var securityContextB = new api.SecurityContext(new model.Principal('testTenantSeparationB', PrincipalTypes.USER, 'mrvisser'));
 
     securityContextA.addRole(ObjectTypes.CONTENT, 'testTenantSeparationContent', 'manager', function(err) {
         test.ok(!err);
@@ -63,10 +63,13 @@ module.exports.testTenantSeparation = function(test) {
     });
 };
 
+/**
+ * Verify the functionality of the `api.SecurityContext.hasRole` function
+ */
 module.exports.testHasRole = function(test) {
     test.expect(6);
 
-    var securityContext = new api.SecurityContext('testHasRole', PrincipalTypes.USER, 'mrvisser');
+    var securityContext = new api.SecurityContext(new model.Principal('testHasRole', PrincipalTypes.USER, 'mrvisser'));
 
     // add the 'manager' role
     securityContext.addRole(ObjectTypes.CONTENT, 'testHasRoleContent', 'manager', function(err) {
@@ -92,10 +95,13 @@ module.exports.testHasRole = function(test) {
     });
 };
 
+/**
+ * Verify the functionality of the `api.SecurityContext.hasAnyRole` function
+ */
 module.exports.testHasAnyRole = function(test) {
     test.expect(6);
 
-    var securityContext = new api.SecurityContext('testHasAnyRole', PrincipalTypes.USER, 'mrvisser');
+    var securityContext = new api.SecurityContext(new model.Principal('testHasAnyRole', PrincipalTypes.USER, 'mrvisser'));
 
     // add the 'manager' role
     securityContext.addRole(ObjectTypes.CONTENT, 'testHasAnyRoleContent', 'manager', function(err) {
@@ -121,14 +127,17 @@ module.exports.testHasAnyRole = function(test) {
     });
 };
 
+/**
+ * Verify the functionality of the `api.SecurityContext.getRolesForObjectType` function
+ */
 module.exports.testGetRolesForObjectType = function(test) {
     test.expect(9);
 
     var baseViewerContentId = 'contentIView';
     var baseManagerContentId = 'contentIManage';
-    var securityContext = new api.SecurityContext('testGetRolesForObjectType', PrincipalTypes.USER, 'mrvisser');
-    loadContentRoles(securityContext, baseViewerContentId, 300, 'viewer', function() {
-        loadContentRoles(securityContext, baseManagerContentId, 300, 'manager', function() {
+    var securityContext = new api.SecurityContext(new model.Principal('testGetRolesForObjectType', PrincipalTypes.USER, 'mrvisser'));
+    loadContentRoles(securityContext, baseViewerContentId, ObjectTypes.CONTENT, 300, 'viewer', function() {
+        loadContentRoles(securityContext, baseManagerContentId, ObjectTypes.CONTENT, 300, 'manager', function() {
 
             // an aggregate to hold a unique set of all keys. Used to ensure we get all the elements back
             var aggregate = {};
@@ -169,14 +178,158 @@ module.exports.testGetRolesForObjectType = function(test) {
     });
 };
 
-function loadContentRoles(securityContext, baseContentId, numContentItems, role, callback) {
+/**
+ * Verify the functionality of the `api.getAssociationsForPrincipalsAndObjectType` function
+ */
+module.exports.testGetAssociationsForPrincipalsAndObjectType = function(test) {
+    test.expect(8);
+
+    var baseViewerContentId = 'contentIView';
+    var baseManagerContentId = 'contentIManage';
+    var principal1 = new model.Principal('testGetRolesForObjectType', PrincipalTypes.USER, 'mrvisser');
+    var principal2 = new model.Principal('testGetRolesForObjectType', PrincipalTypes.GROUP, 'simong');
+
+    var securityContext1 = new api.SecurityContext(principal1);
+    var securityContext2 = new api.SecurityContext(principal2);
+
+    loadContentRoles(securityContext1, baseViewerContentId, ObjectTypes.GROUP, 300, 'viewer', function() {
+        loadContentRoles(securityContext2, baseManagerContentId, ObjectTypes.GROUP, 300, 'manager', function() {
+
+            // make sure they work together
+            api.getAssociationsForPrincipalsAndObjectType([principal1, principal2], ObjectTypes.GROUP, 1000, function(entries, err) {
+                test.ok(!err);
+                test.equal(Object.keys(entries).length, 600);
+                
+                // make sure they work individually
+                api.getAssociationsForPrincipalsAndObjectType([principal1], ObjectTypes.GROUP, 1000, function(entries, err) {
+                    test.ok(!err);
+                    test.equal(Object.keys(entries).length, 300);
+
+                    api.getAssociationsForPrincipalsAndObjectType([principal2], ObjectTypes.GROUP, 1000, function(entries, err) {
+                        test.ok(!err);
+                        test.equal(Object.keys(entries).length, 300);
+
+                        // test per-principal limitations
+                        api.getAssociationsForPrincipalsAndObjectType([principal1, principal2], ObjectTypes.GROUP, 100, function(entries, err) {
+                            test.ok(!err);
+                            test.equal(Object.keys(entries).length, 200);
+                            test.done();
+                        });
+                    });
+                });
+            });
+
+        });
+    });
+};
+
+/**
+ * Verify the functionality for the use-case of getting full group ancestry using `api.getAssociationsForPrincipalsAndObjectType`
+ */
+module.exports.testExplodeGroupHierarchy = function(test) {
+    test.expect(1);
+
+    var tenantId = 'testExplodeGroupHierarchy';
+
+    // user 'mrvisser' is part of 30 groups
+    joinGroups(tenantId, 'mrvisser', PrincipalTypes.USER, 'member-direct', 30, function() {
+
+        // groups 1-5 are members of other groups
+        joinGroups(tenantId, 'member-direct-1', PrincipalTypes.GROUP, 'member-indirect-1', 5, function() {
+            joinGroups(tenantId, 'member-direct-2', PrincipalTypes.GROUP, 'member-indirect-2', 5, function() {
+                joinGroups(tenantId, 'member-direct-3', PrincipalTypes.GROUP, 'member-indirect-3', 5, function() {
+                    joinGroups(tenantId, 'member-direct-4', PrincipalTypes.GROUP, 'member-indirect-4', 5, function() {
+                        joinGroups(tenantId, 'member-direct-5', PrincipalTypes.GROUP, 'member-indirect-5', 5, function() {
+
+                            // groups 5-10 have other groups as children
+                            addMembers(tenantId, 'member-direct-5', 'notmember-5', 5, function() {
+                                addMembers(tenantId, 'member-direct-6', 'notmember-6', 5, function() {
+                                    addMembers(tenantId, 'member-direct-7', 'notmember-7', 5, function() {
+                                        addMembers(tenantId, 'member-direct-8', 'notmember-8', 5, function() {
+                                            addMembers(tenantId, 'member-direct-9', 'notmember-9', 5, function() {
+                                                addMembers(tenantId, 'member-direct-10', 'notmember-10', 5, function() {
+                                                    var mrvisser = new model.Principal(tenantId, PrincipalTypes.USER, 'mrvisser');
+
+                                                    explodeGroupAncestry(tenantId, [mrvisser], {}, function(results) {
+
+                                                        // groups prefixed with 'member' are groups that mrvisser is indirectly a member of
+                                                        // groups prefixed with 'notmember' are groups that mrvisser is NOT indirectly a member of
+                                                        // mrvisser should be a member of 30+(5*5) = 55 groups
+                                                        // there should be 5*6 = 30 groups that mrvisser is not a member of
+
+                                                        test.equal(Object.keys(results).length, 55);
+                                                        test.done();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+}
+
+function explodeGroupAncestry(tenantId, principals, results, callback) {
+    var nextPrincipalBatch = [];
+    api.getAssociationsForPrincipalsAndObjectType(principals, ObjectTypes.GROUP, 1000, function(entries, err) {
+        if (err) throw err;
+        var ancestors = Object.keys(entries);
+        for (var i = 0; i < ancestors.length; i++) {
+            var ancestor = ancestors[i];
+            if (!results[ancestor]) {
+                results[ancestor] = true;
+                nextPrincipalBatch.push(new model.Principal(tenantId, PrincipalTypes.GROUP, ancestor));
+            }
+        }
+
+        if (nextPrincipalBatch.length > 0) {
+            explodeGroupAncestry(tenantId, nextPrincipalBatch, results, callback);
+        } else {
+            callback(results);
+        }
+    });
+}
+
+
+function joinGroups(tenantId, memberId, memberPrincipalType, groupPrefix, numGroups, callback) {
+    if (numGroups === 0) {
+        callback();
+        return;
+    }
+
+    var securityContext = new api.SecurityContext(new model.Principal(tenantId, memberPrincipalType, memberId));
+    securityContext.addRole(ObjectTypes.GROUP, groupPrefix+'-'+numGroups, 'member', function(err) {
+        if (err) throw err;
+        joinGroups(tenantId, memberId, memberPrincipalType, groupPrefix, numGroups-1, callback);
+    });
+}
+
+function addMembers(tenantId, groupId, memberPrefix, numMembers, callback) {
+    if (numMembers === 0) {
+        callback();
+        return;
+    }
+
+    var securityContext = new api.SecurityContext(new model.Principal(tenantId, PrincipalTypes.GROUP, memberPrefix+'-'+numMembers));
+    securityContext.addRole(ObjectTypes.GROUP, groupId, 'member', function(err) {
+        if (err) throw err;
+        addMembers(tenantId, groupId, memberPrefix, numMembers-1, callback);
+    });
+}
+
+function loadContentRoles(securityContext, baseContentId, objectType, numContentItems, role, callback) {
     if (numContentItems === 0) {
         callback();
         return;
     }
 
-    securityContext.addRole(ObjectTypes.CONTENT, baseContentId+'-'+numContentItems, role, function(err) {
+    securityContext.addRole(objectType, baseContentId+'-'+numContentItems, role, function(err) {
         if (err) throw err;
-        loadContentRoles(securityContext, baseContentId, numContentItems-1, role, callback);
+        loadContentRoles(securityContext, baseContentId, objectType, numContentItems-1, role, callback);
     });
 }


### PR DESCRIPTION
The key methods are:

**api.SecurityContext.getRolesForObjectType:** Allows the user to get all the roles assigned to a user for all instances of content that is of a particular object type. The result is that you can search for all role associations for a user of object type `ObjectTypes.GROUP`, to get all the groups to which they belong.

**api.getAssociationsForPrincipalsAndObjectType:** Allows the user to perform a multi-get on the roles storage, for a particular `ObjectType`. Multiple multi-gets can be performed until no new groups are found, and this would result in the total group ancestry. An exact example can be found in the tests, where I specifically test this use-case: https://github.com/mrvisser/Hilary/blob/30539733cd2d505e8536f69dedfc0ca1f9aa536c/node_modules/oae-roles/tests/roles.js#L277 . There is no top-level API method for this yet, because I'm still not convinced that the exploding of group membership should happen in the roles module, but instead I think it should be in the group memberships module
