### PR TITLE
Default group joinability to 'managers add people', return text/plain when responding to file upload (IE9 does not support application/json returns on upload).

### DIFF
--- a/node_modules/oae-content/lib/rest.js
+++ b/node_modules/oae-content/lib/rest.js
@@ -77,6 +77,7 @@ OAE.tenantServer.post('/api/content/create', function(req, res) {
                 // At this point we can use regular responses again.
                 return res.send(err.code, err.msg);
             }
+            res.set('Content-Type', 'text/plain');
             res.send(201, contentObj);
         });
     // Collaborative document creation

--- a/node_modules/oae-principals/config/group.js
+++ b/node_modules/oae-principals/config/group.js
@@ -35,7 +35,7 @@ module.exports = {
                     'value': 'private'
                 }
             ]),
-            'joinable': new Fields.List('Default joinability', 'Default joinability for new groups', 'yes', [
+            'joinable': new Fields.List('Default joinability', 'Default joinability for new groups', 'no', [
                 {
                     'name': 'Users can automatically join',
                     'value': 'yes'


### PR DESCRIPTION
Issue: https://github.com/sakaiproject/3akai-ux/issues/2658
3akai-ux PR: https://github.com/sakaiproject/3akai-ux/pull/2676
