### PR TITLE
Compatibility with elasticsearchclient v0.3+

### DIFF
--- a/node_modules/oae-search/lib/api.js
+++ b/node_modules/oae-search/lib/api.js
@@ -334,9 +334,13 @@ var _handleIndexDocumentTask = function(data, callback) {
                         });
                     } else if (allDocs.length === 1) {
                         var doc = allDocs[0];
-                        var opts = {'parent': doc['_parent']};
-                        delete doc['_parent'];
-                        client.index(doc['_type'], doc, opts, callback);
+                        var opts = {'parent': doc._parent};
+                        var id = doc.id;
+
+                        delete doc._parent;
+                        delete doc.id;
+
+                        client.index(doc._type, id, doc, opts, callback);
                     } else {
                         callback();
                     }

--- a/node_modules/oae-search/lib/internal/elasticsearch.js
+++ b/node_modules/oae-search/lib/internal/elasticsearch.js
@@ -201,14 +201,15 @@ var search = module.exports.search = function(query, options, callback) {
  * Index the given document in ElasticSearch.
  *
  * @param   {String}    typeName        The type of document to index
+ * @param   {String}    id              The id of the document to index
  * @param   {Object}    doc             The document to index
  * @param   {Object}    options         The querystring options to send with the index call
  * @param   {Function}  callback        Invoked whent he process completes
  * @param   {Object}    callback.err    An error that occurred, if any
  */
-var index = module.exports.index = function(typeName, doc, options, callback) {
-    log().trace({ 'typeName': typeName, 'document': doc, 'options': options }, 'Indexing a document.');
-    return _exec('index', client.index(index, typeName, doc, options), callback);
+var index = module.exports.index = function(typeName, id, doc, options, callback) {
+    log().trace({ 'typeName': typeName, 'id': id, 'document': doc, 'options': options }, 'Indexing a document.');
+    return _exec('index', client.index(index, typeName, doc, id, options), callback);
 };
 
 /**


### PR DESCRIPTION
ID handling in updates changed in the nodejs elasticsearchclient library recently. This fix makes it compatible, but is not compatible with 0.2 anymore.

Please be sure to `npm install -d` to get the update to the elasticsearchclient module when taking in this fix.
