### PR TITLE
Adjust oae-content activity test to handle the larger preview sizes.

### DIFF
--- a/node_modules/oae-content/tests/test-activity.js
+++ b/node_modules/oae-content/tests/test-activity.js
@@ -438,8 +438,8 @@ describe('Content Activity', function() {
                                                     var entity = activityStream.items[0].object;
                                                     _assertStandardLinkModel(entity, link.id);
                                                     assert.ok(entity.image);
-                                                    assert.equal(entity.image.width, 162);
-                                                    assert.equal(entity.image.height, 162);
+                                                    assert.equal(entity.image.width, 324);
+                                                    assert.equal(entity.image.height, 324);
                                                     assert.notEqual(entity.image.url.indexOf(link.id), -1);
                                                     assert.notEqual(entity.image.url.indexOf('thumbnail.png'), -1);
                                                     assert.ok(entity['oae:previews']);
@@ -849,7 +849,7 @@ describe('Content Activity', function() {
                                 ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
-                                    
+
                                     var activity = activityStream.items[0];
                                     assert.ok(activity);
                                     assert.equal(activity['oae:activityType'], 'content-update');
@@ -1344,7 +1344,7 @@ describe('Content Activity', function() {
                                             // Share Yahoo link with jane only
                                             RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
                                                 assert.ok(!err);
-                                                
+
                                                 // Verify that the share activities aggregated in both pivot points
                                                 ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
                                                     assert.ok(!err);
@@ -1491,7 +1491,7 @@ describe('Content Activity', function() {
                                                 // Share Yahoo link with jane only
                                                 RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
                                                     assert.ok(!err);
-                                                    
+
                                                     // Verify that the share activities aggregated in both pivot points
                                                     ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
                                                         assert.ok(!err);
@@ -1576,7 +1576,7 @@ describe('Content Activity', function() {
 
                                     // The message probably contains the public alias, though
                                     assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
-                                    
+
                                     callback();
                                 });
                             });
@@ -1637,7 +1637,7 @@ describe('Content Activity', function() {
 
                                 // The message probably contains the public alias, though
                                 assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
-                                
+
                                 callback();
                             });
                         });


### PR DESCRIPTION
Oversight on my part when merging https://github.com/sakaiproject/Hilary/pull/453
