### PR TITLE
`/api/group/:id/members` results aren't wrapped in a results object

### DIFF
--- a/node_modules/oae-principals/lib/rest.group.js
+++ b/node_modules/oae-principals/lib/rest.group.js
@@ -91,7 +91,7 @@ OAE.tenantServer.get('/api/group/:id/members', function(req, res) {
         if (err) {
             return res.send(err.code, err.msg);
         }
-        res.send(200, members);
+        res.send(200, {'results': members});
     });
 });
 

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -212,9 +212,9 @@ describe('Groups', function() {
                         // Get the members of this group.
                         RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, undefined, undefined, function(err, members) {
                             assert.ok(!err);
-                            assert.equal(members.length, 3);
+                            assert.equal(members.results.length, 3);
                             // Morph results to hash for easy access.
-                            var hash = _.groupBy(members, function(member) { return member.profile.id; });
+                            var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
                             assert.equal(hash[jack.id][0].role, 'member');
                             assert.equal(hash[jane.id][0].role, 'manager');
                             assert.equal(hash[johnRestContext.id][0].role, 'manager');
@@ -485,9 +485,9 @@ describe('Groups', function() {
                         // Get the group members
                         RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, 10, function(err, members) {
                             assert.ok(!err);
-                            assert.equal(members.length, 7);
+                            assert.equal(members.results.length, 7);
                             // Morph results to hash for easy access.
-                            var hash = _.groupBy(members, function(member) { return member.profile.id; });
+                            var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
                             // Make sure that all of the expected members are there
                             assert.equal(hash[johnRestContext.id][0].role, 'manager');
                             assert.equal(hash[managerUserIds[0]][0].role, 'manager');
@@ -566,8 +566,8 @@ describe('Groups', function() {
                         RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
-                            assert.equal(members.length, 1);
-                            assert.equal(members[0].profile.id, userA.id);
+                            assert.equal(members.results.length, 1);
+                            assert.equal(members.results[0].profile.id, userA.id);
 
                             var usernameB = TestsUtil.generateTestUserId();
 
@@ -615,8 +615,8 @@ describe('Groups', function() {
                         RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
-                            assert.equal(members.length, 1);
-                            assert.equal(members[0].profile.id, userA.id);
+                            assert.equal(members.results.length, 1);
+                            assert.equal(members.results[0].profile.id, userA.id);
 
                             var usernameB = TestsUtil.generateTestUserId();
 
@@ -629,8 +629,8 @@ describe('Groups', function() {
                                 RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
                                     assert.ok(!err);
                                     assert.ok(members);
-                                    assert.equal(members.length, 1);
-                                    assert.equal(members[0].profile.id, userA.id);
+                                    assert.equal(members.results.length, 1);
+                                    assert.equal(members.results[0].profile.id, userA.id);
                                     callback();
                                 });
                             });
@@ -676,7 +676,7 @@ describe('Groups', function() {
                                 RestAPI.Group.getGroupMembers(restCtxB, groupB.id, null, 10, function(err, members) {
                                     assert.ok(!err);
                                     assert.ok(members);
-                                    assert.equal(members.length, 2);
+                                    assert.equal(members.results.length, 2);
                                     callback();
                                 });
                             });
@@ -702,22 +702,22 @@ describe('Groups', function() {
                     var shouldBeSortedArray = [];
                     RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, 4, function(err, members) {
                         assert.ok(!err);
-                        assert.equal(members.length, 4);
+                        assert.equal(members.results.length, 4);
                         for (var i = 0; i < 4; i++) {
-                            shouldBeSortedArray.push(members[i].profile.id);
+                            shouldBeSortedArray.push(members.results[i].profile.id);
                         }
-                        RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, members[3].profile.id, 4, function(err, members) {
+                        RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, members.results[3].profile.id, 4, function(err, members) {
                             assert.ok(!err);
-                            assert.equal(members.length, 4);
+                            assert.equal(members.results.length, 4);
                             for (var i = 0; i < 4; i++) {
-                                shouldBeSortedArray.push(members[i].profile.id);
+                                shouldBeSortedArray.push(members.results[i].profile.id);
                             }
                             // Get the remaining 3
-                            RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, members[3].profile.id, 4, function(err, members) {
+                            RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, members.results[3].profile.id, 4, function(err, members) {
                                 assert.ok(!err);
-                                assert.equal(members.length, 3);
+                                assert.equal(members.results.length, 3);
                                 for (var i = 0; i < 3; i++) {
-                                    shouldBeSortedArray.push(members[i].profile.id);
+                                    shouldBeSortedArray.push(members.results[i].profile.id);
                                 }
 
                                 // Make sure the shouldBeSortedArray is actually sorted.
@@ -767,7 +767,7 @@ describe('Groups', function() {
                 RestAPI.Group.createGroup(johnRestContext, groupId, 'Group title', 'Group description', 'private', 'request', [], userIds, function(err, newGroup) {
                     RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
                         assert.ok(!err);
-                        assert.equal(members.length, 10);
+                        assert.equal(members.results.length, 10);
                         callback();
                     });
                 });
@@ -904,9 +904,9 @@ describe('Groups', function() {
                                 // Verify that each member has the correct role
                                 RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
                                     assert.ok(!err);
-                                    assert.equal(members.length, 4);
+                                    assert.equal(members.results.length, 4);
                                     // Morph results to hash for easy access.
-                                    var hash = _.groupBy(members, function(member) { return member.profile.id; });
+                                    var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
                                     assert.equal(hash[johnRestContext.id][0].role, 'manager');
                                     assert.equal(hash[jack.id][0].role, 'member');
                                     assert.equal(hash[jane.id][0].role, 'manager');
@@ -928,9 +928,9 @@ describe('Groups', function() {
                                             // Make sure that the membership changes have happened
                                             RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
                                                 assert.ok(!err);
-                                                assert.equal(members.length, 3);
+                                                assert.equal(members.results.length, 3);
                                                 // Morph results to hash for easy access.
-                                                var hash = _.groupBy(members, function(member) { return member.profile.id; });
+                                                var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
                                                 assert.equal(hash[johnRestContext.id][0].role, 'manager');
                                                 assert.equal(hash[jack.id][0].role, 'member');
                                                 assert.equal(hash[jane.id][0].role, 'member');
@@ -1118,8 +1118,8 @@ describe('Groups', function() {
                         // Make sure that the request hasn't gone through
                         RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, null, null, function(err, members) {
                             assert.ok(!err);
-                            assert.equal(members.length, 1);
-                            assert.equal(members[0].profile.id, johnRestContext.id);
+                            assert.equal(members.results.length, 1);
+                            assert.equal(members.results[0].profile.id, johnRestContext.id);
                             callback();
                         });
                     });
@@ -1168,8 +1168,8 @@ describe('Groups', function() {
                         RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
-                            assert.equal(members.length, 1);
-                            assert.equal(members[0].profile.id, userA.id);
+                            assert.equal(members.results.length, 1);
+                            assert.equal(members.results[0].profile.id, userA.id);
 
                             var usernameB = TestsUtil.generateTestUserId();
 
@@ -1215,8 +1215,8 @@ describe('Groups', function() {
                         RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
-                            assert.equal(members.length, 1);
-                            assert.equal(members[0].profile.id, userA.id);
+                            assert.equal(members.results.length, 1);
+                            assert.equal(members.results[0].profile.id, userA.id);
 
                             // Create tenant B
                             TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
@@ -1241,8 +1241,8 @@ describe('Groups', function() {
                                             // Verify userB is not added to the group
                                             RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
                                                 assert.ok(!err);
-                                                assert.equal(members.length, 1);
-                                                assert.equal(members[0].profile.id, userA.id);
+                                                assert.equal(members.results.length, 1);
+                                                assert.equal(members.results[0].profile.id, userA.id);
                                                 callback();
                                             });
                                         });
@@ -1298,8 +1298,8 @@ describe('Groups', function() {
                                         // Verify userB cannot see userA as a member of groupA
                                         RestAPI.Group.getGroupMembers(restCtxB, groupB.id, null, 10, function(err, members) {
                                             assert.ok(!err);
-                                            assert.equal(members.length, 1);
-                                            assert.equal(members[0].profile.id, userB.id);
+                                            assert.equal(members.results.length, 1);
+                                            assert.equal(members.results[0].profile.id, userB.id);
                                             callback();
                                         });
                                     });
@@ -1554,9 +1554,9 @@ describe('Groups', function() {
             RestAPI.Group.getGroupMembers(johnRestContext, createdPrincipals[groupIdentifier].id, null, null, function(err, members) {
                 assert.ok(!err);
                 // We also always expect John to come back as a member
-                assert.equal(members.length, expectedMembers.length + 1);
+                assert.equal(members.results.length, expectedMembers.length + 1);
                 // Morph results to hash for easy access.
-                var hash = _.groupBy(members, function(principal) { return principal.profile.id; });
+                var hash = _.groupBy(members.results, function(principal) { return principal.profile.id; });
                 for (var i = 0; i < expectedMembers.length; i++) {
                     assert.equal(hash[createdPrincipals[expectedMembers[i]].id][0].profile.id, createdPrincipals[expectedMembers[i]].id);
                 }
@@ -1647,7 +1647,7 @@ describe('Groups', function() {
                     RestAPI.Group.getGroupMembers(restContext, groupObj.id, null, null, function(err, members) {
                         if (expectedMembers) {
                             assert.ok(!err);
-                            assert.equal(members.length, expectedMemberLength);
+                            assert.equal(members.results.length, expectedMemberLength);
                         } else {
                             assert.ok(err);
                             assert.equal(err.code, 401);

--- a/node_modules/oae-rest/lib/api.group.js
+++ b/node_modules/oae-rest/lib/api.group.js
@@ -84,7 +84,7 @@ var updateGroup = module.exports.updateGroup = function (restCtx, groupId, profi
  * @param  {Number}             limit               The number of members to retrieve.
  * @param  {Function}           callback            Standard callback method takes arguments `err` and `resp`
  * @param  {Object}             callback.err        Error object containing error code and error message
- * @param  {User[]|Group[]}     callback.response   Array of principals representing the group members
+ * @param  {Object}             callback.response   An object with key 'results', whose value is a mixed array of User and Group objects that are members of the group
  */
 var getGroupMembers = module.exports.getGroupMembers = function(restCtx, groupId, start, limit, callback) {
     var params = {


### PR DESCRIPTION
`/api/group/:id/members` is not returning the results wrapped in a `results` object next to a `total` count.

```
[
    {
        "profile": {
            "tenant": "camtest",
            "id": "u:camtest:eVJLKoN6if",
            "displayName": "Bert Pareyn",
            "visibility": "public",
            "locale": "en_GB",
            "timezone": "Etc/UTC",
            "publicAlias": "Bert Pareyn",
            "extra": {}
        },
        "role": "manager"
    }
]
```
