### PR TITLE
Improve test coverage for oae-profiles

### DIFF
--- a/node_modules/oae-profiles/lib/api.js
+++ b/node_modules/oae-profiles/lib/api.js
@@ -135,7 +135,7 @@ var getSection = module.exports.getSection = function(ctx, principalId, sectionN
         }
 
         var visibility = rows[0].get(columnVisibilityName).value;
-        
+
         // Only actually parse the data when we're sure that the current user can access it.
         PrincipalsAPI.getUser(ctx, principalId, function(err, user) {
             if (err) {
@@ -174,7 +174,7 @@ var getSectionOverview = module.exports.getSectionOverview = function(ctx, princ
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
-    
+
     PrincipalsAPI.getUser(ctx, principalId, function(err, user) {
         if (err) {
             return callback(err);

--- a/node_modules/oae-profiles/lib/rest.js
+++ b/node_modules/oae-profiles/lib/rest.js
@@ -64,9 +64,6 @@ OAE.tenantServer.post('/api/user/:id/profile/:section', function(req, res) {
     // Try parsing the data.
     try {
         data = JSON.parse(data);
-        if (!_.isObject(data)) {
-            return res.send(400, "The data needs to be a proper JSON object.");
-        }
     } catch (err) {
         return res.send(400, "The data needs to be a proper JSON object.");
     }


### PR DESCRIPTION
api.js:
- [x] Execute getSection with a validator error
- [x] Execute getSectionOverview with no user/invalid user
- [x] Execute getSectionOverview for user with no profile sections
- [x] Execute getSectionOverview of a logged in user as logged in user

rest.js:
- [x] Update/create section with invalid JSON
