### PR TITLE
Support more PP image types

### DIFF
--- a/node_modules/oae-preview-processor/lib/constants.js
+++ b/node_modules/oae-preview-processor/lib/constants.js
@@ -16,10 +16,29 @@
 
 module.exports = {
     'TYPES': {
-        'IMAGE': [  'image/bmp',
+        'IMAGE': [  'application/dicom',
+                    'application/tga',
+                    'application/x-font-ttf',
+                    'application/x-tga',
+                    'application/x-targa',
+                    'image/bmp',
+                    'image/gif',
                     'image/jpeg',
                     'image/jpg',
-                    'image/png'
+                    'image/png',
+                    'image/targa',
+                    'image/tga',
+                    'image/tiff',
+                    'image/vnd.adobe.photoshop',
+                    'image/x-cmu-raster',
+                    'image/x-gnuplot',
+                    'image/x-icon',
+                    'image/x-targa',
+                    'image/x-tga',
+                    'image/x-xbitmap',
+                    'image/x-xpixmap',
+                    'image/x-xwindowdump',
+                    'image/xcf'
                  ],
         'OFFICE': [ 'application/msword',
                     'application/rdf+xml',


### PR DESCRIPTION
Right now we're supporting:
- bmp
- png
- jpg

GraphicsMagick supports a bunch more formats though. We should probably add a couple more (maybe even all if we're comfortable with that.)
All the supported mime types are declared in oae-preview-processor/lib/constants in the `module.exports.TYPES.IMAGE` array. It might be a matter of finding out the correct mimetype and adding those in.

A list of supported formats can be found at http://www.graphicsmagick.org/formats.html
