### PR TITLE
Unused code in tz.js

### DIFF
--- a/node_modules/oae-util/lib/tz.js
+++ b/node_modules/oae-util/lib/tz.js
@@ -17,13 +17,6 @@ var tz = require('timezone-js');
 var fs = require('fs');
 tz.timezone.loadingScheme = tz.timezone.loadingSchemes.MANUAL_LOAD;
 tz.timezone.transport = function(opts) {
-    if (opts.async) {
-        if (typeof opts.success !== 'function') return;
-        opts.error = opts.error || console.error;
-        return fs.readFile(opts.url, 'utf8', function (err, data) {
-            return err ? opts.error(err) : opts.success(data);
-        });
-    }
     return fs.readFileSync(opts.url, 'utf8');
 };
 tz.timezone.loadZoneJSONData(__dirname + '/../timezones.json', true);


### PR DESCRIPTION
The following block of code

```
    if (opts.async) {
        if (typeof opts.success !== 'function') return;
        opts.error = opts.error || console.error;
        return fs.readFile(opts.url, 'utf8', function (err, data) {
            return err ? opts.error(err) : opts.success(data);
        });
    }
```

is untested, and doesn't seem to be used by any of our code (only the synchronous line underneath is called). If this is true, the block should be removed.
