### PR TITLE
Setting a minimum score of 0.20 for search results.

### DIFF
--- a/node_modules/oae-search/lib/api.js
+++ b/node_modules/oae-search/lib/api.js
@@ -144,7 +144,6 @@ var registerSearch = module.exports.registerSearch = function(typeName, queryBui
  * @param  {Number}         [opts.limit]        The maximum number of search documents to return
  * @param  {Number}         [opts.start]        The document index from which to start
  * @param  {String}         [opts.sort]         The direction to sort the results. One of 'asc' or 'desc'
- * @param  {Number}         [opts.minScore]    The minimum score for a document to be included in the result set.
  * @param  {Function}       callback            Invoked when the process completes
  * @param  {Object}         callback.err        An error that occurred, if any
  * @param  {Object}         callback.result     The search result object

--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -165,7 +165,7 @@ var transformSearchResults = module.exports.transformSearchResults = function(ct
  * @param   {Number}    [opts.start]        The starting index of the query for paging
  * @param   {Number}    [opts.limit]        The maximum number of documents to return
  * @param   {String}    [opts.sort]         The sort direction (asc or desc)
- * @param   {Number}    [opts.minScore]    The minimum score for a document to be included in the result set.
+ * @param   {Number}    [opts.minScore]     The minimum score for a document to be included in the result set.
  * @return  {Object}                        A valid ElasticSearch Query object that can be sent as a query.
  * @throws  {Error}                         Thrown if the `query` parameter is not an object.
  */
@@ -205,7 +205,7 @@ var createQuery = module.exports.createQuery = function(query, filter, opts) {
             {'_score': {'order': 'desc'}},
             {'sort': getSortParam(opts.sort)}
         ],
-        'min_score': opts.minScore || SearchConstants.query.MINIMUM_SCORE
+        'min_score': (_.isNumber(opts.minScore)) ? opts.minScore : SearchConstants.query.MINIMUM_SCORE
     };
 
     return _.extend(data, opts);

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -1661,7 +1661,45 @@ describe('General Search', function() {
             });
         });
     });
-    
+
+    describe('Search Quality', function() {
+
+        /**
+         * Verifies that there is a cut-off point which eliminates documents that are only slightly relevant to the search query.
+         * Assuming there are documents which are indexed with:
+         *  * OAE Team
+         *  * Theological reasoning
+         *  * Independent workforce
+         * When searching for `Team` only the first document should return.
+         */
+        it('verify results do not match on a single letter', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
+                assert.ok(!err);
+                var restCtx = _.values(users)[0].restContext;
+
+                // Create some content
+                RestAPI.Content.createLink(restCtx, 'Theological reasoning', null, 'public', 'http://www.sakaifoundation.org', [], [], function(err, contentA) {
+                    assert.ok(!err);
+                    RestAPI.Content.createLink(restCtx, 'Independent workforce', null, 'public', 'http://www.sakaifoundation.org', [], [], function(err, contentB) {
+                        assert.ok(!err);
+                        var groupAlias = 'OAE Team ' + Math.random();
+                        RestAPI.Group.createGroup(restCtx, groupAlias, groupAlias, 'A really awesome group', 'public', 'no', [], [], function(err, group) {
+                            assert.ok(!err);
+
+                            // Ensure that only the group returns in the search results when searching for Team
+                            SearchTestsUtil.searchAll(restCtx, 'general', null, {'q': 'Team'}, function(err, results) {
+                                assert.ok(!err);
+                                assert.equal(_.filter(results.results, function(result) { return result.id === contentA.id || result.id === contentB.id; }).length, 0);
+                                assert.equal(_.filter(results.results, function(result) { return result.id === group.id; }).length, 1);
+                                callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
     describe('Search Options', function() {
 
         /**


### PR DESCRIPTION
Naive fix for #307.

This essentially sets the minimum score to 0.2.
I've tried this out with data generated by the model loader and had better results.
