### PR TITLE
docs @see doesn't know about filenames

### DIFF
--- a/node_modules/oae-doc/public/index.html
+++ b/node_modules/oae-doc/public/index.html
@@ -51,7 +51,7 @@
                         {if !func.ignore}
                             <div class="bs-docs-{if func.isPrivate}private{else}public{/if}">
                                 {if func.ctx}
-                                    <h4><a name="#${module}.${func.ctx.name}">${func.ctx.name}</a></h4>
+                                <h4><a name="#${module}.${doc_index.substr(0, doc_index.length - 3)}.${func.ctx.name}">${func.ctx.name}</a></h4>
                                     <p><small>
                                         {if func.ctx.value}
                                             ${func.ctx.value}


### PR DESCRIPTION
currently docs `@see` works with just the module name followed by the element, so if there are two files in a module with elements that have the same name it won't be possible to distinguish them.
