### PR TITLE
Flush MQ after tests

### DIFF
--- a/node_modules/oae-tests/runner/beforeTests.js
+++ b/node_modules/oae-tests/runner/beforeTests.js
@@ -198,23 +198,31 @@ before(function(callback) {
                         _bindRequestLogger();
                     });
 
-                    // Defer the rest of the startup until after the task handlers are successfully bound. This will always
-                    // be fired after OAE.init has successfully finished.
+                    // Defer the rest of the startup until after the task handlers are successfully bound and all the queues are drained.
+                    // This will always be fired after OAE.init has successfully finished.
                     MQ.on('ready', function(err) {
                         if (err) {
                             return callback(err);
                         }
 
-                        setUpTenants(function(err) {
+                        // Purge the queue.
+                        MQ.purgeAll(function(err) {
                             if (err) {
                                 return callback(new Error(err.msg));
                             }
-                            log().info('Disabling the preview processor during tests.');
-                            PreviewAPI.disable(function(err) {
+
+                            // Set up a couple of test tenants.
+                            setUpTenants(function(err) {
                                 if (err) {
                                     return callback(new Error(err.msg));
                                 }
-                                callback();
+                                log().info('Disabling the preview processor during tests.');
+                                PreviewAPI.disable(function(err) {
+                                    if (err) {
+                                        return callback(new Error(err.msg));
+                                    }
+                                    callback();
+                                });
                             });
                         });
                     });
@@ -236,7 +244,13 @@ after(function(callback) {
             if (err) {
                log().error({err: err}, 'Error flushing Redis data after test completion.');
             }
-            callback();
+            // Purge the queue.
+            MQ.purgeAll(function(err) {
+                if (err) {
+                    log().error({err: err}, 'Error purging the RabbitMQ queues.');
+                }
+                callback();
+            });
         });
     });
 });

--- a/node_modules/oae-util/lib/mq.js
+++ b/node_modules/oae-util/lib/mq.js
@@ -116,9 +116,8 @@ var init = module.exports.init = function(mqConfig, callback) {
 
         connection = amqp.createConnection(mqConfig.connection);
 
-        // While the connection always reconnects, this option ensures that all channels that were open before a
-        // connection was closed / error are re-opened when connection is re-established.
-        connection.setImplOptions({'reconnect': true});
+        // When the connection drops away, we try to reconnect every 15 seconds.
+        connection.setImplOptions({'reconnect': true, 'reconnectBackoffTime': 15000});
 
         connection.on('error', function(err) {
             log().error({'err': err}, 'Error connecting to RabbitMQ.');
@@ -304,6 +303,73 @@ var whenTasksEmpty = module.exports.whenTasksEmpty = function(name, handler) {
     } else {
         emitter.once('tasksEmpty-' + name, handler);
     }
+};
+
+/**
+ * Purge a queue.
+ *
+ * @param  {String}     name            The name of the queue to purge. This is the same name as the label you use to bind to a queue.
+ * @param  {Function}   [callback]      Standard callback method
+ * @param  {Object}     [callback.err]  An error that occurred purging the task queue, if any
+ */
+var purge = module.exports.purge = function(name, callback) {
+    callback = callback || function(err) {
+        if (err) {
+            log().error({'err': err, 'queueName': name}, 'Error purging queue.');
+        }
+    };
+
+    log().info({'queueName': name}, 'Purging queue.');
+    queues[name].queue.purge().addCallback(function(ok) {
+        if (!ok) {
+            log().error({'err': err, 'queueName': name}, 'Error purging task queue.');
+            return callback({'code': 500, 'msg': 'Error purging task queue: ' + name});
+        }
+
+        return callback();
+    });
+};
+
+/**
+ * Purges all the known queues.
+ * Note: This does *not* purge all the queues that are in RabbitMQ.
+ * It only purges the queues that are known to the OAE system.
+ *
+ * @param  {Function}   [callback]      Standard callback method
+ * @param  {Object}     [callback.err]  An error that occurred purging the task queue, if any
+ */
+var purgeAll = module.exports.purgeAll = function(callback) {
+    callback = callback || function(err) {
+        if (err) {
+            log().error({'err': err}, 'Error purging all known queues.');
+        }
+    };
+
+    // Get all the known queues we can purge.
+    var toPurge = _.keys(queues);
+    log().info({'queues': toPurge}, 'Purging all known queues.');
+
+    /*!
+     * Purges one of the known queues and calls the callback method when they are all purged (or when an error occurs.)
+     *
+     * @param  {Object}  err    Standard error object (if any.)
+     * @api private
+     */
+    var doPurge = function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        if (toPurge.length === 0) {
+            callback();
+        } else {
+            var queueToPurge = toPurge.pop();
+            purge(queueToPurge, doPurge);
+        }
+    };
+
+    // Start purging.
+    doPurge();
 };
 
 /**

--- a/node_modules/oae-util/tests/test-mq.js
+++ b/node_modules/oae-util/tests/test-mq.js
@@ -17,6 +17,19 @@ var assert = require('assert');
 var MQ = require('oae-util/lib/mq');
 
 describe('MQ', function() {
+
+    /**
+     * Some options that can be used to bind to a message queue.
+     */
+    var purgeQueueOptions = {
+        'subscribe': {
+            'prefetchCount': 1
+        },
+        'queue': {
+            'durable': false
+        }
+    };
+
     describe('#bind()', function() {
 
         /**
@@ -65,7 +78,7 @@ describe('MQ', function() {
                     });
                 });
             });
-        })
+        });
 
         /**
          * Verify that binding a worker when there is already one doesn't invoke an error
@@ -99,6 +112,73 @@ describe('MQ', function() {
                 MQ.submit(testQueue, { 'activity': 'blah' });
                 // Simply make sure tests continue normally when the exception is thrown
                 callback();
+            });
+        });
+    });
+
+    describe('#purge()', function() {
+
+        /**
+         * Verify that a queue can be purged of its tasks.
+         */
+        it ('verify a queue can be purged', function(callback) {
+            var called = 0;
+            var taskHandler = function(data, taskCallback) {
+                called++;
+                setTimeout(taskCallback, 2000);
+            };
+
+            var testQueue = 'testQueue-' + new Date().getTime();
+            MQ.bind(testQueue, taskHandler, purgeQueueOptions, function() {
+                // Submit a couple of tasks.
+                for (var i = 0; i < 10; i++) {
+                    MQ.submit(testQueue, { 'foo': 'bar' });
+                }
+
+                // Purge the queue.
+                MQ.purge(testQueue, function() {
+                    // Because of the asynchronous nature of node/rabbitmq it's possible that a task gets delivered
+                    // before the purge command is processed.
+                    // That means we should have only handled at most 1 task.
+                    assert.ok(called <= 1);
+                    callback();
+                });
+            });
+        });
+    });
+
+    describe('#purgeAll()', function() {
+
+        /**
+         * Verify that all known queues can be purged of its tasks.
+         */
+        it ('verify all queues can be purged', function(callback) {
+            var called = {'a': 0, 'b': 0};
+            var taskHandler = function(data, taskCallback) {
+                called[data.queue]++;
+                setTimeout(taskCallback, 2000);
+            };
+
+            var testQueueA = 'testQueueA-' + new Date().getTime();
+            var testQueueB = 'testQueueB-' + new Date().getTime();
+            MQ.bind(testQueueA, taskHandler, purgeQueueOptions, function() {
+                MQ.bind(testQueueB, taskHandler, purgeQueueOptions, function() {
+                    // Submit a couple of tasks.
+                    for (var i = 0; i < 10; i++) {
+                        MQ.submit(testQueueA, { 'queue': 'a' });
+                        MQ.submit(testQueueB, { 'queue': 'b' });
+                    }
+
+                    // Purge all the queues.
+                    MQ.purgeAll(function() {
+                        // Because of the asynchronous nature of node/rabbitmq it's possible that a task gets delivered
+                        // before the purge command is processed.
+                        // That means we should have only handled at most 1 task.
+                        assert.ok(called['a'] <= 1);
+                        assert.ok(called['b'] <= 1);
+                        callback();
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
To avoid errors like

```
[2013-03-12T11:28:42.788Z] ERROR: oae-preview-processor/99820 on Nicolaass-MacBook-Pro.local: Got an unexpected error from the REST api.
    err: {
      "code": 404,
      "msg": "There is no tenant with alias camtest"
    }
[2013-03-12T11:28:42.789Z] ERROR: oae-preview-processor/99820 on Nicolaass-MacBook-Pro.local: We could not log in on the the tenant. The status of the content item will not be set. (contentId=c:camtest:VTvsW1BmHf)
    err: {
      "code": 404,
      "msg": "There is no tenant with alias camtest"
    }
```
