### PR TITLE
Follow up on skinning issues

### DIFF
--- a/node_modules/oae-ui/lib/api.js
+++ b/node_modules/oae-ui/lib/api.js
@@ -14,6 +14,7 @@
  */
 
 var _ = require('underscore');
+var events = require('events');
 var fs = require('fs');
 var less = require('less');
 var readdirp = require('readdirp');
@@ -48,6 +49,16 @@ var staticFileCache = {};
 // initialization.
 var widgetManifestCache = {};
 
+
+/**
+ * The UI API.
+ *
+ * ## Events
+ *
+ * * `skinParsed` - Invoked when the skin file has been parsed on the application node.
+ */
+var UIAPI = module.exports = new events.EventEmitter();
+var emitter = UIAPI;
 
 ////////////////////
 // Initialization //
@@ -90,6 +101,8 @@ ConfigAPI.on('update', function(tenantAlias) {
         if (err) {
             log().error({'err': err, 'tenantAlias': tenantAlias}, 'Could not re-cache the tenant skin after a config update.');
         }
+
+        emitter.emit('skinParsed');
     });
 });
 
@@ -117,7 +130,7 @@ var updateFileCaches = function(filename) {
     if (/^\/node_modules\/(.*?)\/manifest.json$/.test(filename)) {
         cacheWidgetManifests();
     // If the changed file is the base skin file, we re-cache it.
-    } else if (filename === UIConstants.path.BASE_SKIN) {
+    } else if (filename === UIConstants.paths.BASE_SKIN) {
         // The skin file has changed, reset the skin files, they will be lazy loaded.
         cachedSkins = {};
 

--- a/node_modules/oae-ui/lib/test/util.js
+++ b/node_modules/oae-ui/lib/test/util.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2012 Sakai Foundation (SF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://www.osedu.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+
+var RestAPI = require('oae-rest');
+var UIAPI = require('oae-ui');
+
+/**
+ * Updates the skin variables for a tenant and waits till the CSS has been regenerated.
+ *
+ * @param  {RestContext}    restCtx             The RestContext to make to post with. This should be a global or tenant admin.
+ * @param  {String}         tenantAlias         The alias of the tenant for which the skin should be changed.
+ * @param  {Object}         skinConfig          The config that contains the CSS variables.
+ * @param  {Function}       callback            Standard callback method.
+ * @param  {Object}         callback.err        Standard error object.
+ * @param  {Object}         callback.response   The response from the Config REST API.
+ */
+var updateSkinAndWait = module.exports.updateSkinAndWait = function(restCtx, tenantAlias, skinConfig, callback) {
+
+    var calledBack = false;
+    var requestReturned = false;
+    var skinFileParsed = false;
+
+    var responseArgs = null;
+
+    /*!
+     * Monitors the result of both the updateConfig web request and the internal "skin file parsed" event
+     * to only callback when both the request has executed completely and the asynchronous parse process
+     * has completed.
+     *
+     * @param  {Object}     err     An error that occured in either request
+     */
+    var _callback = function(err) {
+        if (calledBack) {
+            // Already called back, do nothing
+            return;
+        }
+
+        if (err) {
+            // Received an from either rest endpoint or skin parse, throw the error
+            calledBack = true;
+            return callback(err);
+        }
+
+        if (requestReturned && skinFileParsed) {
+            // Call the callback with the arguments from the web request
+            calledBack = true;
+            setTimeout(function() { callback.apply(this, responseArgs); }, 500);
+        }
+    };
+
+    var update = skinConfig;
+    if (skinConfig && _.isObject(skinConfig)) {
+        update = JSON.stringify(skinConfig);
+    }
+    RestAPI.Config.updateConfig(restCtx, tenantAlias, 'oae-ui/skin/variables', update, function(err) {
+        if (err) {
+            // Remove this listener, since it may not be invoked and "leak" due to this error
+            UIAPI.removeListener('skinParsed', _updateListener);
+            return _callback(err);
+        }
+
+        responseArgs = arguments;
+        requestReturned = true;
+        _callback();
+    });
+
+    /*!
+     * Handles the 'skinParsed' event, simply notifying the `_callback` that the skin has been parsed.
+     *
+     * @see UIAPI events for parameter description
+     */
+    var _updateListener = function() {
+        skinFileParsed = true;
+        _callback();
+    };
+
+    UIAPI.once('skinParsed', _updateListener);
+
+};

--- a/node_modules/oae-ui/package.json
+++ b/node_modules/oae-ui/package.json
@@ -1,4 +1,5 @@
 {
     "name" : "oae-ui",
-    "version": "0.0.1"
+    "version": "0.0.1",
+    "main": "./lib/api.js"
 }

--- a/node_modules/oae-ui/tests/test-ui.js
+++ b/node_modules/oae-ui/tests/test-ui.js
@@ -19,10 +19,9 @@ var assert = require('assert');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var TestsUtil = require('oae-tests');
+
+var UITestUtil = require('oae-ui/lib/test/util');
 var UIConstants = require('oae-ui/lib/constants').UIConstants;
-
-var SKIN_TIMEOUT = process.env['SKIN_TIMEOUT'] || 500;
-
 
 describe('UI', function() {
 
@@ -227,9 +226,12 @@ describe('UI', function() {
          * Reset any modifications we do to the skin.
          */
         beforeEach(function(callback) {
-            RestAPI.Config.updateConfig(globalAdminRestContext, global.oaeTests.tenants.cam.alias, 'oae-ui/skin/variables', '{"body-background-color": "#' + DEFAULT_BODY_BACKGROUND_COLOR + '"}', function(err) {
+            var skinConfig = {
+                'body-background-color': '#' + DEFAULT_BODY_BACKGROUND_COLOR
+            };
+            UITestUtil.updateSkinAndWait(globalAdminRestContext, global.oaeTests.tenants.cam.alias, skinConfig, function(err) {
                 assert.ok(!err);
-                setTimeout(callback, SKIN_TIMEOUT);
+                callback();
             });
         });
 
@@ -282,21 +284,15 @@ describe('UI', function() {
             checkSkin(anonymousCamRestContext, expectedOldBackgroundColor, function() {
 
                 // Update the cambridge skin.
-                var update = skinConfig;
-                if (skinConfig && _.isObject(skinConfig)) {
-                    update = JSON.stringify(skinConfig);
-                }
-                RestAPI.Config.updateConfig(globalAdminRestContext, global.oaeTests.tenants.cam.alias, 'oae-ui/skin/variables', update, function(err) {
+                UITestUtil.updateSkinAndWait(globalAdminRestContext, global.oaeTests.tenants.cam.alias, skinConfig, function(err) {
                     assert.ok(!err);
 
-                    setTimeout(function() {
-                        // Check the skin for the new value.
-                        checkSkin(anonymousCamRestContext, expectedNewBackgroundColor, function() {
+                    // Check the skin for the new value.
+                    checkSkin(anonymousCamRestContext, expectedNewBackgroundColor, function() {
 
-                            // Check the GT skin is unchanged.
-                            checkSkin(anonymousGTRestContext, DEFAULT_BODY_BACKGROUND_COLOR, callback);
-                        });
-                    }, SKIN_TIMEOUT);
+                        // Check the GT skin is unchanged.
+                        checkSkin(anonymousGTRestContext, DEFAULT_BODY_BACKGROUND_COLOR, callback);
+                    });
                 });
             });
         };


### PR DESCRIPTION
- When running, the following error shows in the logs:

```
[2013-03-28T16:34:03.451Z] ERROR: oae/27219 on Nicolaass-MacBook-Pro.local: An uncaught exception was raised to the application.
    TypeError: Cannot read property 'BASE_SKIN' of undefined
        at EventEmitter.updateFileCaches (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/oae-ui/lib/api.js:120:45)
        at EventEmitter.emit (events.js:98:17)
        at exports.createMonitor (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/watch/main.js:117:13)
        at StatWatcher.exports.watchTree.fileWatcher (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/watch/main.js:72:38)
        at StatWatcher.EventEmitter.emit (events.js:91:17)
        at StatWatcher._handle.onchange (fs.js:886:10)
```
- Building occasionally fails, presumably because the new skin file is not generated in time.

```
AssertionError: "123456" == "eceae5"
      at checkSkin (/home/travis/build/sakaiproject/Hilary/node_modules/oae-ui/tests/test-ui.js:262:24)
      at Request._callback (/home/travis/build/sakaiproject/Hilary/node_modules/oae-rest/lib/util.js:197:16)
      at Request.init.self.callback (/home/travis/build/sakaiproject/Hilary/node_modules/request/index.js:142:22)
      at Request.EventEmitter.emit (events.js:99:17)
      at Request.onResponse (/home/travis/build/sakaiproject/Hilary/node_modules/request/index.js:856:14)
      at Request.EventEmitter.emit (events.js:126:20)
      at IncomingMessage.Request.onResponse.buffer (/home/travis/build/sakaiproject/Hilary/node_modules/request/index.js:808:12)
      at IncomingMessage.EventEmitter.emit (events.js:126:20)
      at IncomingMessage._emitEnd (http.js:366:10)
      at HTTPParser.parserOnMessageComplete [as onMessageComplete] (http.js:149:23)
  2) UI Skinning verify that variables get updated with values from the config:

      actual expected

      1234eceae56

  AssertionError: "eceae5" == "123456"
      at checkSkin (/home/travis/build/sakaiproject/Hilary/node_modules/oae-ui/tests/test-ui.js:262:24)
      at Request._callback (/home/travis/build/sakaiproject/Hilary/node_modules/oae-rest/lib/util.js:197:16)
      at Request.init.self.callback (/home/travis/build/sakaiproject/Hilary/node_modules/request/index.js:142:22)
      at Request.EventEmitter.emit (events.js:99:17)
      at Request.onResponse (/home/travis/build/sakaiproject/Hilary/node_modules/request/index.js:856:14)
      at Request.EventEmitter.emit (events.js:126:20)
      at IncomingMessage.Request.onResponse.buffer (/home/travis/build/sakaiproject/Hilary/node_modules/request/index.js:808:12)
      at IncomingMessage.EventEmitter.emit (events.js:126:20)
      at IncomingMessage._emitEnd (http.js:366:10)
      at HTTPParser.parserOnMessageComplete [as onMessageComplete] (http.js:149:23)
```
