### PR TITLE
Let bunyan-syslog exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "optimist": "latest"
   },
   "optionalDependencies": {
-    "hiredis": "latest"
+    "hiredis": "latest",
+    "bunyan-syslog": "latest"
   },
   "bundleDependencies": [
     "oae-authentication",


### PR DESCRIPTION
Importing this allows us to support logging to a central syslog server VIA an update to config.js
