### PR TITLE
Don't execute "_.keys(..)" unnecessarily on iterations

### DIFF
--- a/node_modules/oae-authz/lib/api.js
+++ b/node_modules/oae-authz/lib/api.js
@@ -176,8 +176,8 @@ var applyRoleChanges = module.exports.applyRoleChanges = function(resourceUuid, 
     var validator = new Validator();
     validator.check(resourceUuid, {code: 400, msg: 'Invalid resource UUID provided.'}).isValidUuid();
     validator.check(resourceUuid, {code: 400, msg: 'Cannot assign a role for a principal on a group resource.'}).isNotGroupResource();
-    for (var i = 0; i<_.keys(changes).length; i++) {
-        var principalUuid = _.keys(changes)[i];
+    for (var i = 0, keys = _.keys(changes); i < keys.length; i++) {
+        var principalUuid = keys[i];
         validator.check(principalUuid, {code: 400, msg: 'Invalid principal UUID specified: '+principalUuid}).isValidUuid();
         validator.check(changes[principalUuid], {code: 400, msg: 'Invalid role provided.'}).isValidRoleChange();
 
@@ -367,8 +367,8 @@ var _hasRole = function(principalUuid, resourceUuid, role, callback) {
  */
 var _applyRoleChanges = function(resourceUuid, changes, callback) {
     var queries = [];
-    for (var i = 0; i < _.keys(changes).length; i++) {
-        var principalUuid = _.keys(changes)[i];
+    for (var i = 0, keys = _.keys(changes); i < keys.length; i++) {
+        var principalUuid = keys[i];
         if (changes[principalUuid]) {
             queries.push({
                 'query': 'UPDATE AuthzRoles SET ? = ? WHERE principalId = ?',
@@ -404,8 +404,8 @@ var _applyRoleChanges = function(resourceUuid, changes, callback) {
 var applyGroupMembershipChanges = module.exports.applyGroupMembershipChanges = function(groupUuid, changes, callback) {
     var validator = new Validator();
     validator.check(groupUuid, {code: 400, msg: 'Invalid group UUID provided.'}).isGroupPrincipal();
-    for (var i = 0; i < _.keys(changes).length; i++) {
-        var memberUuid = _.keys(changes)[i];
+    for (var i = 0, keys = _.keys(changes); i < keys.length; i++) {
+        var memberUuid = keys[i];
         validator.check(memberUuid, {code: 400, msg: 'Invalid principal UUID provided: '+memberUuid}).isPrincipal();
         validator.check(changes[memberUuid], {code: 400, msg: 'Invalid role provided.'}).isValidRoleChange();
     }


### PR DESCRIPTION
There are some instances around for loops where _.keys is executed at each iteration. These should be changed to pre-calculate into a variable and use those variables instead.

e.g., 

``` javascript
for (var i = 0; i < _.keys(changes); i++) {
  var change = _.keys(changes)[i];
  ...
}
```

Should be changed to:

``` javascript
for (var i = 0, keys = _.keys(changes); i < keys.length; i++) {
  var change = keys[i];
  ...
}
```

Please fix these up.
