### PR TITLE
Return response for picture uploads as `text/plain` for IE9 support.

### DIFF
--- a/node_modules/oae-principals/lib/rest.group.js
+++ b/node_modules/oae-principals/lib/rest.group.js
@@ -3,7 +3,7 @@
  * Educational Community License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may
  * obtain a copy of the License at
- * 
+ *
  *     http://www.osedu.org/licenses/ECL-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -169,6 +169,9 @@ OAE.tenantServer.post('/api/group/:id/picture', function(req, res) {
             return res.send(err.code, err.msg);
         }
 
+        // Set the response type to text/plain, as the UI uses an iFrame upload mechanism to support IE9
+        // file uploads. If the response type is not set to text/plain, IE9 will try to download the response.
+        res.set('Content-Type', 'text/plain');
         res.send(200, principal);
     });
 });

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -3,7 +3,7 @@
  * Educational Community License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may
  * obtain a copy of the License at
- * 
+ *
  *     http://www.osedu.org/licenses/ECL-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -147,6 +147,9 @@ OAE.tenantServer.post('/api/user/:id/picture', function(req, res) {
             return res.send(err.code, err.msg);
         }
 
+        // Set the response type to text/plain, as the UI uses an iFrame upload mechanism to support IE9
+        // file uploads. If the response type is not set to text/plain, IE9 will try to download the response.
+        res.set('Content-Type', 'text/plain');
         res.send(200, principal);
     });
 });


### PR DESCRIPTION
In support of https://github.com/sakaiproject/3akai-ux/pull/2743
