### PR TITLE
Revert hiredis to 0.1.13 so it builds on smartos

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "optionalDependencies": {
     "bunyan-syslog": "latest",
-    "hiredis": "latest"
+    "hiredis": "0.1.13"
   },
   "bundleDependencies": [
     "oae-authentication",


### PR DESCRIPTION
This can be bumped up to the version in which this is fixed:

https://github.com/pietern/hiredis-node/issues/34
