### PR TITLE
Increase default timeouts

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
             all: {
                 src: ['node_modules/oae-tests/runner/beforeTests.js', 'node_modules/oae-*/tests/**/*.js'],
                 options: {
-                    timeout: 20000,
+                    timeout: 30000,
                     ignoreLeaks: true,
                     reporter: 'spec',
                     grep: mocha_grep
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
         var config = {
             src: ['node_modules/oae-tests/runner/beforeTests.js', 'node_modules/' + module + '/tests/**/*.js'],
             options: {
-                timeout: 20000,
+                timeout: 30000,
                 ignoreLeaks: true,
                 reporter: 'spec',
                 grep: mocha_grep
@@ -72,7 +72,7 @@ module.exports = function(grunt) {
         // Set a covering environment variable, as this will be used to determine where the UI resides relative to the Hilary folder.
         shell.env['OAE_COVERING'] = true;
         var MODULES = grunt.file.expandDirs('node_modules/oae-*/tests').join(' ');
-        var output = shell.exec('../node_modules/.bin/mocha --ignore-leaks --timeout 20000 --reporter html-cov node_modules/oae-tests/runner/beforeTests.js ' + MODULES, {silent:true}).output;
+        var output = shell.exec('../node_modules/.bin/mocha --ignore-leaks --timeout 30000 --reporter html-cov node_modules/oae-tests/runner/beforeTests.js ' + MODULES, {silent:true}).output;
         output.to('coverage.html');
         grunt.log.writeln('Code Coverage report generated at ' + 'target/coverage.html'.cyan);
 

--- a/node_modules/oae-rest/lib/api.config.js
+++ b/node_modules/oae-rest/lib/api.config.js
@@ -17,7 +17,7 @@ var RestUtil = require('./util');
 
 // Changing a config value is async, this variable
 // holds how long we should wait before returning
-var WAIT_TIME = 100;
+var WAIT_TIME = 150;
 
 /**
  * Get the global config schema through the REST API. This should only return for a global or tenant admin.

--- a/node_modules/oae-search/lib/test/util.js
+++ b/node_modules/oae-search/lib/test/util.js
@@ -15,7 +15,7 @@
 
 var RestAPI = require('oae-rest');
 
-var REFRESH_DELAY = 250;
+var REFRESH_DELAY = 400;
 
 /**
  * Search for all the documents that match the query. This bypasses paging, meaning all the results will be

--- a/node_modules/oae-util/lib/cassandra.js
+++ b/node_modules/oae-util/lib/cassandra.js
@@ -117,7 +117,7 @@ var createKeyspace = module.exports.createKeyspace = function(name, callback) {
                     return callback(err);
                 }
                 // pause for a second to ensure the keyspace gets agreed upon across the cluster.
-                setTimeout(callback, 1000, null, true);
+                setTimeout(callback, 3000, null, true);
             });
         } else {
             return callback(null, false);


### PR DESCRIPTION
I'm seeing more test failures caused by our timeouts not being long enough, and am often having to run the tests twice to be able to verify that they work. We should increase our timeouts (beforeTests, as well as the ones in oae-rest) so that the tests work better on slower machines.
