### PR TITLE
make test-coverage failing on new module

### DIFF
--- a/node_modules/oae-tests/runner/instrument_code.js
+++ b/node_modules/oae-tests/runner/instrument_code.js
@@ -40,19 +40,21 @@ var abortIfError = function(error, stdout, stderr) {
 
 var instrument = function(dir, module) {
     var lib = ROOT_DIR + '/target/' + dir + '/lib';
-    var libCov = ROOT_DIR + '/target/' + dir + '/lib-cov';
-    shell.exec('jscoverage --no-highlight ' + quote(lib) + ' ' + quote(libCov)); 
-    // Replace filenames in instrumentation with entire path.
-    var files = shell.find(libCov);
-    for (var i=0; i < files.length; i++) {
-        var path = files[i];
-        if (shell.test('-f', path)) {
-            var re = /_\$jscoverage\['(.*)'\]/gi;
-            shell.sed('-i', re, "_$jscoverage['" + module + "/lib/$1']", path);
+    if (shell.test('-d', lib)) {
+        var libCov = ROOT_DIR + '/target/' + dir + '/lib-cov';
+        shell.exec('jscoverage --no-highlight ' + quote(lib) + ' ' + quote(libCov)); 
+        // Replace filenames in instrumentation with entire path.
+        var files = shell.find(libCov);
+        for (var i=0; i < files.length; i++) {
+            var path = files[i];
+            if (shell.test('-f', path)) {
+                var re = /_\$jscoverage\['(.*)'\]/gi;
+                shell.sed('-i', re, "_$jscoverage['" + module + "/lib/$1']", path);
+            }
         }
+        shell.rm('-r', lib);
+        shell.mv(libCov, lib);
     }
-    shell.rm('-r', lib);
-    shell.mv(libCov, lib);
 };
 
 // Get the available OAE modules and instrument them


### PR DESCRIPTION
I added a new module to one of my branches and the test-coverage report is failing on that branch. The specific error I get here tells me this might be a problem with the shell.js work that went in to master.

```
dhcp-76:Hilary Bert$ make test-coverage
Creating target directory
Copying all files.
Instrumenting all files.
jscoverage: cannot stat file: /Users/Bert/sakai/Hilary/target/node_modules/oae-ui/lib
shell.js: internal error
Error: ENOENT, no such file or directory '/Users/Bert/sakai/Hilary/target/node_modules/oae-ui/lib-cov'
    at Object.fs.statSync (fs.js:524:18)
    at /Users/Bert/sakai/Hilary/node_modules/shelljs/shell.js:219:12
    at Array.forEach (native)
    at Object._find (/Users/Bert/sakai/Hilary/node_modules/shelljs/shell.js:216:9)
    at Object.find (/Users/Bert/sakai/Hilary/node_modules/shelljs/shell.js:1103:23)
    at instrument (/Users/Bert/sakai/Hilary/node_modules/oae-tests/runner/instrument_code.js:46:23)
    at /Users/Bert/sakai/Hilary/node_modules/oae-tests/runner/instrument_code.js:62:9
    at module.exports.refreshAvailableModules (/Users/Bert/sakai/Hilary/node_modules/oae-util/lib/oae.js:184:9)
    at module.exports.getFileListForFolder (/Users/Bert/sakai/Hilary/node_modules/oae-util/lib/io.js:37:17)
    at Object.oncomplete (fs.js:297:15)
make: *** [lib-cov] Error 1
```
