### PR TITLE
Fix typo in oae-principles api.js comment

### DIFF
--- a/node_modules/oae-principals/lib/api.js
+++ b/node_modules/oae-principals/lib/api.js
@@ -17,6 +17,6 @@ var _ = require('underscore');
 var groupAPI = require('./api.group');
 var userAPI = require('./api.user');
 
-// This file would become unmaintable if all the logic would be placed here.
+// This file would become unmaintainable if all the logic would be placed here.
 // That's why we split them up in a couple of files of which the api logic gets exported.
 _.extend(module.exports, groupAPI, userAPI);


### PR DESCRIPTION
Typo "unmainable"

// This file would become unmainable if all the logic would be placed here.

should be

// This file would become unmaintainable if all the logic would be placed here.
