### PR TITLE
notificationsUnread is not reporting the correct number of unread notifications

### DIFF
--- a/node_modules/oae-activity/lib/internal/notifications.js
+++ b/node_modules/oae-activity/lib/internal/notifications.js
@@ -209,7 +209,7 @@ var incrementNotificationsUnread = module.exports.incrementNotificationsUnread =
         };
 
         // Update all principal profiles with the new count
-        _.each(userIdIncrs, function(newValue, userId) {
+        _.each(newValues, function(newValue, userId) {
             PrincipalsDAO.updatePrincipal(userId, {'notificationsUnread': newValue}, _monitorUpdatePrincipal);
         });
     });

--- a/node_modules/oae-activity/tests/test-notifications.js
+++ b/node_modules/oae-activity/tests/test-notifications.js
@@ -111,6 +111,38 @@ describe('Notifications', function() {
                 });
             });
         });
+
+        /**
+         * Ensure that receiving 2 activities who do not get aggregated result in an increment of +2.
+         */
+        it('verify that n non-aggregated activities result in a +n increment of the notification count', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, createdUsers) {
+                assert.ok(!err);
+                var mrvisser = createdUsers[_.keys(createdUsers)[0]];
+                var simong = createdUsers[_.keys(createdUsers)[1]];
+
+                // Generate 2 non-aggregatable activities
+                RestAPI.Content.createLink(mrvisser.restContext, 'Google', 'Google', 'private', 'http://www.google.ca', [], [simong.user.id], function(err, content) {
+                    assert.ok(!err);
+                    RestAPI.Group.createGroup(mrvisser.restContext, 'some group', 'Group title', 'Group description', 'private', 'request', [], [simong.user.id], function(err, newGroup) {
+                        assert.ok(!err);
+
+                        // Simon should have 2 notifications
+                        ActivityTestsUtil.collectAndGetNotificationStream(simong.restContext, null, function(err, notificationStream) {
+                            assert.ok(!err);
+                            assert.equal(notificationStream.items.length, 2);
+
+                            // Verify the count.
+                            RestAPI.User.getMe(simong.restContext, function(err, meData) {
+                                assert.ok(!err);
+                                assert.strictEqual(meData.notificationsUnread, 2);
+                                callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
     });
 
     describe('Mark Notifications Read', function() {


### PR DESCRIPTION
When no unread notifications are waiting, I correctly get 0 as the unreadNotificationsCount. When there should be unread notifications, I always get '1' as the count, even when there should be more unread notifications.

Assigning to @simong
