### PR TITLE
Use tenant locale for new users

### DIFF
--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -63,7 +63,7 @@ var createUser = module.exports.createUser = function(ctx, displayName, opts, ca
 
     var tenantAlias = ctx.tenant().alias;
 
-    opts.locale = opts.locale || Config.getValue(tenantAlias, 'user', 'defaultLanguage') || 'en_GB';
+    opts.locale = opts.locale || Config.getValue(tenantAlias, 'user', 'defaultLanguage');
     opts.timezone = opts.timezone || 'Etc/UTC';
     opts.visibility = opts.visibility || PrincipalsConstants.visibility.PUBLIC;
     opts.publicAlias = opts.publicAlias || displayName;

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -163,8 +163,49 @@ describe('Users', function() {
             });
         });
 
-    });
+        /**
+         * Test that verifies that users created without a locale get the
+         *  default tenant locale
+         */
+        it('verify user gets default locale', function(callback) {
+            var userId = TestsUtil.generateTestUserId();
+            var otherUserId = TestsUtil.generateTestUserId();
+            var localeTenantAlias = TestsUtil.generateTestUserId();
 
+            // Verify recaptcha token is needed when feature is enabled
+            TestsUtil.createTenantWithAdmin(localeTenantAlias, 'localhost', function(err, localeTenant, localeAdminRestContext) {
+                assert.ok(!err);
+                var localeAnonymousRestContext = TestsUtil.createTenantRestContext(localeTenantAlias);
+
+                // Set default language to Spanish
+                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, localeTenantAlias, 'oae-principals/user/defaultLanguage', 'es_ES', function(err) {
+                    assert.ok(!err);
+
+                    RestAPI.User.createUser(localeAdminRestContext, userId, 'password', 'Test User', {'visibility': 'public'}, function(err, createdUser) {
+                        assert.ok(!err);
+                        assert.ok(createdUser);
+                        assert.equal(createdUser.locale, 'es_ES');
+
+                        // Change default language to British English
+                        ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, localeTenantAlias, 'oae-principals/user/defaultLanguage', 'en_GB', function(err) {
+                            RestAPI.User.createUser(localeAdminRestContext, otherUserId, 'password', 'Test User', {'visibility': 'public'}, function(err, otherCreatedUser) {
+                                assert.ok(!err);
+                                assert.ok(otherCreatedUser);
+                                assert.equal(otherCreatedUser.locale, 'en_GB');
+                            });
+                            // Make sure the first user still speaks Spanish
+                            RestAPI.User.getUser(localeAdminRestContext, createdUser.id, function(err, user) {
+                                assert.ok(!err);
+                                assert.ok(user);
+                                assert.equal(user.locale, 'es_ES');
+                                callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
     describe('Get user', function() {
 
         /**


### PR DESCRIPTION
When creating a new user, its locale is hardcoded to `en_GB` (api.user.js) if it is not provided through the endpoint. Instead, the locale should default to the tenant's default UI language.
