### PR TITLE
(Issue540) Compatibility with PDFtk 2+

### DIFF
--- a/node_modules/oae-preview-processor/lib/processors/file/pdf.js
+++ b/node_modules/oae-preview-processor/lib/processors/file/pdf.js
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+var _ = require('underscore');
 var clone = require('clone');
 var exec = require('child_process').exec;
 var fs = require('fs');
@@ -120,6 +121,9 @@ var previewPDF = module.exports.previewPDF = function(ctx, path, callback) {
              * as doing (n pages) * (3 images per page) would be too cpu intensive otherwise.
              */
             var resize = function() {
+
+                // The page filenames are ordered first to last, so we can process them in left-most order
+                // in the filename array to process them in correct order
                 var page = pageFilenames.shift();
 
                 // The absolute path where the pdf page is stored.
@@ -135,7 +139,6 @@ var previewPDF = module.exports.previewPDF = function(ctx, path, callback) {
                     if (err) {
                         return callback(err);
                     }
-
                     ctx.addPreview(pngPath, 'large');
 
                     // Downscale the large image to a normal sized version.
@@ -187,7 +190,7 @@ var previewPDF = module.exports.previewPDF = function(ctx, path, callback) {
  * @param  {String}              pagesDir        The directory where the pages can be stored in.
  * @param  {Function}            callback        Standard callback method.
  * @param  {Object}              callback.err    Standard error object (if any.)
- * @param  {String[]}            callback.files  An array of file names that were generated and stored in `pagesDir`.
+ * @param  {String[]}            callback.files  An array of file names that were generated and stored in `pagesDir`. The array will be sorted from the first page to the last page.
  * @api private
  */
 var _splitPDF = function(ctx, path, pagesDir, callback) {
@@ -206,6 +209,18 @@ var _splitPDF = function(ctx, path, pagesDir, callback) {
                 log().error({'err': err, 'contentId': ctx.contentId}, 'Could not read the %s directory to list the files', pagesDir);
                 return callback({'code': 500, 'msg': 'Could not read the directory'});
             }
+
+            // Only return files whose extension is 'pdf'
+            files = _.filter(files, function(file) {
+                return (file.split('.').pop() === 'pdf');
+            });
+
+            // Sort the page filenames from first page to last page
+            files.sort(function(a, b) {
+                // The file name is in the format "page.12.pdf"
+                return parseInt(a.split('.')[1], 10) - parseInt(b.split('.')[1], 10);
+            });
+
             callback(null, files);
         });
     });


### PR DESCRIPTION
We'll need to upgrade PDFtk to version 2.01 to address issues with generating PDFs created with Keynote (and probably many other issues with processing PDFs).

While that is a deployment configuration change, these changes make our code work with that version (and is backward compatible with 1.44 / 1.45):
- Filter out non-pdf files (compatibility with 2.01)
- Sort pages by page number when splitting the document (spotted a potential bug here with pages being processed in weird order when the doc was over 250 pages)
