### PR TITLE
Follow up on PR #102

### DIFF
--- a/node_modules/oae-util/lib/oae.js
+++ b/node_modules/oae-util/lib/oae.js
@@ -130,8 +130,8 @@ var getAvailableModules = module.exports.getAvailableModules = function(callback
         modules.forEach(function(module) {
             if (module.substring(0, 4) === 'oae-') {
                 // determine module priority
-                var filename = "./node_modules/" + module + "/package.json";
-                var pkg = JSON.parse(fs.readFileSync(filename, 'utf-8'));
+                var filename = module + "/package.json";
+                var pkg = require(filename);
                 if (pkg.oae && pkg.oae.priority) {
                     // found a priority in package.json at oae.priority
                     modulePriority[module] = pkg.oae.priority;


### PR DESCRIPTION
According to http://stackoverflow.com/questions/7163061/is-there-a-require-for-json-in-node-js, you can just use require to load the json file, rather than having to read the file and parse the JSON. I'll create a follow up ticket to make this change.
