### PR TITLE
Update a group response has missing parameters

### DIFF
--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -517,7 +517,7 @@ var updateGroup = module.exports.updateGroup = function(ctx, groupId, profileFie
         return callback(validator.getFirstError());
     }
 
-    getGroup(ctx, groupId, function(err, oldGroup) {
+    getFullGroupProfile(ctx, groupId, function(err, oldGroup) {
         if (err) {
             return callback(err);
         }

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -394,6 +394,8 @@ describe('Groups', function() {
                     assert.equal(newGroup.description, 'new group description');
                     assert.equal(newGroup.visibility, 'loggedin');
                     assert.equal(newGroup.joinable, 'yes');
+                    assert.ok(newGroup.isManager);
+                    assert.ok(newGroup.isMember);
 
                     RestAPI.Group.getGroup(johnRestContext, newGroup.id, function(err, group) {
                         assert.ok(!err);


### PR DESCRIPTION
The following parameters are missing in the response when updating a group:
- isManager
- isMember

The feed should be changed to return the full group profile.
