### PR TITLE
If the previews folder isn't there an error occurs

### DIFF
--- a/node_modules/oae-util/lib/cleaner.js
+++ b/node_modules/oae-util/lib/cleaner.js
@@ -16,6 +16,7 @@
 var _ = require('underscore');
 var events = require('events');
 var fs = require('fs');
+var mkdirp = require('mkdirp');
 
 var log = require('oae-logger').logger('oae-cleaner');
 
@@ -38,9 +39,16 @@ var start = module.exports.start = function(directory, interval) {
     log().info({ 'interval': interval, 'directory': directory }, 'Starting clean job.');
 
     // Start it once and than start the interval
-    cleanDirectory(interval, directory);
-    cleaners[directory] = setInterval(cleanDirectory, interval, interval, directory);
+    mkdirp(directory, function(err) {
+        if (err) {
+            log().error(err);
+        } else {
+            cleanDirectory(interval, directory);
+            cleaners[directory] = setInterval(cleanDirectory, interval, interval, directory);
+        }
+    });
 };
+
 
 /**
  * Stops a cleaning job.


### PR DESCRIPTION
@simong mentioned the interval should be higher as well.

```
[2013-03-08T09:10:00.236Z] ERROR: oae-cleaner/1628 on Berts-MacBook-Pro.local: Could not list the files.
    Error: ENOENT, readdir '/var/folders/rc/08k275f96gd93bqzv7yc1dhm0000gn/T//oae/previews'
    --
    directory: /var/folders/rc/08k275f96gd93bqzv7yc1dhm0000gn/T//oae/previews
```
