### PR TITLE
Incorrect role for user on content should be caught.

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -817,6 +817,14 @@ var setContentPermissions = module.exports.setContentPermissions = function(ctx,
     var validator = new Validator();
     validator.check(contentId, {'code': 400, 'msg': 'A content id must be provided'}).isResourceId();
     validator.check(_.keys(newPermissions).length, {'code': 400, 'msg': 'You should specify at least 1 user/group to set content permissions on'}).min(1);
+    var validRoleValues = _.values(ContentConstants.roles);
+    _.each(newPermissions, function(role, principalId) {
+        validator.check(principalId, {'code': 400, 'msg': 'A principalId needs to be specified for a role.'}).isPrincipalId();
+        // A role can be set to false if we're removing it.
+        if (role !== false) {
+            validator.check(role, {'code': 400, 'msg': 'An invalid role has been specified.'}).isIn(validRoleValues);
+        }
+    });
     validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to create a content item'}).isLoggedInUser(ctx);
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -2881,6 +2881,62 @@ describe('Content', function() {
             });
         });
 
+        /**
+         * Simple test that performs some basic validation mechanismes
+         * when setting permissions on a piece of content.
+         */
+        it('verify validation on setting content permissions', function(callback) {
+            setUpUsers(function(contexts) {
+                // Create a content item
+                RestAPI.Content.createLink(contexts['nicolaas'].restContext, 'Test Content 1', 'Test content description 1', 'public', 'http://www.sakaiproject.org/', [], [], function(err, contentObj) {
+                    assert.ok(!err);
+
+                    // Invalid content id.
+                    var permissions = {};
+                    RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, 'invalidContentId', permissions, function(err) {
+                        assert.equal(err.code, 400);
+
+                        // Missing role changes
+                        RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                            assert.equal(err.code, 400);
+
+                            // Invalid principal
+                            permissions = {'invalid-id': 'manager'};
+                            RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                assert.equal(err.code, 400);
+
+                                // Invalid role change
+                                permissions = {};
+                                permissions[contexts['simon'].user.id] = 'totally-wrong-role';
+                                RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                    assert.equal(err.code, 400);
+
+                                    // The value `true` is not a valid role change either
+                                    permissions = {};
+                                    permissions[contexts['simon'].user.id] = true;
+                                    RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                        assert.equal(err.code, 400);
+
+                                        // Sanity check
+                                        permissions = {};
+                                        permissions[contexts['simon'].user.id] = 'manager';
+                                        RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                            assert.ok(!err);
+                                            RestAPI.Content.updateContent(contexts['simon'].restContext, contentObj.id, {'displayName': 'Sweet stuff'}, function(err, updatedContentObj) {
+                                                assert.ok(!err);
+                                                assert.equal(updatedContentObj.displayName, 'Sweet stuff');
+                                                callback();
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
 
         // TODO: Create unit test for paging on getContentMembers
         // TODO: Test get content members with no provided contentId


### PR DESCRIPTION
I can currently post `':id': 'member'` to add a member (viewer) to the content even though the constant in Hilary specifies this should be `viewer`
