### PR TITLE
Revert node-validator to pre-1.2.0 due to API incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "temp": "latest",
     "timezone-js": "latest",
     "underscore": "latest",
-    "validator": "latest",
+    "validator": "1.1.3",
     "watch": "latest",
     "webshot": "latest",
     "xml2js": "latest",


### PR DESCRIPTION
This is still failing locally, but may be as a result of me running 0.10.0 (darn homebrew). I'll have a look at the travis output.
