### PR TITLE
Use _getRoles to get roles for multiple principals instead of burst-and-monitor

### DIFF
--- a/node_modules/oae-authz/lib/api.js
+++ b/node_modules/oae-authz/lib/api.js
@@ -318,7 +318,7 @@ var _getRoles = function(principalUuids, resourceUuid, callback) {
         rows.forEach(function(row) {
             var resourceCol = row.get(resourceUuid);
             var principalCol = row.get('principalId');
-            if (resourceCol) {
+            if (resourceCol && resourceCol.value) {
                 roles[principalCol.value] = resourceCol.value;
             }
         });
@@ -732,42 +732,25 @@ var _isAllowed = function(principalUuids, action, resourceUuid, callback) {
         return callback(null, false);
     }
 
-    // variables for monitoring the progress of permissions checks
-    var index = 0;
-    var isAllowedResult = false;
-    var errResult = false;
+    _getRoles(principalUuids, resourceUuid, function(err, roles) {
+        if (err) {
+            return callback(err);
+        }
 
-    // this function monitors the progress of asynchronous permissions checks, calling back to the caller when appropriate
-    var checkStatus = function(err, isAllowed) {
-        if (errResult || isAllowedResult) {
-            // do nothing, because we've already finished executing and called the callback
-        } else if (err) {
-            // we got an error while executing, call back with the error
-            errResult = err;
-            return callback(errResult);
-        } else if (isAllowed) {
-            // one of the principals is allowed to perform the action, short circuit
-            isAllowedResult = isAllowed;
-            return callback(null, isAllowedResult);
-        } else {
-            index++;
-            if (index >= principalUuids.length) {
-                // we've reached the end of the check and none are allowed, return false
-                return callback(null, false);
+        for (var principal in roles) {
+            if (roles.hasOwnProperty(principal)) {
+                if (action === null) {
+                    return callback(null, true);
+                }
+
+                if (roles[principal] === action) {
+                    return callback(null, true);
+                }
             }
         }
-    };
 
-    // invoke the entire ancestry asynchronously. checkStatus will determine the result and when it is possible to call back.
-    for (var i = 0; i < principalUuids.length; i++) {
-        var principalUuid = principalUuids[i];
-        if (action !== null) {
-            hasRole(principalUuid, resourceUuid, action, checkStatus);
-        } else {
-            // we pass checkStatus directly here on the basis that the 'isAllowed' parameter is a duck-check and not strictly typed.
-            getRole(principalUuid, resourceUuid, checkStatus);
-        }
-    }
+        return callback(null, false);
+    });
 };
 
 /**


### PR DESCRIPTION
Currently _isAllowed will burst many individual role checks against Cassandra to determine if one group has a role on a resource from an array of groups.

Changing this to use the new _getRoles that performs one multi-get demonstrates displays better stability while performing a permission-heavy content profile test.

Also _getRoles has a bug where it will return principals with null roles. This should be fixed at the same time.
