### PR TITLE
Paging in search broken

### DIFF
--- a/node_modules/oae-rest/lib/api.search.js
+++ b/node_modules/oae-rest/lib/api.search.js
@@ -24,7 +24,7 @@ var RestUtil = require('./util');
  * @param {Object}                  [opts]              Options for the search
  * @param {String}                  [opts.q]            The full-text search term (default: *)
  * @param {Number}                  [opts.limit]        The number of items to retrieve. If -1, then return all. (default: -1)
- * @param {Number}                  [opts.from]         What item to start on in the results (default: 0)
+ * @param {Number}                  [opts.start]        What item to start on in the results, for paging (default: 0)
  * @param {String}                  [opts.sort]         The direction of sorting: asc, or desc (default: asc)
  * @param {Function}                callback            Standard callback method
  * @param {Object}                  callback.err        Error object containing error code and error message
@@ -42,7 +42,7 @@ var search = module.exports.search = function(restCtx, searchType, params, opts,
 
     opts.q = opts.q || '*';
     opts.limit = (opts.limit >= 0) ? opts.limit : -1;
-    opts.from = opts.from || 0;
+    opts.start = opts.start || 0;
     opts.sort = opts.sort || 'asc';
 
     var path = '/api/search/' + RestUtil.encodeURIComponent(searchType);

--- a/node_modules/oae-search/lib/searches/general.js
+++ b/node_modules/oae-search/lib/searches/general.js
@@ -42,7 +42,7 @@ module.exports = function(ctx, opts, callback) {
         'limit': isNaN(opts.limit) ? 10 : opts.limit,
         'start': isNaN(opts.start) ? 0 : opts.start,
         'sort': SearchUtil.getSortParam(opts.sort)
-    }
+    };
 
     if (_needsFilterByAccess(ctx, opts)) {
         // We'll need to know the group membership of this user to scope by content they have access to

--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -30,7 +30,7 @@ var getSearchParams = module.exports.getSearchParams = function(req) {
 
     return {
         'q': req.query.q,
-        'from': req.query.from,
+        'start': req.query.start,
         'limit': req.query.limit,
         'sort': req.query.sort
     };
@@ -88,7 +88,7 @@ var transformSearchResults = module.exports.transformSearchResults = function(ct
         return callback(null, new SearchModel.SearchResult(0, []));
     } else {
 
-        // aggregate all the documents to be keyed by type
+        // Aggregate all the documents to be keyed by type
         var total = hits.total;
         var docsByType = {};
         var docIdOrdering = {};
@@ -98,7 +98,7 @@ var transformSearchResults = module.exports.transformSearchResults = function(ct
             var id = doc._id;
             var type = doc.fields.resourceType;
 
-            // if transformer does not exist, pass it through the default "raw" transformer
+            // If transformer does not exist, pass it through the default "raw" transformer
             if (!transformers[type]) {
                 type = '*';
             }
@@ -110,33 +110,33 @@ var transformSearchResults = module.exports.transformSearchResults = function(ct
             docIdOrdering[id] = i;
         }
 
-        // run all the documents through the document transformers for their particular type
+        // Run all the documents through the document transformers for their particular type
         var transformersToRun = _.keys(docsByType).length;
         var transformersComplete = 0;
         var transformErr = null;
         var transformedDocs = {};
         var _monitorTransformers = function(err, docs) {
             if (transformErr) {
-                // nothing to do, we've already returned because of an error.
+                // Nothing to do, we've already returned because of an error.
             } else if (err) {
                 transformErr = err;
                 return callback(transformErr);
             } else {
 
-                // merge the docs from this iteration
+                // Merge the docs from this iteration
                 _.extend(transformedDocs, docs);
 
                 transformersComplete++;
                 if (transformersComplete >= transformersToRun) {
 
-                    // we're done all transformations, reorder the docs and send back the response
+                    // We're done all transformations, reorder the docs and send back the response
                     var orderedDocs = _orderDocs(transformedDocs, docIdOrdering);
                     return callback(null, new SearchModel.SearchResult(total, orderedDocs));
                 }
             }
         }
 
-        // execute all transformers asynchronously from one another. _monitorTransformers will keep track fo their completion.
+        // Execute all transformers asynchronously from one another. _monitorTransformers will keep track fo their completion.
         for (var type in docsByType) {
             transformers[type](ctx, docsByType[type], _monitorTransformers);
         }
@@ -149,14 +149,14 @@ var transformSearchResults = module.exports.transformSearchResults = function(ct
  * @param   {Object}    query           The ElasticSearch query representation.
  * @param   {Object}    [filter]        The ElasticSearch filter to apply. If not specified, then the resulting object will be a simple query.
  * @param   {Object}    [opts]          A set of additional options for the query
- * @param   {Number}    [opts.from]     The starting index of the query
+ * @param   {Number}    [opts.start]    The starting index of the query for paging
  * @param   {Number}    [opts.limit]    The maximum number of documents to return
  * @param   {String}    [opts.sort]     The sort direction (asc or desc)
  * @return  {Object}                    A valid ElasticSearch Query object that can be sent as a query.
  */
 var createQuery = module.exports.createQuery = function(query, filter, opts) {
     if (filter) {
-        // if we have filters, we need to create a 'filtered' query
+        // If we have filters, we need to create a 'filtered' query
         var data = {
             'query': {
                 'filtered': {
@@ -166,18 +166,18 @@ var createQuery = module.exports.createQuery = function(query, filter, opts) {
             }
         };
     } else {
-        // if it's just a query, we wrap it in a standard query.
+        // If it's just a query, we wrap it in a standard query.
         var data = {
             'query': query
         };
     }
 
-    // strip the opts down to the relevant parameters
+    // Strip the opts down to the relevant ElasticSearch parameters
     opts = {
-        'from': opts.from,
+        'from': opts.start,
         'size': opts.limit,
         'sort': {
-            // this 'sort' key is the name of the field on the document that we're sorting on
+            // This 'sort' key is the name of the field on the document that we're sorting on
             'sort': getSortParam(opts.sort)
         }
     }
@@ -206,7 +206,7 @@ var createBulkIndexOperations = module.exports.createBulkIndexOperations = funct
             }
         };
 
-        // these meta attributes have been promoted and shouldn't be on the core doc anymore
+        // These meta attributes have been promoted and shouldn't be on the core doc anymore
         delete doc.id;
         delete doc._type;
         delete doc._parent;
@@ -356,7 +356,7 @@ var filterMemberships = module.exports.filterMemberships = function(memberships)
  */
 var createQueryStringQuery = module.exports.createQueryStringQuery = function(field, q) {
     if (!q || q === SearchConstants.query.ALL) {
-        // we're searching everything, use query_string syntax
+        // We're searching everything, use query_string syntax
         return {
             'query_string': {
                 'default_field': field,
@@ -364,7 +364,7 @@ var createQueryStringQuery = module.exports.createQueryStringQuery = function(fi
             }
         };
     } else {
-        // we're searching for a keyword, use a safe match query instead of query_string
+        // We're searching for a keyword, use a safe match query instead of query_string
         var match = {};
         match[field] = {
             'query': q,

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -202,6 +202,48 @@ describe('General Search', function() {
         });
     });
 
+    describe('Search Paging', function() {
+
+        /**
+         * Test that verifies that the 'start' property properly pages search results
+         */
+        it('verify search paging', function(callback) {
+            // Make sure we have at least 2 content items to page with, their actual information is not important for this test
+            RestAPI.Content.createLink(camAdminRestContext, 'Sakai Foundation', 'Link to Sakai Foundation Website', 'public', 'http://www.sakaifoundation.org', [], [], function(err, link) {
+                assert.ok(!err);
+
+                RestAPI.Content.createLink(camAdminRestContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], function(err, link) {
+                    assert.ok(!err);
+
+                    // Search once and grab the first document id
+                    RestAPI.Search.search(camAdminRestContext, 'general', ['all'], {'limit': '1'}, function(err, results) {
+                        assert.ok(!err);
+                        assert.ok(results);
+                        assert.ok(results.results);
+                        assert.equal(results.results.length, 1);
+
+                        var firstDocId = results.results[0].id;
+                        assert.ok(firstDocId);
+
+                        // Search again with start=1 and verify the first document id of the previous search is not the same as the first document id of this search
+                        RestAPI.Search.search(camAdminRestContext, 'general', ['all'], {'limit': '1', 'start': 1}, function(err, results) {
+                            assert.ok(!err);
+                            assert.ok(results);
+                            assert.ok(results.results);
+                            assert.equal(results.results.length, 1);
+
+                            var secondDocId = results.results[0].id;
+                            assert.ok(secondDocId);
+
+                            assert.notEqual(firstDocId, secondDocId);
+                            callback();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
     describe('Content Search', function() {
 
         /**

--- a/node_modules/oae-search/tests/test-search-util.js
+++ b/node_modules/oae-search/tests/test-search-util.js
@@ -31,7 +31,7 @@ describe('Search Util', function() {
             var params = SearchUtil.getSearchParams({
                 query: {
                     'q': 'qVal',
-                    'from': 'fromVal',
+                    'start': 'startVal',
                     'limit': 'limitVal',
                     'sort': 'sortVal',
                     'rogue': 'rogueVal'
@@ -39,7 +39,7 @@ describe('Search Util', function() {
             });
 
             assert.equal(params.q, 'qVal');
-            assert.equal(params.from, 'fromVal');
+            assert.equal(params.start, 'startVal');
             assert.equal(params.limit, 'limitVal');
             assert.equal(params.sort, 'sortVal');
             assert.equal(params.rogue, undefined);
@@ -53,7 +53,7 @@ describe('Search Util', function() {
             var params = SearchUtil.getSearchParams({query:{}});
 
             assert.equal(params.q, undefined);
-            assert.equal(params.from, undefined);
+            assert.equal(params.start, undefined);
             assert.equal(params.limit, undefined);
             assert.equal(params.sort, undefined);
             assert.equal(params.rogue, undefined);


### PR DESCRIPTION
Paging in search seems to be broken.

```
/api/search/general/all?limit=12&from=11
```

Should return the second set of data but returns the first page again.
Also, to keep things consistent we should use `start` instead of `from` for paging.
