### PR TITLE
Intermittent test failures

### DIFF
--- a/node_modules/oae-content/lib/internal/dao.content.js
+++ b/node_modules/oae-content/lib/internal/dao.content.js
@@ -72,8 +72,16 @@ var getMultipleContentItems = module.exports.getMultipleContentItems = function(
             }
             // Iterate over the content items.
             for (var i = 0; i < rows.length; i++) {
-                var contentObj = _rowToContent(rows[i]);
-                contentIds[_.indexOf(contentIds, contentObj.id)] = contentObj;
+                // Use the tenant alias as a slug column to check the piece of content hasn't been removed.
+                if (rows[i].get('tenantAlias')) {
+                    var contentObj = _rowToContent(rows[i]);
+                    contentIds[_.indexOf(contentIds, contentObj.id)] = contentObj;
+
+                // If the tenant alias could not be found, the item has probably been deleted.
+                // Pass back a null value.
+                } else {
+                    contentIds[_.indexOf(contentIds, rows[i].get('contentId').value)] = null;
+                }
             }
             callback(null, contentIds);
         });

--- a/node_modules/oae-content/lib/search.js
+++ b/node_modules/oae-content/lib/search.js
@@ -133,6 +133,9 @@ var _produceContentSearchDocuments = function(resources, callback) {
     _getContentItems(resources, function(err, contentItems) {
         if (err) {
             return callback(err);
+        } else if (contentItems.length === 0) {
+            // If the content items could not be found, there isn't much we can do.
+            return callback(null, docs);
         }
 
         _getRevisionItems(contentItems, function(err, revisionsById) {
@@ -215,6 +218,9 @@ var _getContentItems = function(resources, callback) {
         if (err) {
             return callback(err);
         }
+
+        // Filter the null values from the multiple content items array.
+        extraContentItems = _.compact(extraContentItems);
 
         // Add the content items that came from Cassandra.
         contentItems = contentItems.concat(extraContentItems);


### PR DESCRIPTION
Seen both locally and on Travis:

```
3 of 581 tests failed:
  1) Content Delete content verify file delete:
     TypeError: Cannot read property 'alias' of undefined
      at _produceContentSearchDocument (/home/travis/build/sakaiproject/Hilary/node_modules/oae-content/lib/search.js:245:38)
      at _produceContentSearchDocuments (/home/travis/build/sakaiproject/Hilary/node_modules/oae-content/lib/search.js:144:27)
      at Array.forEach (native)
      at Function._.each._.forEach (/home/travis/build/sakaiproject/Hilary/node_modules/underscore/underscore.js:78:11)
      at _produceContentSearchDocuments (/home/travis/build/sakaiproject/Hilary/node_modules/oae-content/lib/search.js:143:15)
      at _getRevisionItems (/home/travis/build/sakaiproject/Hilary/node_modules/oae-content/lib/search.js:169:16)
      at _produceContentSearchDocuments (/home/travis/build/sakaiproject/Hilary/node_modules/oae-content/lib/search.js:138:9)
      at _getContentItems (/home/travis/build/sakaiproject/Hilary/node_modules/oae-content/lib/search.js:221:9)
      at module.exports.getMultipleContentItems (/home/travis/build/sakaiproject/Hilary/node_modules/oae-content/lib/internal/dao.content.js:78:13)
      at executeQuery (/home/travis/build/sakaiproject/Hilary/node_modules/oae-util/lib/cassandra.js:725:9)
  2) File previews verify negative preview expires are not possible:
     Error: timeout of 40000ms exceeded
      at Object.<anonymous> (/home/travis/build/sakaiproject/Hilary/node_modules/mocha/lib/runnable.js:167:14)
      at Timer.list.ontimeout (timers.js:101:19)
  3) Related content "before all" hook:
     Error: timeout of 40000ms exceeded
      at Object.<anonymous> (/home/travis/build/sakaiproject/Hilary/node_modules/mocha/lib/runnable.js:167:14)
      at Timer.list.ontimeout (timers.js:101:19)
```

When the first test succeeds, the other two never fail.
