### PR TITLE
getAllProfileSections should only return list of available sections

### DIFF
--- a/node_modules/oae-profiles/lib/api.js
+++ b/node_modules/oae-profiles/lib/api.js
@@ -155,13 +155,13 @@ var getSection = module.exports.getSection = function(context, principalId, sect
 };
 
 /**
- * Gets all the profile sections for a principal.
+ * Gets all the profile sections for a principal. Lists only the sections the requesting user can access along with their visibility
  *
  * @param  {Context}                context         The current user's context
  * @param  {String}                 principalId     The id of the principal for whom the profile should be retrieved.
  * @param  {Function}               callback        A callback method takes arguments `err` and `data`
  * @param  {Object}                 callback.err    An error object (if any)
- * @param  {Object}                 callback.data   Object where keys are section ids and values are sections the user has access to.
+ * @param  {Object}                 callback.data   Object where keys are section ids and values are visibility of the section.
  */
 var getSectionOverview = module.exports.getSectionOverview = function(context, principalId, callback) {
     var validator = new Validator();
@@ -180,7 +180,7 @@ var getSectionOverview = module.exports.getSectionOverview = function(context, p
             return callback(null, []);
         }
 
-        var visibilities = { 'profile': {} };
+        var visibilities = {};
 
         rows[0].forEach(function(name, value, ts, ttl) {
             if (name === 'principalId') {
@@ -190,10 +190,10 @@ var getSectionOverview = module.exports.getSectionOverview = function(context, p
             if (parts[1] === 'data') {
                 var sectionName = parts[0];
                 var visibility = rows[0].get(sectionName + '#visibility').value;
-                var ps = new ProfileSection(principalId, sectionName, {}, visibility);
-                _hasAccess(context, ps, function(err, hasAccess) {
+                var profileSection = new ProfileSection(principalId, sectionName, {}, visibility);
+                _hasAccess(context, profileSection, function(err, hasAccess) {
                     if (!err && hasAccess) {
-                        visibilities.profile[sectionName] = visibility;
+                        visibilities[sectionName] = visibility;
                     }
                 });
             }

--- a/node_modules/oae-profiles/lib/rest.js
+++ b/node_modules/oae-profiles/lib/rest.js
@@ -30,12 +30,15 @@ OAE.tenantServer.get('/api/user/:id/profile/sections', function(req, res) {
             return res.send(err.code, err.msg);
         }
 
-        ProfileAPI.getSectionOverview(req.ctx, req.params.id, function(err, visibilities) {
+        ProfileAPI.getSectionOverview(req.ctx, req.params.id, function(err, profiles) {
             if (err) {
                 return res.send(err.code, err.msg);
             }
 
-            visibilities.accountVisibility = user.visibility;
+            var visibilities = {
+                'profile': profiles,
+                'accountVisibility': user.visibility
+            };
             return res.send(200, visibilities);
         });
     });

--- a/node_modules/oae-profiles/tests/test-profiles.js
+++ b/node_modules/oae-profiles/tests/test-profiles.js
@@ -248,7 +248,7 @@ describe('Profiles', function() {
                         assert.ok(!err);
     
                         // Get the visibility overview
-                        RestAPI.Profile.getAllSectionsVisibility(users[userIds[0]].restContext, userIds[0], function(err, sectionVisibilities) {
+                        RestAPI.Profile.getSectionOverview(users[userIds[0]].restContext, userIds[0], function(err, sectionVisibilities) {
                             assert.ok(!err);
                             assert.ok(sectionVisibilities);
                             assert.equal(sectionVisibilities.accountVisibility, 'public');
@@ -256,7 +256,7 @@ describe('Profiles', function() {
                             assert.equal(sectionVisibilities.profile.publications, 'loggedin');
                             
                             // Get the visibility overview as a different user. This should not include the private sections
-                            RestAPI.Profile.getAllSectionsVisibility(users[userIds[1]].restContext, userIds[0], function(err, sectionVisibilities) {
+                            RestAPI.Profile.getSectionOverview(users[userIds[1]].restContext, userIds[0], function(err, sectionVisibilities) {
                                 assert.ok(!err);
                                 assert.ok(sectionVisibilities);
                                 assert.equal(sectionVisibilities.accountVisibility, 'public');
@@ -278,7 +278,7 @@ describe('Profiles', function() {
                                             assert.ok(!err);
                                             
                                             // Check the visibility overview
-                                            RestAPI.Profile.getAllSectionsVisibility(users[userIds[0]].restContext, userIds[0], function(err, sectionVisibilities) {
+                                            RestAPI.Profile.getSectionOverview(users[userIds[0]].restContext, userIds[0], function(err, sectionVisibilities) {
                                                 assert.ok(!err);
                                                 assert.ok(sectionVisibilities);
                                                 assert.equal(sectionVisibilities.accountVisibility, 'public');
@@ -286,7 +286,7 @@ describe('Profiles', function() {
                                                 assert.equal(sectionVisibilities.profile.publications, 'private');
                                                 
                                                 // Check the visibility overview as a different user. This should not include the private sections
-                                                RestAPI.Profile.getAllSectionsVisibility(users[userIds[1]].restContext, userIds[0], function(err, sectionVisibilities) {
+                                                RestAPI.Profile.getSectionOverview(users[userIds[1]].restContext, userIds[0], function(err, sectionVisibilities) {
                                                     assert.ok(!err);
                                                     assert.ok(sectionVisibilities);
                                                     assert.equal(sectionVisibilities.accountVisibility, 'public');

--- a/node_modules/oae-rest/lib/api.profile.js
+++ b/node_modules/oae-rest/lib/api.profile.js
@@ -38,7 +38,7 @@ var getSection = module.exports.getSection = function(restCtx, userId, sectionId
  * @param  {Object}                  callback.err        Error object containing error code and error message
  * @param  {Object}                  callback.vis        JSON object representing all of the user's profile sections and their visibility. The keys are the profile section ids, and the values are the visibility settings for those sections
  */
-var getAllSectionsVisibility = module.exports.getAllSectionsVisibility = function(restCtx, userId, callback) {
+var getSectionOverview = module.exports.getSectionOverview = function(restCtx, userId, callback) {
     RestUtil.RestRequest(restCtx, '/api/user/' + RestUtil.encodeURIComponent(userId) + '/profile/sections', 'GET', null, callback);
 };
 


### PR DESCRIPTION
The getAllProfileSections function/endpoint should just return a list of section IDs for which the current user has profile information, instead of also returning all of the content for all these profile sections.
