### PR TITLE
Skinning regex fixes

### DIFF
--- a/node_modules/oae-ui/lib/api.js
+++ b/node_modules/oae-ui/lib/api.js
@@ -552,8 +552,8 @@ var _cacheSkinVariables = function(callback) {
         var sections = [];
         var subsections = [];
 
-        var sectionRegex = new RegExp('[*] [@]section[ ]+([a-zA-Z0-9 ]+) [*]');
-        var subsectionRegex = new RegExp('[*] [@]subsection[ ]+([a-zA-Z0-9 ]+) [*]');
+        var sectionRegex = new RegExp('[*] [@]section[ ]+([^*]+) [*]');
+        var subsectionRegex = new RegExp('[*] [@]subsection[ ]+([^*]+) [*]');
 
         for (var i = 0; i < tree.rules.length; i++) {
 


### PR DESCRIPTION
In the LESS file, `Modals, dialogs and clickovers` was not being recognised as a section title. Simplifying the regex fixes the problem.
