### PR TITLE
Make preview images optimized for tablets and other high resolution devices

### DIFF
--- a/node_modules/oae-preview-processor/lib/constants.js
+++ b/node_modules/oae-preview-processor/lib/constants.js
@@ -65,15 +65,15 @@ module.exports = {
     },
     'SIZES': {
         'IMAGE': {
-            'SMALL': 174,
-            'MEDIUM': 700,
-            'LARGE': 1000,
-            'THUMBNAIL': 162
+            'SMALL': 348,
+            'MEDIUM': 1400,
+            'LARGE': 2000,
+            'THUMBNAIL': 324
         },
         'PDF': {
-            'SMALL': 180,
-            'NORMAL': 700, // We can't use medium here as the documentviewer requires 'normal' as part of the filename.
-            'LARGE': 1000
+            'SMALL': 360,
+            'NORMAL': 1400, // We can't use medium here as the documentviewer requires 'normal' as part of the filename.
+            'LARGE': 2000
         }
     }
 };


### PR DESCRIPTION
Currently previews are a bit blurry when viewing them on high resolution devices. The width and height of the previews should be a bit larger.
