### PR TITLE
Add configuration for HTTPS

### DIFF
--- a/config.js
+++ b/config.js
@@ -61,17 +61,18 @@ config.redis = {
  *
  * Configuration namespace for servers.
  *
- * @param   {String}    globalAdminAlias        The tenant alias that will be used for the global admins.
- * @param   {String}    globalAdminHost         The hostname on which the global admin server can be reached by users.
- * @param   {Number}    globalAdminPort         The network port on which the global admin express server can run.
- * @param   {Number}    tenantPort              The network port on which the tenant express server can run.
+ * @param  {String}     globalAdminAlias        The tenant alias that will be used for the global admins.
+ * @param  {String}     globalAdminHost         The hostname on which the global admin server can be reached by users.
+ * @param  {Number}     globalAdminPort         The network port on which the global admin express server can run.
+ * @param  {Number}     tenantPort              The network port on which the tenant express server can run.
+ * @param  {Boolean}    useHttps                Whether or not the server is accessible via HTTPS. Hilary will *not* expose an HTTPS server, it's up to a frontend server such as Apache or Nginx to deal with the actual delivery of HTTPS traffic. This flag is mainly used to generate correct backlinks to the web application.
  */
 config.servers = {
-    // Port on which the global admin server should be initialized
     'globalAdminAlias': 'admin',
     'globalAdminHost': 'admin.oae.com',
     'globalAdminPort': 2000,
-    'tenantPort': 2001
+    'tenantPort': 2001,
+    'useHttps': false
 };
 
 var tmpDir = process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' || process.cwd();

--- a/node_modules/oae-tenants/config/config.js
+++ b/node_modules/oae-tenants/config/config.js
@@ -24,13 +24,6 @@ module.exports = {
             'allowStop': new Fields.Bool('Stop tenant', 'Allow a tenant admin to stop the tenant server', false, {'tenantOverride': false, 'suppress': true})
         }
     },
-    'web': {
-        'name': 'Web Settings',
-        'description': 'Specifies configuration for the tenant web server',
-        'elements': {
-            'usehttps': new Fields.Bool('Use HTTPS', 'Whether or not to use HTTPS when creating URLs for this tenant', false, {'tenantOverride': false, 'suppress': false})
-        }
-    },
     'tenantprivacy': {
         'name': 'Tenant Privacy',
         'description': 'Specifies if the tenant is private',

--- a/node_modules/oae-tenants/lib/util.js
+++ b/node_modules/oae-tenants/lib/util.js
@@ -3,7 +3,7 @@
  * Educational Community License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may
  * obtain a copy of the License at
- * 
+ *
  *     http://www.osedu.org/licenses/ECL-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -13,8 +13,10 @@
  * permissions and limitations under the License.
  */
 
-var TenantsAPI = require('oae-tenants');
+var Server = require('oae-util/lib/server');
 var TenantsConfig = require('oae-config').config('oae-tenants');
+
+var TenantsAPI = require('./api');
 
 /**
  * Determine whether or not the given context represents a session that is authenticated to the specified tenant.
@@ -93,22 +95,12 @@ var canInteract = module.exports.canInteract = function(tenantAliasOne, tenantAl
 };
 
 /**
- * Specifies whether or not the tenant of the given alias uses https.
- *
- * @param  {String}     tenantAlias     The tenant to check
- * @return {Boolean}                    `true` if they use secure HTTPS. `false` otherwise
- */
-var useHttps = module.exports.useHttps = function(tenantAlias) {
-    return TenantsConfig.getValue(tenantAlias, 'web', 'usehttps') === true;
-};
-
-/**
  * Returns the base URL (including protocol) for the tenant.
  *
  * @param  {Tenant} tenant The tenant for which to retrieve the base URL.
  * @return {String}        The base URL for the specified tenant.
  */
 var getBaseUrl = module.exports.getBaseUrl = function(tenant) {
-    var protocol = (useHttps(tenant.alias)) ? 'https' : 'http';
+    var protocol = (Server.useHttps()) ? 'https' : 'http';
     return protocol + '://' + tenant.host;
 };

--- a/node_modules/oae-util/lib/server.js
+++ b/node_modules/oae-util/lib/server.js
@@ -22,6 +22,9 @@ var TelemetryAPI = require('oae-telemetry');
 
 var Shutdown = require('./internal/shutdown');
 
+// The main OAE config
+var config = null;
+
 // Maintains a list of paths that are safe from CSRF attacks
 var safePathPrefixes = [];
 
@@ -33,7 +36,10 @@ var safePathPrefixes = [];
  * @param  {Object}     config      JSON object containing configuration values for Cassandra, Redis, logging and telemetry
  * @return {Express}                The created express server
  */
-module.exports.setupServer = function(port, config) {
+module.exports.setupServer = function(port, _config) {
+    // Cache the config
+    config = _config;
+
     // Create the express server
     var app = express();
 
@@ -249,4 +255,13 @@ var _isSameOrigin = function(req) {
         // If the referer is a relative uri, it must be from same origin.
         return true;
     }
+};
+
+/**
+ * Whether or not the server is running behind HTTPs.
+ *
+ * @return  {Boolean}   Whether or not the server is running behind https.
+ */
+var useHttps = module.exports.useHttps = function() {
+    return config.servers.useHttps;
 };


### PR DESCRIPTION
Currently at the tenant-level you can configure if you're HTTPS, which is intended for static links for user navigation.

We should have a config.js configuration to specify whether or not your server supports HTTPS. If true, all direct API requests (e.g., preview processor usage of RestAPI) should go to HTTPS links, otherwise HTTP. The only reason this configuration really exists is to distinguish between non-ssl dev and ssl-enabled production/qa environments.

The above-mentioned is the only problem instance I can think of with HTTPS. Once this is done, we should run our QA server in HTTPS.
