### PR TITLE
oae-cleaner reports invalid path

### DIFF
--- a/node_modules/oae-util/lib/cleaner.js
+++ b/node_modules/oae-util/lib/cleaner.js
@@ -16,6 +16,7 @@
 var _ = require('underscore');
 var events = require('events');
 var fs = require('fs');
+var Path = require('path');
 
 var log = require('oae-logger').logger('oae-cleaner');
 
@@ -35,6 +36,8 @@ var Cleaner = module.exports = new events.EventEmitter();
  * @param  {Number}     interval    The interval (in seconds) at which the directory should be cleaned out.
  */
 var start = module.exports.start = function(directory, interval) {
+    // Take care of double slashes, as that's a major thing.
+    directory = Path.normalize(directory);
     log().info({ 'interval': interval, 'directory': directory }, 'Starting clean job.');
 
     // Start it once and than start the interval

--- a/node_modules/oae-util/tests/test-cleaner.js
+++ b/node_modules/oae-util/tests/test-cleaner.js
@@ -3,7 +3,7 @@
  * Educational Community License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may
  * obtain a copy of the License at
- * 
+ *
  *     http://www.osedu.org/licenses/ECL-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var assert = require('assert');
 var fs = require('fs');
 var mkdirp = require('mkdirp');
+var Path = require('path');
 var shell = require('shelljs');
 
 var Cleaner = require('oae-util/lib/cleaner');
@@ -27,6 +28,9 @@ describe('Content', function() {
 
         var dir = process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' || process.cwd();
         dir += '/oae/tests';
+
+        // We need to normalize as some OSes (like Mac OS X) return a path with double slashes.
+        dir = Path.normalize(dir);
 
         /**
          * Sets up a directory with some dummy files.


### PR DESCRIPTION
I'm seeing the following in the logs:

```
[2013-03-05T12:02:35.686Z]  INFO: oae-cleaner/54637 on Nicolaass-MacBook-Pro.local: Starting clean job. (interval=7200)
    directory: /var/folders/b6/kd6b88z9601bxrfsr5jl72tw0000gn/T//oae/uploads

[2013-03-05T12:16:44.539Z]  INFO: oae-cleaner/54908 on Nicolaass-MacBook-Pro.local: Starting clean job. (interval=7200)
    directory: /var/folders/b6/kd6b88z9601bxrfsr5jl72tw0000gn/T//oae/previews
```

Both paths have a double /. It doesn't seem to be breaking anything, so I'm not sure if it's just the logging that has this issue.
