### PR TITLE
More efficient content sharing

### DIFF
--- a/node_modules/oae-authz/lib/api.js
+++ b/node_modules/oae-authz/lib/api.js
@@ -36,7 +36,7 @@ var AuthzConstants = require('oae-authz/lib/constants').AuthzConstants;
  * @param  {String}     callback.role   The role of the principal on the resource. If the principal has no role or there is an error performing the check, role will be null.
  */
 var _getDirectRole = function(principalId, resourceId, callback) {
-    _getDirectRoles([principalId], resourceId, function(err, roles) {
+    getDirectRoles([principalId], resourceId, function(err, roles) {
         if (err) {
             return callback(err);
         }
@@ -54,7 +54,7 @@ var _getDirectRole = function(principalId, resourceId, callback) {
  * @param   {Object}       callback.err    An error that occurred, if any.
  * @param   {Object}       callback.roles  A hash keyed by principal id, with value set to the role they have directly on the resource. If the principal has no role or there is an error performing the check, role will be null.
  **/
-var _getDirectRoles = function(principalIds, resourceId, callback) {
+var getDirectRoles = module.exports.getDirectRoles = function(principalIds, resourceId, callback) {
     Cassandra.runQuery('SELECT ? FROM AuthzMembers USING CONSISTENCY QUORUM WHERE resourceId = ?', [principalIds, resourceId], function(err, rows) {
         if (err) {
             return callback(err);

--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -448,26 +448,26 @@ var shareContent = module.exports.shareContent = function(ctx, contentId, princi
  * @param  {Object}    callback.err      Error object containing the error message
  */
 var _shareContent = function(ctx, contentObj, principalIds, callback) {
-    // Get the current members and filter out the ones that are already a member, as we want to avoid
-    // turning an existing manager into a viewer
-    _getAllContentMembers(contentObj.contentId, function(err, members) {
+    // Check if any of the passed in principal ids already have a direct role on the piece of content. We
+    // filter those out to avoid turning an existing manager into a viewer
+    AuthzAPI.getDirectRoles(principalIds, contentObj.contentId, function(err, roles) {
         if (err) {
             return callback(err);
         }
-        var memberIds = _.map(members, function(member){ return member.id; });
-        principalIds = _.difference(principalIds, memberIds);
-        // Check if there are any principals left to share with
-        if (principalIds.length === 0) {
-            return callback(null);
-        }
 
-        // Make all of the remaining principals a member
         var shareObject = {};
         for (var p = 0; p < principalIds.length; p++) {
-            shareObject[principalIds[p]] = ContentConstants.roles.VIEWER;
+            // Check if the principal already has a role on the content
+            if (!roles[principalIds[p]]) {
+                shareObject[principalIds[p]] = ContentConstants.roles.VIEWER;
+            }
         }
         
-        _setContentPermissions(ctx, contentObj, shareObject, callback);
+        if (_.keys(shareObject).length === 0) {
+            callback(null);
+        } else {
+            _setContentPermissions(ctx, contentObj, shareObject, callback);
+        }
     });
 };
 


### PR DESCRIPTION
Instead of getting the full membership list of the content and matching it to the list of principals we want to share with, we just request the ones we want to share with. This avoids a full load of all content members per share action.
