### PR TITLE
Use websockets for Etherpad by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Download and install [PDFTK](http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/
 
 Download and install [LibreOffice](http://www.libreoffice.org/download/). This dependency takes care of converting Microsoft Office files to PDFs so they may be further split into previews by PDFTK.
 
-#### Nginx (version 1.4.0 or higher)
+#### Nginx (version 1.4.1 or higher)
 
-Download [Nginx **version 1.4.0 or higher**](http://nginx.org/en/download.html). You will need to download [PCRE](http://www.pcre.org/) as well for configuring Nginx.
+Download [Nginx **version 1.4.1 or higher**](http://nginx.org/en/download.html). You will need to download [PCRE](http://www.pcre.org/) as well for configuring Nginx.
 
 Once you've downloaded and extracted both to directories of your choice, you can configure and install:
 

--- a/config.js
+++ b/config.js
@@ -335,7 +335,7 @@ config.etherpad = {
         {
             'externalProtocol': 'http',
             'externalHost': '0.etherpad.oae.com',
-            'externalPort': false,
+            'externalPort': 80,
             'internalHost': '127.0.0.1',
             'internalPort': 9001
         }


### PR DESCRIPTION
- Use websocket for Etherpad by default as outlined in sakaiproject/3akai-ux#2717. The nginx config file changes are covered in sakaiproject/3akai-ux#2796.
- Various README fixes
