### PR TITLE
We should support other mail protocols then SMTP

### DIFF
--- a/config.js
+++ b/config.js
@@ -290,9 +290,10 @@ config.activity = {
  * Configuration namespace for emails.
  *
  * @param  {Boolean}    [debug]                     Determines whether or not email is in debug mode. If in debug mode, email messages are logged, not actually sent through any service.
- * @param  {String}     [customEmailTemplatesDir]   Specifies a directory that holds the tenant-specific email template overrides
  * @param  {String}     transport                   Which method of e-mail transport should be used. Either `SMTP` or `sendmail`.
- * @param  {Object}     [sendmailTransport]         An object with a `path` key which value points to the sendmail binary.
+ * @param  {String}     [customEmailTemplatesDir]   Specifies a directory that holds the tenant-specific email template overrides
+ * @param  {Object}     [sendmailTransport]         The sendmail information for sending emails.
+ * @param  {String}     [sendmailTransport.path]    The path that points to the sendmail binary.
  * @param  {Object}     [smtpTransport]             The SMTP connection information for sending emails. This is the settings object that will be used by nodemailer to form an smtp connection: https://github.com/andris9/Nodemailer
  */
 config.email = {

--- a/node_modules/oae-email/lib/api.js
+++ b/node_modules/oae-email/lib/api.js
@@ -100,12 +100,15 @@ var init = module.exports.init = function(emailSystemConfig, callback) {
     customEmailTemplatesDir = emailSystemConfig.customEmailTemplatesDir;
     debug = (emailSystemConfig.debug !== false);
 
-    if (debug && emailTransport) {
-        // Close the email transport if we're in debug mode
+    // If there was an existing email transport,
+    // we close it.
+    if (emailTransport) {
         emailTransport.close();
         emailTransport = null;
-    } else if (!debug && !emailTransport) {
-        // Open an email transport if we're not in debug mode
+    }
+
+    // Open an email transport if we're not in debug mode
+    if (!debug) {
         if (emailSystemConfig.transport === 'SMTP') {
             log().info({'data': emailSystemConfig.smtpTransport}, 'Configuring SMTP email transport.');
             emailTransport = nodemailer.createTransport('SMTP', emailSystemConfig.smtpTransport);

--- a/node_modules/oae-email/tests/test-email.js
+++ b/node_modules/oae-email/tests/test-email.js
@@ -395,6 +395,7 @@ describe('Emails', function() {
     });
 
     describe('Email configuration', function() {
+
         /**
          * A test that verifies the email transport config property gets validated.
          */


### PR DESCRIPTION
Right now, we're only supporting SMTP via nodemailer.
Nodemailer however, supports more protocols.

It would be nice if we could at least get sendmail support, that way we can configure postfix to relay via SMTP and blacklist certain domains. This would be very useful for dataloads as we could then create user accounts with foo@example.com and simply block '@example.com'
