### PR TITLE
Restore a revision response is missing parameters

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -154,7 +154,7 @@ var _getFullContentProfile = function(ctx, contentObj, isManager, callback) {
 
         // If the content item is a collaborative document, add the revision data.
         if (contentObj.resourceSubType === 'collabdoc') {
-            _getRevision(ctx, contentObj.id, contentObj.latestRevisionId, function(err, revision) {
+            _getRevision(ctx, contentObj, contentObj.latestRevisionId, function(err, revision) {
                 if (err) {
                     return callback(err);
                 }
@@ -437,7 +437,7 @@ var publishCollabDoc = module.exports.publishCollabDoc = function(ctx, contentId
 
             // Get our latest revision and compare the html on there to the one in Etherpad.
             // We only need to create a new revision if there is an actual update.
-            _getRevision(ctx, contentId, contentObj.latestRevisionId, function(err, revision) {
+            _getRevision(ctx, contentObj, contentObj.latestRevisionId, function(err, revision) {
                 if (err) {
                     return callback(err);
                 } else if (revision.etherpadHtml === html) {
@@ -1674,7 +1674,7 @@ var getRevisions = module.exports.getRevisions = function(ctx, contentId, start,
             return callback(err);
         }
 
-        _getRevisions(ctx, contentId, start, limit, callback);
+        _getRevisions(ctx, contentObj, start, limit, callback);
     });
 };
 
@@ -1683,7 +1683,7 @@ var getRevisions = module.exports.getRevisions = function(ctx, contentId, start,
  * This method performs no access checks.
  *
  * @param  {Context}        ctx                 Standard context object, representing the currently logged in user and its tenant
- * @param  {String}         contentId           The id of the object for which we want to get the revisions
+ * @param  {Content}        contentObj          The content object for which we need to retrieve the revisions.
  * @param  {String}         start               Determines the point at which revisions are returned for paging purposes.  If not provided, the first x elements will be returned
  * @param  {Integer}        limit               Number of revisions to return. Will default to 10 if not provided
  * @param  {Function}       callback            Standard callback function takes arguments `err` and `revisions`
@@ -1691,9 +1691,9 @@ var getRevisions = module.exports.getRevisions = function(ctx, contentId, start,
  * @param  {Revision[]}     callback.revisions  Array that contains an object for each revision.
  * @api private
  */
-var _getRevisions = function(ctx, contentId, start, limit, callback) {
+var _getRevisions = function(ctx, contentObj, start, limit, callback) {
     // Page the query.
-    ContentDAO.Revisions.getRevisions(contentId, start, limit, function(err, revisions) {
+    ContentDAO.Revisions.getRevisions(contentObj.id, start, limit, function(err, revisions) {
         if (err) {
             return callback(err);
         }
@@ -1708,7 +1708,7 @@ var _getRevisions = function(ctx, contentId, start, limit, callback) {
             _.each(revisions, function(revision) {
                 if (users[revision.createdBy]) {
                     revision.createdBy = users[revision.createdBy];
-                    _augmentRevision(ctx, revision);
+                    _augmentRevision(ctx, revision, contentObj);
                 }
             });
 
@@ -1745,17 +1745,7 @@ var getRevision = module.exports.getRevision = function(ctx, contentId, revision
 
         // The user has access, get the revision and augment it with a downloadload link
         // if this piece of content is a file.
-        _getRevision(ctx, contentId, revisionId, function(err, revision) {
-            if (err) {
-                return callback(err);
-            } else if (contentObj.resourceSubType === 'file') {
-                revision.downloadLink = getStorageBackend(ctx, revision.uri).getDownloadLink(ctx, revision.uri);
-            }
-
-            _augmentRevision(ctx, revision);
-
-            callback(null, revision);
-        });
+        _getRevision(ctx, contentObj, revisionId, callback);
     });
 };
 
@@ -1764,26 +1754,27 @@ var getRevision = module.exports.getRevision = function(ctx, contentId, revision
  * It's assumed that the parameters have been properly validated beforehand.
  *
  * @param  {Context}        ctx                 Standard context object, representing the currently logged in user and its tenant
- * @param  {String}         contentId           The id of the content for which we want to get the revision
+ * @param  {Content}        contentObj          The content object for which we need to retrieve a revision.
  * @param  {String}         [revisionId]        The id of the revision that needs to be retrieved, if left null the latest will be retrieved.
  * @param  {Function}       callback            Standard callback function
  * @param  {Object}         callback.err        Error object containing the error message
  * @param  {Revision}       callback.revision   The retrieved revision
  * @api private
  */
-var _getRevision = function(ctx, contentId, revisionId, callback) {
+var _getRevision = function(ctx, contentObj, revisionId, callback) {
     if (!revisionId) {
         // Get the latest one.
-        getRevisions(ctx, contentId, null, 1, function(err, revisions) {
+        getRevisions(ctx, contentObj.id, null, 1, function(err, revisions) {
             if (err) {
                 return callback(err);
             }
 
             if (revisions.length === 0) {
-                return callback({'code': 404, 'msg': 'No revision found for ' + contentId});
+                return callback({'code': 404, 'msg': 'No revision found for ' + contentObj.id});
             }
 
-            ContentDAO.Revisions.getRevision(revisions[0].revisionId, callback);
+            // There is no need to augment the revisions here as that has already happened.
+            callback(null, revisions[0]);
         });
     } else {
         ContentDAO.Revisions.getRevision(revisionId, function(err, revisionObj) {
@@ -1791,10 +1782,11 @@ var _getRevision = function(ctx, contentId, revisionId, callback) {
             // This is to counter that someone tries to get the revision of a piece of content he has no access to.
             // Ex: Alice has access to c:cam:aliceDoc but not to c:cam:bobDoc which has revision rev:cam:foo
             // doing getRevision(ctx, 'c:cam:aliceDoc', 'rev:cam:foo', ..) should return this error.
-            if (revisionObj.contentId !== contentId) {
+            if (revisionObj.contentId !== contentObj.id) {
                 return callback({'code': 400, 'msg': 'This revision ID is not associated with the specified piece of content.'});
             }
 
+            _augmentRevision(ctx, revisionObj, contentObj);
             callback(null, revisionObj);
         });
     }
@@ -1805,15 +1797,19 @@ var _getRevision = function(ctx, contentId, revisionId, callback) {
  *
  * @param  {Context}    ctx         Standard context object, representing the currently logged in user and its tenant
  * @param  {Revision}   revision    The revision to augment
+ * @param  {Content}    contentObj  The content object that the revision is attached to
  * @api private
  */
-var _augmentRevision = function(ctx, revision) {
+var _augmentRevision = function(ctx, revision, contentObj) {
     var principalId = (ctx.user() ? ctx.user().id : '');
     if (revision.thumbnailUri) {
         revision.thumbnailUrl = ContentUtil.getDownloadUrlForUri(principalId, ctx.tenant().alias, revision.thumbnailUri);
     }
     if (revision.mediumUri) {
         revision.mediumUrl = ContentUtil.getDownloadUrlForUri(principalId, ctx.tenant().alias, revision.mediumUri);
+    }
+    if (contentObj.resourceSubType === 'file') {
+        revision.downloadLink = getStorageBackend(ctx, revision.uri).getDownloadLink(ctx, revision.uri);
     }
 };
 
@@ -1841,7 +1837,7 @@ var restoreRevision = module.exports.restoreRevision = function(ctx, contentId, 
             return callback(err);
         }
 
-        _getRevision(ctx, contentId, revisionId, function(err, revision) {
+        _getRevision(ctx, contentObj, revisionId, function(err, revision) {
             if (err) {
                 return callback(err);
             } else if (!canManage) {

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -2370,8 +2370,9 @@ describe('Content', function() {
                                 var url = response.headers['x-accel-redirect'];
 
                                 // Now restore the original file.
-                                RestAPI.Content.restoreRevision(contexts['simon'].restContext, contentObj.id, revisions[1].revisionId, function(err) {
+                                RestAPI.Content.restoreRevision(contexts['simon'].restContext, contentObj.id, revisions[1].revisionId, function(err, revisionObj) {
                                     assert.ok(!err);
+                                    assert.ok(revisionObj);
 
                                     // Get the url for the 'new latest' version of the file.
                                     RestAPI.Content.download(contexts['simon'].restContext, contentObj.id, null, path, function(err, response) {

--- a/node_modules/oae-content/tests/test-previews.js
+++ b/node_modules/oae-content/tests/test-previews.js
@@ -550,7 +550,19 @@ describe('File previews', function() {
                             assert.ok(revision.thumbnailUrl);
                             assert.ok(revision.mediumUrl);
                             verifySignedUriDownload(contexts['nicolaas'].restContext, revision.thumbnailUrl, function() {
-                                verifySignedUriDownload(contexts['nicolaas'].restContext, revision.mediumUrl, callback);
+                                verifySignedUriDownload(contexts['nicolaas'].restContext, revision.mediumUrl, function() {
+
+                                    // Restore the revision
+                                    RestAPI.Content.restoreRevision(contexts['nicolaas'].restContext, contentObj.id, revisions[0].revisionId, function(err, restoredRevisionObj) {
+                                        assert.ok(!err);
+                                        // Make sure the restored revision contains all the image urls.
+                                        assert.ok(restoredRevisionObj);
+                                        assert.ok(restoredRevisionObj.thumbnailUrl);
+                                        assert.ok(restoredRevisionObj.mediumUrl);
+                                        assert.equal(restoredRevisionObj.previews.status, 'done');
+                                        callback();
+                                    });
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
The full content profile is expected to come back in response to restoring a revision. Currently it's missing some fields like previews etc.
