### PR TITLE
Increase default timeouts

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
             all: {
                 src: ['node_modules/oae-tests/runner/beforeTests.js', 'node_modules/oae-*/tests/**/*.js'],
                 options: {
-                    timeout: 20000,
+                    timeout: 30000,
                     ignoreLeaks: true,
                     reporter: 'spec',
                     grep: mocha_grep
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
         var config = {
             src: ['node_modules/oae-tests/runner/beforeTests.js', 'node_modules/' + module + '/tests/**/*.js'],
             options: {
-                timeout: 20000,
+                timeout: 30000,
                 ignoreLeaks: true,
                 reporter: 'spec',
                 grep: mocha_grep

--- a/node_modules/oae-rest/lib/api.config.js
+++ b/node_modules/oae-rest/lib/api.config.js
@@ -17,7 +17,7 @@ var RestUtil = require('./util');
 
 // Changing a config value is async, this variable
 // holds how long we should wait before returning
-var WAIT_TIME = 100;
+var WAIT_TIME = 150;
 
 /**
  * Get the global config schema through the REST API. This should only return for a global or tenant admin.

--- a/node_modules/oae-search/lib/test/util.js
+++ b/node_modules/oae-search/lib/test/util.js
@@ -15,7 +15,7 @@
 
 var RestAPI = require('oae-rest');
 
-var REFRESH_DELAY = 250;
+var REFRESH_DELAY = 400;
 
 /**
  * Search for all the documents that match the query. This bypasses paging, meaning all the results will be


### PR DESCRIPTION
Increase default timeouts for tests

```
mocha 30000ms
cassandra 3000ms
tenant 100ms
config 150ms
mq 250ms
search 400ms
```
