### PR TITLE
Clustered starting and stopping of tenants.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-unit:
 
 test-coverage: lib-cov
 	@echo "Running tests"
-	@cd target; export OAE_COVERING=true; ../node_modules/.bin/mocha --ignore-leaks --reporter html-cov $(MOCHA_OPTS) node_modules/oae-tests/runner/beforeTests.js $(MODULES) > coverage.html
+	@cd target; export OAE_COVERING=true; ../node_modules/.bin/mocha --ignore-leaks --timeout $(TIMEOUT) --reporter html-cov $(MOCHA_OPTS) node_modules/oae-tests/runner/beforeTests.js $(MODULES) > coverage.html
 	@echo "Code Coverage report generated at target/coverage.html"
 	@open target/coverage.html
 

--- a/app.js
+++ b/app.js
@@ -17,6 +17,6 @@ var OAE = require('oae-util/lib/oae');
 
 var config = require('./config').config;
 
-OAE.init(config.cassandra, function() {
+OAE.init(config, function() {
     console.log("All done ... Enjoy!");
 });

--- a/config.js
+++ b/config.js
@@ -24,6 +24,11 @@ config.cassandra = {
     'timeout': 3000
 };
 
+config.redis = {
+    'host': '127.0.0.1',
+    'port': 6379
+};
+
 
 
 module.exports.config = config;

--- a/node_modules/oae-config-aggregator/public/admin.html
+++ b/node_modules/oae-config-aggregator/public/admin.html
@@ -69,8 +69,10 @@
                                     <td><a href="http://${tenant.baseUrl}/api/tenant" title="${tenant.name}" target="_blank">${tenant.baseUrl}</a></td>
                                     <td>${tenant.port}</td>
                                     <td>
-                                        {if status == "0"}
+                                        {if tenant.active}
                                             <span class="text-success">Running</span>
+                                        {else}
+                                            <span class="text-error">Maintenance mode</span>
                                         {/if}
                                     </td>
                                     <td>
@@ -118,6 +120,12 @@
                                     <label for="createtenant_port" class="control-label">Port:</label>
                                     <div class="controls">
                                         <input type="text" name="port" id="createtenant_port" placeholder="Port"/>
+                                    </div>
+                                </div>
+                                <div class="control-group">
+                                    <label for="createtenant_baseurl" class="control-label">Base URL:</label>
+                                    <div class="controls">
+                                        <input type="text" name="baseurl" id="createtenant_baseurl" placeholder="Base URL"/>
                                         <button type="button" id="createtenant_submit_button" class="btn btn-primary">Create new tenant</button>
                                     </div>
                                 </div>

--- a/node_modules/oae-config-aggregator/public/js/admin.js
+++ b/node_modules/oae-config-aggregator/public/js/admin.js
@@ -289,7 +289,8 @@
                 'id': $('#createtenant_id').val(),
                 'name': $('#createtenant_name').val(),
                 'description': $('#createtenant_description').val(),
-                'port': $('#createtenant_port').val()
+                'port': $('#createtenant_port').val(),
+                'baseurl': $('#createtenant_baseurl').val()
             },
             success: function(data) {
                 getTenants(function(tenants) {
@@ -306,11 +307,9 @@
      * Starts or stops a tenant server
      */
     var startStopTenant = function(tenants, isStart, callback) {
-        var data = {};
+        var ports = [];
         $.each(tenants, function(index, tenant) {
-            data[tenant.alias] = {
-                'port': tenant.port
-            };
+            ports.push(tenant.port);
         });
 
         var url = '/api/tenant/stop';
@@ -321,7 +320,9 @@
         $.ajax({
             url: url,
             type: 'POST',
-            data: data,
+            data: {
+                'tenants': ports
+            },
             success: function(data) {
                 if ($.isFunction(callback)) {
                     callback(true);
@@ -338,17 +339,17 @@
      * Stops a tenant server
      */
     var deleteTenant = function(tenants, callback) {
-        var data = {};
+        var ports = [];
         $.each(tenants, function(index, tenant) {
-            data[tenant.alias] = {
-                'port': tenant.port
-            };
+            ports.push(tenant.port);
         });
 
         $.ajax({
             url: '/api/tenant/delete',
             type: 'POST',
-            data: data,
+            data: {
+                'tenants': ports
+            },
             success: function(data) {
                 if ($.isFunction(callback)) {
                     callback(true);

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -14,70 +14,217 @@
  */
 
 var express = require('express');
+var http = require('http');
+var redis = require('redis');
+var util = require('util');
 
 var OAE = require('oae-util/lib/oae');
 var IO = require('oae-util/lib/io');
 var Cassandra = require('oae-util/lib/cassandra');
+var Pubsub = require('oae-util/lib/pubsub');
+var Validator = require('oae-util/lib/validator').Validator;
 
 var model = require('./model');
 
-/**
- * Start a new tenant
- * @param {Tenant}          tenant          The tenant object representing the tenant to be started
- * @param {Function(err)}   callback        Standard callback function execute when the tenant is fully started up
- * @param {Object}          callback.err    Error object containing error message
- */
-var startTenant = module.exports.startTenant = function(tenant, callback) {
-    callback = callback || function() {};
-    if (tenant && tenant.port) {
-        tenant.server = express();
-        tenant.server.listen(tenant.port);
-        tenant.server.use(function(req, res, next){
-            req.tenant = tenant;
-            req.user = null;
-            next();
+var runningServers = {};
+
+
+
+Pubsub.on('oae-tenants', function (message) {
+    // Commands are of the form:
+    //     start 2001
+    //     stop 2001
+    var args = message.split(' ');
+    var cmd = args.shift();
+    if (cmd === 'start') {
+        var port = args.shift();
+        getTenantByPort(port, function(err, tenant) {
+            if (err) {
+                return console.warn(err.msg);
+            }
+            _startTenant(tenant, function(err, startedInMaintenanceMode) {
+                if (err) {
+                    console.warn('Could not start tenant on port %d', port);
+                } else {
+                    if (startedInMaintenanceMode) {
+                        console.log('Tenant %s on port %d started (in maintenance mode.)', tenant.alias, port);
+                    } else {
+                        console.log('Tenant %s on port %d started.', tenant.alias, port);
+                    }
+                }
+            });
         });
-        tenant.passport = require('passport');
-        registerAPI(tenant, callback);
-        console.log('Start tenant "' + tenant.name + '" on port ' + tenant.port);
+    } else if (cmd === 'stop') {
+        var port = args.shift();
+        getTenantByPort(port, function(err, tenant) {
+            if (err) {
+                return console.warn(err.msg);
+            }
+            _stopTenant(tenant, function(err) {
+                if (err) {
+                    console.warn(err.msg);
+                } else {
+                    console.log('Tenant on port %d stopped.', port);
+                }
+            });
+        });
     } else {
-        callback({'code': 500, 'msg': 'The tenant could not be started as it is invalid'});
+        console.log('Received a message but did not know what to do with it: %s', message);
+    }
+});
+
+/**
+ * Publishes a message that a new tenant should be started.
+ * Note that the actual server startup will happen asynchronous from this method.
+ *
+ * @param {Tenant}          tenant          The tenant object representing the tenant to be started
+ */
+module.exports.startTenant = function(tenant) {
+    Pubsub.publish('oae-tenants', 'start ' + tenant.port);
+};
+
+/**
+ * Start a new tenant by listening on the provided ports.
+ *
+ * @param {Tenant}                          tenant                      The tenant object representing the tenant to be started
+ * @param {Function(err, maintenanceMode)}  callback                    Standard callback function
+ * @param {Object}                          callback.err                An error object (if any)
+ * @param {Boolean}                         callback.maintenanceMode    Whether or not this tenant started in maintenance mode.
+ * @private
+ */
+var _startTenant = function(tenant, callback) {
+    callback = callback || function() {};
+    if (tenant) {
+        if (runningServers[tenant.port]) {
+            // We already created the server object.
+            // Take it out of maintenance mode.
+            runningServers[tenant.port].inMaintenanceMode = !tenant.active;
+            callback(false, !tenant.active);
+        } else {
+            // Create a basic express server.
+            tenant.server = express();
+
+            // Keep all the servers in memory so we can access them later.
+            runningServers[tenant.port] = http.createServer(tenant.server);
+            runningServers[tenant.port].listen(tenant.port);
+            runningServers[tenant.port].inMaintenanceMode = !tenant.active;
+
+            // Provide this middleware that checks if this server should be in maintenance mode
+            // and if not, expose the tenant on each request.
+            tenant.server.use(function(req, res, next) {
+                if (runningServers[tenant.port].inMaintenanceMode) {
+                    // If we're running in maintenance mode, there is no point in keeping connections open.
+                    res.setHeader('Connection', 'Close');
+                    return res.send(200, 'This server is currently in maintenance mode. Please check back later.');
+                }
+                req.tenant = tenant;
+                req.user = null;
+                next();
+            });
+
+            // Each tenant has it's own passport impl
+            tenant.passport = require('passport');
+
+            // The server has start uped, register all our endpoints.
+            registerAPI(tenant, function() {
+                callback(false, !tenant.active);
+            });
+        }
+    } else {
+        callback({'code': 400, 'msg': 'No tenant was provided.'});
+    }
+};
+
+/**
+ * Stops a running tenant.
+ *
+ * @param   {Tenant}        tenant          The tenant object representing the tenant to be stopped
+ * @param   {Function(err)} callback        Standard callback function
+ * @param   {Object}        callback.err    An error object (if any.)
+ * @private
+ */
+var _stopTenant = function(tenant, callback) {
+    if (tenant && runningServers[tenant.port]) {
+        // Stick that server into maintenance mode.
+        runningServers[tenant.port].inMaintenanceMode = true;
+        callback();
+    } else {
+        callback({'code': 404, 'msg': 'No server found on that port.'});
     }
 };
 
 /**
  * Put a tenant in maintenance mode or take it out of it.
- * @param {Tenant}   tenant              The tenant object representing the tenant to be stopped
- * @param {Boolean}  needsMaintenance    True if the tenant needs to go into maintenance mode
- * @param {Function} callback            Callback function executed when request is completed.
+ * @param {Array<Number>}   ports               An array of ports that should be stopped.
+ * @param {Boolean}         needsMaintenance    True if the tenant needs to go into maintenance mode
+ * @param {Function(err)}   callback            Callback function executed when request is completed.
+ * @param {Object}          callback.err        An error object (if any.)
  */
-var putTenantsInMaintenanceMode = module.exports.putTenantsInMaintenanceMode = function(tenants, needsMaintenance, callback) {
+var putTenantsInMaintenanceMode = module.exports.putTenantsInMaintenanceMode = function(ports, needsMaintenance, callback) {
     callback = callback || function() {};
-    var queries = []
-    for (var i in tenants) {
+    if (!ports) {
+        return callback({'code': 400, 'msg': 'Please provide a ports array'});
+    }
+    if (!util.isArray(ports)) {
+        ports = [ports];
+    }
+
+    // Store the activity flag in cassandra.
+    var queries = [];
+    ports.forEach(function(port) {
         queries.push({
             'query': 'UPDATE Tenant SET active = ? WHERE port = ?',
-            'parameters': [!needsMaintenance, tenants[i].port]
+            'parameters': [!needsMaintenance, port]
         });
-    }
-    Cassandra.runBatchQuery(queries, callback);
+    });
+    Cassandra.runBatchQuery(queries, function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Broadcast the message accross the cluster
+        // so we can start/stop the tenants.
+        var cmd = (needsMaintenance) ? 'stop' : 'start';
+        ports.forEach(function(port) {
+            Pubsub.publish('oae-tenants', cmd + ' ' + port);
+        });
+        callback();
+    });
 };
 
 /**
- * Put a tenant in maintenance mode or take it out of it.
- * @param {Tenant}   tenant              The tenant object representing the tenant to be stopped
+ * Rather than physically deleting a tenant, we just stick it in maintenance mode for now.
+ *
+ * @param {Tenant}   ports               The tenant object representing the tenant to be stopped
  * @param {Function} callback            Callback function executed when request is completed.
  */
-var deleteTenants = module.exports.deleteTenants = function(tenants, callback) {
+var deleteTenants = module.exports.deleteTenants = function(ports, callback) {
     callback = callback || function() {};
+    if (!ports) {
+        return callback({'code': 400, 'msg': 'Please provide a ports array'});
+    }
+    if (!util.isArray(ports)) {
+        ports = [ports];
+    }
+
     var queries = []
-    for (var i in tenants) {
+    ports.forEach(function(port) {
         queries.push({
             'query': 'UPDATE Tenant SET active = ?, deleted = ? WHERE port = ?',
-            'parameters': [false, true, tenants[i].port]
+            'parameters': [false, true, port]
         });
-    }
-    Cassandra.runBatchQuery(queries, callback);
+    });
+    Cassandra.runBatchQuery(queries, function(err) {
+        if (err) {
+            return callback(err);
+        }
+        // Broadcast the message accross the cluster
+        // so we can stop the tenants.
+        ports.forEach(function(port) {
+            Pubsub.publish('oae-tenants', 'stop ' + port);
+        });
+        callback();
+    });
 };
 
 /**
@@ -92,8 +239,10 @@ var getAllTenants = module.exports.getAllTenants = function(callback) {
             var tenants = [];
             if (hasTenant(rows)) {
                 rows.forEach(function(row) {
-                    var t = mapToTenant(row, false);
-                    t ? tenants.push(t) : '';
+                    var tenant = mapToTenant(row, false);
+                    if (!tenant.deleted) {
+                        tenants.push(tenant);
+                    }
                 });
             }
             callback(null, tenants);
@@ -152,29 +301,43 @@ var getTenantByAlias = module.exports.getTenantByAlias = function(alias, callbac
 /**
  * Create a tenant using the provided information.
  * 
- * @param {String}   alias The unique alias assigned to the tenant
- * @param {String}   name A descriptive short name for the tenant
- * @param {String}   description A long description of the tenant
- * @param {Number}   port The port on which the tenant should listen
- * @param {String}   baseUrl The baseUrl on which this tenant is proxying (ie: oae.cam.ac.uk or oae.gatech.edu)
- * @param {Function} callback A function(err, tenant) specifying the tenant information that was persisted.
+ * @param {String}                  alias           The unique alias assigned to the tenant
+ * @param {String}                  name            A descriptive short name for the tenant
+ * @param {String}                  description     A long description of the tenant
+ * @param {Number}                  port            The port on which the tenant should listen
+ * @param {String}                  baseUrl         The baseUrl on which this tenant is proxying (ie: oae.cam.ac.uk or oae.gatech.edu)
+ * @param {Function(err, tenant)}   callback        A function(err, tenant) specifying the tenant information that was persisted.
+ * @param {Object}                  callback.err    An error object (if any)
+ * @param {Tenant}                  callback.tenant The tenant that was persisted.
  */
 var createTenant = module.exports.createTenant = function(alias, name, description, port, baseUrl, callback) {
     callback = callback || function() {};
+    var validator = new Validator();
+    validator.check(alias, {'code': 400, 'msg': 'Missing alias'}).notEmpty();
+    validator.check(name, {'code': 400, 'msg': 'Missing name'}).notEmpty();
+    validator.check(description, {'code': 400, 'msg': 'Missing description'}).notEmpty();
+    validator.check(port, {'code': 400, 'msg': 'Missing port'}).notEmpty();
+    validator.check(port, {'code': 400, 'msg': 'Provided port is not a number'}).isInt();
+    validator.check(baseUrl, {'code': 400, 'msg': 'Missing base url'}).notEmpty();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
     getTenantByPort(port, function(err, tenant) {
         if (!tenant) {
             getTenantByAlias(alias, function(err, tenant) {
                 if (!tenant) {
                     baseUrl = baseUrl || "localhost:" + port;
                     description = description || "";
-                    tenant = new model.Tenant(alias, name, description, port, baseUrl);
+                    tenant = new model.Tenant(alias, name, description, port, baseUrl, true, false);
                     // no tenant by this alias or port exist, create one
-                    Cassandra.runQuery('UPDATE Tenant SET alias = ?, name = ?, description = ?, baseUrl = ? where port = ?',
-                        [tenant.alias, tenant.name, tenant.description || "", baseUrl, tenant.port], function(err) {
+                    Cassandra.runQuery('UPDATE Tenant SET alias = ?, name = ?, description = ?, baseUrl = ?, active = ? where port = ?',
+                        [tenant.alias, tenant.name, tenant.description, baseUrl, tenant.active, tenant.port], function(err) {
                         if (!err) {
-                            startTenant(tenant, function() {
-                                callback(null, tenant);
-                            });
+                            // Send a message to all the app servers in the cluster that they
+                            // should start up the tenant.
+                            Pubsub.publish('oae-tenants', 'start ' + port);
+                            callback(false, tenant);
                         } else {
                             callback(err);
                         }
@@ -228,10 +391,5 @@ var hasTenant = function(rows) {
  */
 var mapToTenant = function(row, returnDeleted) {
     var hash = Cassandra.rowToHash(row);
-    if (returnDeleted) {
-        return new model.Tenant(hash.alias, hash.name, hash.description, hash.port, hash.baseUrl, hash.active, hash.deleted);
-    } else if (!hash.deleted) {
-        return new model.Tenant(hash.alias, hash.name, hash.description, hash.port, hash.baseUrl, hash.active, hash.deleted);
-    }
-    return false;
+    return new model.Tenant(hash.alias, hash.name, hash.description, hash.port, hash.baseUrl, hash.active, hash.deleted);
 };

--- a/node_modules/oae-tests/lib/api.js
+++ b/node_modules/oae-tests/lib/api.js
@@ -23,3 +23,4 @@ var UserTestAPI = require('./api.user');
 
 module.exports.User = UserTestAPI;
 module.exports.Http = HttpTestAPI;
+module.exports.Tenant = require('./api.tenant');

--- a/node_modules/oae-tests/lib/api.tenant.js
+++ b/node_modules/oae-tests/lib/api.tenant.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012 Sakai Foundation (SF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var request = require('request');
+
+var TestUserAPI = require('./api.user');
+var TenantAPI = require('oae-tenants');
+
+
+// Stopping a server is async, this variable
+// holds how long we should wait before returning on start/stop/delete
+// of a tenant.
+var WAIT_TIME = 1000;
+
+var createTenant = module.exports.createTenant = function(tenant, callback) {
+    // Todo: authentication once that gets merged in.
+    request.post({
+            'uri': 'http://localhost:2000/api/tenant/create',
+            'json': {
+                'id': tenant.alias,
+                'name': tenant.name,
+                'description': tenant.description,
+                'port': tenant.port,
+                'baseurl': tenant.baseUrl
+            }
+        }, callback);
+};
+
+var stopTenants = module.exports.stopTenants = function(tenants, callback) {
+    // Todo: authentication once that gets merged in.
+    request.post({
+        'uri': 'http://localhost:2000/api/tenant/stop',
+        'form': {
+            'tenants': tenants
+        }
+    }, function(err, response, body) {
+        setTimeout(function() {
+            callback(err, response, body);
+        }, WAIT_TIME);
+    });
+};
+
+var startTenants = module.exports.startTenants = function(tenants, callback) {
+    // Todo: authentication once that gets merged in.
+    request.post({
+        'uri': 'http://localhost:2000/api/tenant/start',
+        'form': {
+            'tenants': tenants
+        }
+    }, function(err, response, body) {
+        setTimeout(function() {
+            callback(err, response, body);
+        }, WAIT_TIME);
+    });
+};
+
+var deleteTenants = module.exports.deleteTenants = function(tenants, callback) {
+    // Todo: authentication once that gets merged in.
+    request.post({
+        'uri': 'http://localhost:2000/api/tenant/delete',
+        'form': {
+            'tenants': tenants
+        }
+    }, function(err, response, body) {
+        setTimeout(function() {
+            callback(err, response, body);
+        }, WAIT_TIME);
+    });
+};

--- a/node_modules/oae-tests/runner/beforeTests.js
+++ b/node_modules/oae-tests/runner/beforeTests.js
@@ -27,11 +27,17 @@ var OAE = require('oae-util/lib/oae');
 // The Cassandra connection config that should be used for unit tests, using
 // a custom keyspace for just the tests
 var config = {
-    'hosts': ['localhost:9160'],
-    'keyspace': 'oaeTest',
-    'user': '',
-    'pass': '',
-    'timeout': 3000
+    'cassandra': {
+        'hosts': ['localhost:9160'],
+        'keyspace': 'oaeTest',
+        'user': '',
+        'pass': '',
+        'timeout': 3000
+    },
+    'redis': {
+        'host': '127.0.0.1',
+        'port': 6379
+    }
 };
 
 /**
@@ -41,7 +47,7 @@ var config = {
  */
 var finishTests = function(callback) {
     // Clean up after ourselves
-    cassandra.dropKeyspace(config.keyspace, function(err) {
+    cassandra.dropKeyspace(config.cassandra.keyspace, function(err) {
         if (err) {
             console.error(err);
         }
@@ -64,10 +70,8 @@ var setUpTenants = function(err, callback) {
     var tenantAPI = require('oae-tenants');
     tenantAPI.createTenant("camtest", "Cambridge University Test", "Cambridge University Description", 2001, "oae.cam.ac.uk", function() {
         tenantAPI.createTenant("gttest", "Georgia Tech Test", "Georgia Tech Description", 2002, "oae.gatech.edu", function() {
-            // If we're in coverage mode we've disabled initial log output.
-            // Re-enable it to run the tests. If a tests outputs something
-            // it's an indicitation that something has gone wrong.
-            callback();
+            // Because the actual server startup is async from the createTenant request we wait a bit till they have started up.
+            setTimeout(callback, 2000);
         });
     });
 };
@@ -80,16 +84,8 @@ if (process.env.OAE_COVERING) {
 // for all of the different OAE modules
 before(function(callback) {
     OAE.init(config, function(err) {
-        console.log(err);
         setUpTenants(err, callback);
     });
-});
-
-beforeEach(function() {
-    if (process.env.OAE_COVERING) {
-        // If we're running in coverage mode we supress log output.
-        console.log = function() {};
-    }
 });
 
 

--- a/node_modules/oae-util/lib/oae.js
+++ b/node_modules/oae-util/lib/oae.js
@@ -19,12 +19,14 @@ var fs = require('fs');
 var Cassandra = require('oae-util/lib/cassandra');
 var Context = require('oae-context').Context;
 var PrincipalAPI = require('oae-principals');
-var tenantAPI = require('oae-tenants');
+var Pubsub = require('./pubsub');
+var TenantAPI = require('oae-tenants');
 var Tenant = require('oae-tenants/lib/model').Tenant;
 var fs = require('fs');
 
 var IO = require('./io');
 var configAPI = require('oae-config-aggregator');
+var PubSub = require('./pubsub');
 
 
 ///////////////////////////
@@ -67,43 +69,39 @@ var registerAPI = function(server, config, callback) {
         });
     });
 
-    server.post('/api/tenant/create', function(req, res, next) {
-        if (req.body.port && req.body.id) {
-            tenantAPI.createTenant(req.body.id, req.body.name, req.body.description, req.body.port, '', function(err) {
-                if (err) {
-                    return res.send(err.code, err.msg);
-                }
-                res.send(200, 'New tenant "' + req.body.name + '" has been fired up on port ' + req.body.port);
-            });
-        } else {
-            res.send(400, 'The port and id for a tenant need to be specified');
-        }
-    });
-
-    server.post('/api/tenant/start', function(req, res, next) {
-        tenantAPI.putTenantsInMaintenanceMode(req.body, false, function(err) {
+    server.post('/api/tenant/create', function(req, res) {
+        TenantAPI.createTenant(req.body.id, req.body.name, req.body.description, req.body.port, req.body.baseurl, function(err) {
             if (err) {
                 return res.send(err.code, err.msg);
             }
-            res.send({'code': 200, 'msg': 'Tenant successfully taken out of maintenance mode.'});
+            res.send(200, 'New tenant "' + req.body.name + '" has been fired up on port ' + req.body.port);
         });
     });
 
-    server.post('/api/tenant/stop', function(req, res, next) {
-        tenantAPI.putTenantsInMaintenanceMode(req.body, true, function(err) {
+    server.post('/api/tenant/start', function(req, res) {
+        TenantAPI.putTenantsInMaintenanceMode(req.body.tenants, false, function(err) {
             if (err) {
                 return res.send(err.code, err.msg);
             }
-            res.send({'code': 200, 'msg': 'Tenant successfully put in to maintenance mode.'});
+            res.send(200);
         });
     });
 
-    server.post('/api/tenant/delete', function(req, res, next) {
-        tenantAPI.deleteTenants(req.body, function(err) {
+    server.post('/api/tenant/stop', function(req, res) {
+        TenantAPI.putTenantsInMaintenanceMode(req.body.tenants, true, function(err) {
             if (err) {
                 return res.send(err.code, err.msg);
             }
-            res.send({'code': 200, 'msg': 'Tenant successfully deleted.'});
+            res.send(200);
+        });
+    });
+
+    server.post('/api/tenant/delete', function(req, res) {
+        TenantAPI.deleteTenants(req.body.tenants, function(err) {
+            if (err) {
+                return res.send(err.code, err.msg);
+            }
+            res.send(200);
         });
     });
 
@@ -130,7 +128,7 @@ var registerAPI = function(server, config, callback) {
     });
 
     server.get('/api/tenants', function(req, res, next) {
-        tenantAPI.getAllTenants(function(err, tenants) {
+        TenantAPI.getAllTenants(function(err, tenants) {
             if (err) {
                 return res.send(err.code, err.msg);
             }
@@ -152,10 +150,13 @@ var registerAPI = function(server, config, callback) {
     });
 
     // Create Cassandra database.
-    Cassandra.init(config, function(err) {
+    Cassandra.init(config.cassandra, function(err) {
         if (err) {
             return callback(err);
         }
+
+        // Setup the Pubsub communication
+        Pubsub.init(config.redis);
         
         // We'll create/get 1 global admin account in the fake tenant system that can be used
         // to create tenants/other global accounts.
@@ -182,23 +183,14 @@ var registerAPI = function(server, config, callback) {
  *                                  started up, including registration of all REST endpoints
  */
 var startTenants = function(callback) {
-    tenantAPI.getAllTenants(function(err, tenants) {
+    TenantAPI.getAllTenants(function(err, tenants) {
         if (err) {
-            throw err;
+            return callback(err);
         }
-        if (tenants.length) {
-            var tenantsStarted = 0;
-            for (var t = 0; t < tenants.length; t++) {
-                tenantAPI.startTenant(tenants[t], function() {
-                    tenantsStarted++;
-                    if (tenantsStarted === tenants.length) {
-                        callback();
-                    }
-                });
-            }
-        } else {
-            callback();
+        for (var t = 0; t < tenants.length; t++) {
+            TenantAPI.startTenant(tenants[t]);
         }
+        callback();
     });
 };
 

--- a/node_modules/oae-util/lib/pubsub.js
+++ b/node_modules/oae-util/lib/pubsub.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 Sakai Foundation (SF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var EventEmitter = require('events').EventEmitter
+var redis = require('redis');
+
+var Validator = require('./validator').Validator;
+
+/**
+ * This module abstracts most of the redis publish/subscribe functions away.
+ * It will listen to all channels and emit an event for each message it receives.
+ * The redis channel name will be the event name and the message it's only argument.
+ */
+
+
+// Create the event emitter.
+var emitter = module.exports = new EventEmitter();
+var redisSubscriber = null;
+var redisPublisher = null;
+
+
+/**
+ * Initializes the connection to redis.
+ */
+module.exports.init = function(config) {
+    // Create 2 clients, one for publishing and one for subscriptions.
+    redisSubscriber = redis.createClient(config.port, config.host);
+    redisPublisher = redis.createClient(config.port, config.host);
+
+    var redisErrorHandler = function(err) {
+        console.warn("Got an error when dealing with redis:" + err);
+    };
+
+    redisSubscriber.on("error", redisErrorHandler);
+    redisPublisher.on("error", redisErrorHandler);
+
+    // Listen to all channels and emit them as events.
+    redisSubscriber.on("pmessage", function (pattern, channel, message) {
+        emitter.emit(channel, message);
+    });
+    redisSubscriber.psubscribe('*');
+};
+
+
+/**
+ * Broadcast a message accross a channel.
+ * This can be used to publish messages to all the app nodes.
+ *
+ * @param  {String}   channel  The channel you wish to publish on. ex: 'oae-tenants'
+ * @param  {String}   message  The message you wish to send on a channel. ex: 'start 2000'
+ */
+var publish = module.exports.publish = function(channel, message) {
+    var validator = new Validator();
+    validator.check(channel, {'code': 400, 'msg': 'No channel was provided.'}).notNull().notEmpty();
+    validator.check(message, {'code': 400, 'msg': 'No message was provided.'}).notNull().notEmpty();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    redisPublisher.publish(channel, message);
+};

--- a/node_modules/oae-util/tests/test-oae.js
+++ b/node_modules/oae-util/tests/test-oae.js
@@ -16,6 +16,7 @@
 var assert = require('assert');
 
 var OAE = require('oae-util/lib/oae');
+var Tenant = require('oae-tenants/lib/model').Tenant;
 var TestAPI = require('oae-tests');
 
 var request = TestAPI.Http.createRequest();
@@ -34,25 +35,23 @@ describe('Utilities', function() {
             });
 
             it('Test tenant creation requires port', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/create'
-                }, function(err, response, body) {
+                var tenant = new Tenant('cam', 'Cambridge', 'Cambridge University');
+                TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
                     assert.equal(response.statusCode, 400);
-                    assert.equal(body, 'The port and id for a tenant need to be specified');
-                    callback();
+                    assert.equal(body, 'Missing port');
+
+                    tenant.port = 'not-a-numner';
+                    TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
+                        assert.equal(response.statusCode, 400);
+                        assert.equal(body, 'Provided port is not a number');
+                        callback();
+                    });
                 });
             });
 
             it('Test tenant creation on running port fails', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/create',
-                    'json': {
-                        'id': 'cam',
-                        'name': 'Cambridge University',
-                        'description': 'The University of Cambridge',
-                        'port': 2001
-                    }
-                }, function(err, response, body) {
+                var tenant = new Tenant('cam', 'Cambridge', 'Cambridge University', 2001, 'localhost');
+                TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
                     assert.equal(response.statusCode, 400);
                     assert.equal(body, 'A tenant is already running on port 2001');
                     callback();
@@ -60,15 +59,8 @@ describe('Utilities', function() {
             });
 
             it('Test tenant creation with same alias fails', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/create',
-                    'json': {
-                        'id': 'camtest',
-                        'name': 'Cambridge University',
-                        'description': 'The University of Cambridge',
-                        'port': 2099
-                    }
-                }, function(err, response, body) {
+                var tenant = new Tenant('camtest', 'Cambridge', 'Cambridge University', 2099, 'localhost');
+                TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
                     assert.equal(response.statusCode, 400);
                     assert.equal(body, 'A tenant with the alias camtest already exists');
                     callback();
@@ -76,102 +68,64 @@ describe('Utilities', function() {
             });
 
             it('Test tenant creation succeeds', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/create',
-                    'json': {
-                        'id': 'cam',
-                        'name': 'Cambridge University',
-                        'description': 'The University of Cambridge',
-                        'port': 2100
-                    }
-                }, function(err, response, body) {
+                var r = Math.random()*10000;
+                var tenant = new Tenant('cam' + r, 'Cambridge University', 'Cambridge University', 2100, 'localhost');
+                TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
                     assert.equal(response.statusCode, 200);
                     assert.equal(body, 'New tenant "Cambridge University" has been fired up on port 2100');
                     callback();
                 });
             });
 
-            it('Test putting tenant in maintenance mode succeeds', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/stop',
-                    'json': {
-                        "cam": {
-                            'port': 2100
-                        }
-                    }
-                }, function(err, response, body) {
+            it('Test maintenance mode', function(callback) {
+                var r = Math.random()*10000;
+                var tenant = new Tenant('cam' + r, 'Cambridge University', 'Cambridge University', 2101, 'localhost');
+                TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
                     assert.equal(response.statusCode, 200);
-                    callback();
+                    assert.equal(body, 'New tenant "Cambridge University" has been fired up on port 2101');
+
+                    // Stick tenant in maintenance mode.
+                    TestAPI.Tenant.stopTenants([tenant.port], function(err, response, body) {
+                        assert.equal(response.statusCode, 200);
+
+                        // Check if we actually get the maintenance page.
+                        request.get('http://localhost:2101', function(err, response, body) {
+                            assert.ok(!err);
+                            assert.ok(body.indexOf('maintenance') > 0, body);
+
+                            // Start it back up.
+                            TestAPI.Tenant.startTenants([tenant.port], function(err, response, body) {
+                                assert.equal(response.statusCode, 200);
+
+                                // Check if we actually get a page (that is is not a maintenance mode)
+                                request.get('http://localhost:2101', function(err, response, body) {
+                                    assert.ok(!err);
+                                    assert.equal(body.indexOf('maintenance'), -1);
+                                    callback();
+                                });
+                            });
+                        });
+                    });
                 });
             });
 
-            it('Test port is provided when putting tenant in maintenance mode', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/stop',
-                    'json': {
-                        "cam": {
-                            'id': 'camtest'
-                        }
-                    }
-                }, function(err, response, body) {
-                    assert.equal(response.statusCode, 400);
-                    callback();
-                });
-            });
-
-            it('Test taking tenant out of maintenance mode succeeds', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/start',
-                    'json': {
-                        "cam": {
-                            'port': 2100
-                        }
-                    }
-                }, function(err, response, body) {
+            it('Test deleting a tenant', function(callback) {
+                var r = Math.random()*10000;
+                var tenant = new Tenant('cam' + r, 'Cambridge University', 'Cambridge University', 2102, 'localhost');
+                TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
                     assert.equal(response.statusCode, 200);
-                    callback();
-                });
-            });
+                    assert.equal(body, 'New tenant "Cambridge University" has been fired up on port 2102');
 
-            it('Test port is provided when taking tenant out of maintenance mode', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/start',
-                    'json': {
-                        "cam": {
-                            'id': 'camtest'
-                        }
-                    }
-                }, function(err, response, body) {
-                    assert.equal(response.statusCode, 400);
-                    callback();
-                });
-            });
+                    // First try a bad request.
+                    TestAPI.Tenant.deleteTenants([], function(err, response, body) {
+                        assert.equal(response.statusCode, 400);
 
-            it('Test port is provided when deleting a tenant', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/delete',
-                    'json': {
-                        "cam": {
-                            'id': 'camtest'
-                        }
-                    }
-                }, function(err, response, body) {
-                    assert.equal(response.statusCode, 400);
-                    callback();
-                });
-            });
-
-            it('Test deleting a tenant succeeds', function(callback) {
-                request.post({
-                    'uri': 'http://localhost:2000/api/tenant/delete',
-                    'json': {
-                        "cam": {
-                            'port': 2100
-                        }
-                    }
-                }, function(err, response, body) {
-                    assert.equal(response.statusCode, 200);
-                    callback();
+                        // Now try a proper request.
+                        TestAPI.Tenant.deleteTenants([tenant.port], function(err, response, body) {
+                            assert.equal(response.statusCode, 200);
+                            callback();
+                        });
+                    });
                 });
             });
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "shortid": "latest",
     "time": "latest",
     "underscore": "latest",
-    "validator": "latest"
+    "validator": "latest",
+    "redis": "latest"
   },
   "devDependencies": {
     "optimist": "latest",


### PR DESCRIPTION
This PR brings in clustered start and stop of tenants.
It requires [redis](http://redis.io/download) for it's publish/subscribe capabilities so it'll be one dependency extra.

I looked into taking down a tenant server programatically and there seems to be no good (scalable) way to do it. I therefor opted to just add a middleware that checks if the server is in `maintenance mode` or not.

I've tried this out on 2 app nodes:
- OS X host with Cassandra and redis
- Ubuntu VM

and was able to start/stop/delete tenants in a clustered way. It should all be hooked into the Admin UI  and display properly. (I found one bug where the page doesn't display the tenant list when creating a new tenant, but will leave that for another PR)

When the global authentication comes in, I'll secure these services as well.
