### PR TITLE
Rename "Maintenance Mode" terminology to "Disabled"

### DIFF
--- a/node_modules/oae-config-aggregator/public/admin.html
+++ b/node_modules/oae-config-aggregator/public/admin.html
@@ -128,7 +128,7 @@
                                         {if tenant.active}
                                             <span class="text-success">Running</span>
                                         {else}
-                                            <span class="text-error">Maintenance mode</span>
+                                            <span class="text-error">Disabled</span>
                                         {/if}
                                     </td>
                                     <td>

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -43,12 +43,12 @@ Pubsub.on('oae-tenants', function (message) {
             if (err) {
                 return log().error({err: err}, 'There was an error retrieving the tenant to start on port %d', port);
             }
-            _startTenant(tenant, function(err, startedInMaintenanceMode) {
+            _startTenant(tenant, function(err, disabled) {
                 if (err) {
                     log().error({err: err}, 'Could not start tenant on port %d', port);
                 } else {
-                    if (startedInMaintenanceMode) {
-                        log().info({tenant: tenant.alias}, 'Tenant on port %d started (in maintenance mode.)', port);
+                    if (disabled) {
+                        log().info({tenant: tenant.alias}, 'Tenant on port %d started (disabled)', port);
                     } else {
                         log().info({tenant: tenant.alias}, 'Tenant on port %d started.', port);
                     }
@@ -90,9 +90,9 @@ module.exports.startTenant = function(tenant, callback) {
  * Start a new tenant by listening on the provided ports.
  *
  * @param {Tenant}                          tenant                      The tenant object representing the tenant to be started
- * @param {Function(err, maintenanceMode)}  callback                    Standard callback function
+ * @param {Function(err, disabled)}         callback                    Standard callback function
  * @param {Object}                          callback.err                An error object (if any)
- * @param {Boolean}                         callback.maintenanceMode    Whether or not this tenant started in maintenance mode.
+ * @param {Boolean}                         callback.disabled           Whether or not this tenant is disabled.
  * @private
  */
 var _startTenant = function(tenant, callback) {
@@ -100,8 +100,8 @@ var _startTenant = function(tenant, callback) {
     if (tenant) {
         if (runningServers[tenant.port]) {
             // We already created the server object.
-            // Take it out of maintenance mode.
-            runningServers[tenant.port].inMaintenanceMode = !tenant.active;
+            // Enable the tenant
+            runningServers[tenant.port].disabled = !tenant.active;
             callback(false, !tenant.active);
         } else {
             // Create a basic express server.
@@ -110,15 +110,15 @@ var _startTenant = function(tenant, callback) {
             // Keep all the servers in memory so we can access them later.
             runningServers[tenant.port] = http.createServer(tenant.server);
             runningServers[tenant.port].listen(tenant.port);
-            runningServers[tenant.port].inMaintenanceMode = !tenant.active;
+            runningServers[tenant.port].disabled = !tenant.active;
 
-            // Provide this middleware that checks if this server should be in maintenance mode
+            // Provide this middleware that checks if this server should be disabled
             // and if not, expose the tenant on each request.
             tenant.server.use(function(req, res, next) {
-                if (runningServers[tenant.port].inMaintenanceMode) {
-                    // If we're running in maintenance mode, there is no point in keeping connections open.
+                if (runningServers[tenant.port].disabled) {
+                    // If we're disabled, there is no point in keeping connections open.
                     res.setHeader('Connection', 'Close');
-                    return res.send(200, 'This server is currently in maintenance mode. Please check back later.');
+                    return res.send(200, 'This server is currently disabled. Please check back later.');
                 }
                 req.tenant = tenant;
                 req.user = null;
@@ -148,8 +148,8 @@ var _startTenant = function(tenant, callback) {
  */
 var _stopTenant = function(tenant, callback) {
     if (tenant && runningServers[tenant.port]) {
-        // Stick that server into maintenance mode.
-        runningServers[tenant.port].inMaintenanceMode = true;
+        // Disable that server
+        runningServers[tenant.port].disabled = true;
         callback();
     } else {
         callback({'code': 404, 'msg': 'No server found on that port.'});
@@ -157,13 +157,13 @@ var _stopTenant = function(tenant, callback) {
 };
 
 /**
- * Put a tenant in maintenance mode or take it out of it.
+ * Disable or enable a tenant
  * @param {Array<Number>}   ports               An array of ports that should be stopped.
- * @param {Boolean}         needsMaintenance    True if the tenant needs to go into maintenance mode
+ * @param {Boolean}         disabled            True if the tenant needs to be disabled
  * @param {Function(err)}   callback            Callback function executed when request is completed.
  * @param {Object}          callback.err        An error object (if any.)
  */
-var putTenantsInMaintenanceMode = module.exports.putTenantsInMaintenanceMode = function(ports, needsMaintenance, callback) {
+var disableTenants = module.exports.disableTenants = function(ports, disabled, callback) {
     callback = callback || function() {};
     if (!ports) {
         return callback({'code': 400, 'msg': 'Please provide a ports array'});
@@ -177,7 +177,7 @@ var putTenantsInMaintenanceMode = module.exports.putTenantsInMaintenanceMode = f
     for (var i = 0; i < ports.length; i++) {
         queries.push({
             'query': 'UPDATE Tenant SET active = ? WHERE port = ?',
-            'parameters': [!needsMaintenance, ports[i]]
+            'parameters': [!disabled, ports[i]]
         });
     }
     Cassandra.runBatchQuery(queries, 'QUORUM', function(err) {
@@ -187,7 +187,7 @@ var putTenantsInMaintenanceMode = module.exports.putTenantsInMaintenanceMode = f
 
         // Broadcast the message accross the cluster
         // so we can start/stop the tenants.
-        var cmd = (needsMaintenance) ? 'stop' : 'start';
+        var cmd = (disabled) ? 'stop' : 'start';
         for (var i = 0; i < ports.length; i++) {
             Pubsub.publish('oae-tenants', cmd + ' ' + ports[i], callback);
         }
@@ -195,7 +195,7 @@ var putTenantsInMaintenanceMode = module.exports.putTenantsInMaintenanceMode = f
 };
 
 /**
- * Rather than physically deleting a tenant, we just stick it in maintenance mode for now.
+ * Rather than physically deleting a tenant, we just disable it for now.
  *
  * @param {Tenant}   ports               The tenant object representing the tenant to be stopped
  * @param {Function} callback            Callback function executed when request is completed.

--- a/node_modules/oae-tenants/lib/init.js
+++ b/node_modules/oae-tenants/lib/init.js
@@ -66,7 +66,8 @@ var registerGlobalRestEndpoints = function(app) {
     });
 
     app.server.post('/api/tenant/start', function(req, res) {
-        TenantAPI.putTenantsInMaintenanceMode(req.body.tenants, false, function(err) {
+        // sets the tenant to be ENABLED, by passing in 'false'
+        TenantAPI.disableTenants(req.body.tenants, false, function(err) {
             if (err) {
                 return res.send(err.code, err.msg);
             }
@@ -75,7 +76,8 @@ var registerGlobalRestEndpoints = function(app) {
     });
 
     app.server.post('/api/tenant/stop', function(req, res) {
-        TenantAPI.putTenantsInMaintenanceMode(req.body.tenants, true, function(err) {
+        // sets the tenant to be disabled, by passing in 'true'
+        TenantAPI.disableTenants(req.body.tenants, true, function(err) {
             if (err) {
                 return res.send(err.code, err.msg);
             }

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -458,32 +458,32 @@ describe('Tenants', function() {
     });
 
     /**
-     * Test that a tenant can be put in and taken out of maintenance mode
+     * Test that a tenant can enabled and disabled
      */
-    it('Test maintenance mode', function(callback) {
+    it('Test disabling', function(callback) {
         var r = Math.random()*10000;
         var tenant = new Tenant('cam' + r, 'Cambridge University', 'Cambridge University', 2101, 'localhost');
         TestAPI.Tenant.createTenant(tenant, function(err, response, body) {
             assert.equal(response.statusCode, 200);
             assert.equal(body, 'New tenant "Cambridge University" has been fired up on port 2101');
 
-            // Stick tenant in maintenance mode.
+            // Disable a tenant.
             TestAPI.Tenant.stopTenants([tenant.port], function(err, response, body) {
                 assert.equal(response.statusCode, 200);
 
-                // Check if we actually get the maintenance page.
+                // Check if we actually get the disabled notification.
                 request.get('http://localhost:2101', function(err, response, body) {
                     assert.ok(!err);
-                    assert.ok(body.indexOf('maintenance') > 0, body);
+                    assert.ok(body.indexOf('currently disabled') > 0, body);
 
                     // Start it back up.
                     TestAPI.Tenant.startTenants([tenant.port], function(err, response, body) {
                         assert.equal(response.statusCode, 200);
 
-                        // Check if we actually get a page (that is is not a maintenance mode)
+                        // Check if we actually get an "active" page
                         request.get('http://localhost:2101', function(err, response, body) {
                             assert.ok(!err);
-                            assert.equal(body.indexOf('maintenance'), -1);
+                            assert.equal(body.indexOf('currently disabled'), -1);
                             callback();
                         });
                     });


### PR DESCRIPTION
Currently tenants are put into "Maintenance Mode" to shut down service, however there aren't currently any "maintenance" tasks known of that would require a tenant to be shutdown across the cluster to perform.

Ideally, maintenance could be performed in an incremental approach across the nodes to avoid down-time, so the notion of being down for maintenance should be avoided.

The need to disable / stop a tenant is still there, though. So lets just rename it to "Disabled" for now.
