### PR TITLE
(Facets) Facet searches on resource type

### DIFF
--- a/node_modules/oae-search/lib/api.js
+++ b/node_modules/oae-search/lib/api.js
@@ -187,42 +187,71 @@ var search = module.exports.search = function(ctx, searchType, opts, callback) {
         // Query only the document fields in the index, and not the _source and others
         queryData.fields = '*';
 
+        // Facet on the resource type (content, discussion, user, group, etc...)
+        queryData.facets = {
+            'resourceTypes': {
+                'terms': {
+                    'field' : 'resourceType'
+                }
+            }
+        };
+
         // Perform the search with the query data
-        client.search(queryData, null, function(err, results) {
+        client.search(queryData, null, function(err, elasticSearchResult) {
             if (err) {
                 return callback(err);
             }
 
             // We pull the '_extra' field out and parse it into JSON
-            var hits = results.hits.hits;
+            var hits = elasticSearchResult.hits.hits;
             for (var i = 0; i < hits.length; i++) {
                 var hit = hits[i];
                 if (hit.fields._extra) {
                     try {
                         hit.fields._extra = JSON.parse(hit.fields._extra);
-                    } catch (err) {
-                        log().warn({'err': err, 'hit': hit}, 'Failed to parse _extra field of search document into JSON. Ignoring.');
+                    } catch (ex) {
+                        log().warn({'err': ex, 'hit': hit}, 'Failed to parse _extra field of search document into JSON. Ignoring.');
                     }
                 }
             }
 
-            SearchUtil.transformSearchResults(ctx, documentTransformers, results, function(err, results) {
+            SearchUtil.transformSearchResults(ctx, documentTransformers, elasticSearchResult, function(err, transformedResults) {
                 if (err) {
                     return callback(err);
                 }
 
-                // Scrub the _extra field from all results
-                var docs = results.results;
+                // Scrub the _extra field from all transformedResults
+                var docs = transformedResults.results;
                 if (docs && docs.length > 0) {
                     for (var i = 0; i < docs.length; i++) {
                         delete docs[i]._extra;
                     }
                 }
 
-                return callback(null, results);
+                // Extract the facets into the search response
+                transformedResults.facets = {'resourceTypes': _extractFacetData(elasticSearchResult, 'resourceTypes')};
+
+                return callback(null, transformedResults);
             });
         });
     });
+};
+
+/**
+ * Extract the facet data for the UI, leaving out things that the UI doesn't need to know about, such as the
+ * low-level "type" (e.g., "terms") facet it was.
+ *
+ * @param  {Object}     elasticSearchResult     The elasticsearch search result that was received by elasticsearch
+ * @param  {String}     facetName               The name of the facet to extract
+ * @return {Object}                             The UI representation of this facet
+ * @api private
+ */
+var _extractFacetData = function(elasticSearchResult, facetName) {
+    var facet = elasticSearchResult.facets[facetName];
+    return {
+        'total': facet.total,
+        'items': facet[facet._type]
+    };
 };
 
 /**

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -1735,22 +1735,22 @@ describe('General Search', function() {
                         SearchTestsUtil.searchAll(jackCtx, 'general', null, {'resourceTypes': 'user'}, function(err, results) {
                             assert.ok(!err);
                             assert.ok(_getDocById(results, jack.id));
-                            assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group' }).length, 0);
-                            assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content' }).length, 0);
+                            assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group'; }).length, 0);
+                            assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content'; }).length, 0);
 
                             // Verify we only get groups from a group search
                             SearchTestsUtil.searchAll(jackCtx, 'general', null, {'resourceTypes': 'group'}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(_getDocById(results, group.id));
-                                assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user' }).length, 0);
-                                assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content' }).length, 0);
+                                assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user'; }).length, 0);
+                                assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content'; }).length, 0);
 
                                 // Verify we only get content from a content search
                                 SearchTestsUtil.searchAll(jackCtx, 'general', null, {'resourceTypes': 'content'}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(_getDocById(results, content.id));
-                                    assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user' }).length, 0);
-                                    assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group' }).length, 0);
+                                    assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user'; }).length, 0);
+                                    assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group'; }).length, 0);
                                     callback();
                                 });
                             });
@@ -1797,6 +1797,67 @@ describe('General Search', function() {
                                 assert.ok(!_getDocById(results, group2.id));
                                 callback();
                             });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Faceting', function() {
+
+        /**
+         * Test that verifies the model of the resource type facet
+         */
+        it('verify the model and contents of the resource type facet', function(callback) {
+            // Create a user, group and content item
+            var jackUsername = TestsUtil.generateTestUserId('jack');
+            var groupAlias = TestsUtil.generateTestUserId('group');
+
+            // Populate user, group and content item into the index for us to test with
+            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack JickMackerson', null, function(err, jack) {
+                assert.ok(!err);
+                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
+
+                RestAPI.Group.createGroup(jackCtx, groupAlias, groupAlias, 'A really awesome group JickMackerson', 'private', 'no', [], [], function(err, group1) {
+                    assert.ok(!err);
+
+                    RestAPI.Content.createLink(jackCtx, 'Sakai Foundation', 'Link to Sakai Foundation Website JickMackerson', 'public', 'http://www.sakaifoundation.org', [], [], function(err, content) {
+                        assert.ok(!err);
+
+                        // Search for a small page of everything and ensure the facet counts include everything
+                        SearchTestsUtil.searchRefreshed(jackCtx, 'general', null, {'q': 'JickMackerson', 'limit': 1}, function(err, results) {
+                            assert.ok(!err);
+                            assert.equal(results.results.length, 1);
+                            assert.ok(results.facets);
+                            assert.ok(results.facets.resourceTypes);
+
+                            // We just created a user, group and content item. There should at least be content, user and group facets
+                            assert.ok(results.facets.resourceTypes.total >= 3);
+                            assert.ok(results.facets.resourceTypes.items.length >= 3);
+
+                            var hadUser = false;
+                            var hadGroup = false;
+                            var hadContent = false;
+
+                            _.each(results.facets.resourceTypes.items, function(facetItem) {
+                                if (facetItem.term === 'user') {
+                                    hadUser = true;
+                                    assert.ok(facetItem.count >= 1);
+                                } else if (facetItem.term === 'group') {
+                                    hadGroup = true;
+                                    assert.ok(facetItem.count >= 1);
+                                } else if (facetItem.term === 'content') {
+                                    hadContent = true;
+                                    assert.ok(facetItem.count >= 1);
+                                }
+                            });
+
+                            assert.ok(hadUser);
+                            assert.ok(hadGroup);
+                            assert.ok(hadContent);
+
+                            return callback();
                         });
                     });
                 });


### PR DESCRIPTION
There is now a `facets` object on the search results. Example result:

``` json
{
  "total": 1,
  "results": [
    {
      "resourceType": "user",
      "id": "u:cam:VVR0wpRSxM",
      "tenantAlias": "cam",
      "displayName": "Branden Visser",
      "visibility": "public",
      "profilePath": "/user/u:cam:VVR0wpRSxM",
      "thumbnailUrl": "/api/download/signed?uri=remote:https://si0.twimg.com/profile_images/987425409/me1_normal.jpg&signature=eec7c2d39276c133a19d59b5cfc7e75a7c20631c&expires=1368090000000",
      "tenant": {
        "alias": "cam",
        "displayName": "Cambridge"
      }
    }
  ],
  "facets": {
    "resourceTypes": {
      "total": 1,
      "items": [
        {
          "term": "user",
          "count": 1
        }
      ]
    }
  }
}
```

`resourceTypes` is a "name" of many different types of facets we can have (resourceTypes is a "term" facet that facets on the "resourceType" field).

`total` is the total number of unique facets that were matched (it is possible to page the facets themselves, I believe)

`items` is a list of the facets in the current facet-page

Then each item has a "term", for the value that matched the facet term, and a "count", which is how many total items in the search index would match the query with that facet value.
