### PR TITLE
Links and collabdocs expose downloadPath

### DIFF
--- a/node_modules/oae-content/lib/internal/dao.content.js
+++ b/node_modules/oae-content/lib/internal/dao.content.js
@@ -201,7 +201,9 @@ var updateContent = module.exports.updateContent = function(contentObj, profileU
         var newContentObj = _.extend({}, contentObj, profileUpdates);
 
         // In case the revision ID has changed
-        newContentObj.downloadPath = '/api/content/' + newContentObj.id + '/download/' + newContentObj.latestRevisionId;
+        if (newContentObj.resourceSubType === 'file') {
+            newContentObj.downloadPath = '/api/content/' + newContentObj.id + '/download/' + newContentObj.latestRevisionId;
+        }
 
         if (!librariesUpdate) {
             return callback(null, newContentObj);

--- a/node_modules/oae-content/lib/model.js
+++ b/node_modules/oae-content/lib/model.js
@@ -49,7 +49,9 @@ module.exports.Content = function(tenantAlias, id, visibility, displayName, desc
     that.createdBy = createdBy;
     that.created = created;
     that.lastModified = lastModified;
-    that.downloadPath = '/api/content/' + id + '/download/' + latestRevisionId;
+    if (resourceSubType === 'file') {
+        that.downloadPath = '/api/content/' + id + '/download/' + latestRevisionId;
+    }
     that.profilePath = '/content/' + tenantAlias + '/' + resourceId;
     that.resourceType = 'content';
     that.latestRevisionId = latestRevisionId;

--- a/node_modules/oae-content/tests/test-collabdoc.js
+++ b/node_modules/oae-content/tests/test-collabdoc.js
@@ -528,13 +528,18 @@ describe('Collaborative documents', function() {
                     assert.equal(err.code, 400);
                     RestAPI.Content.updateContent(simonCtx, contentObj.id, {'etherpadPadId': 'bleh'}, function(err) {
                         assert.equal(err.code, 400);
-
-                        // Double-check the the content item didn't change.
-                        RestAPI.Content.getContent(simonCtx, contentObj.id, function(err, latestContentObj) {
+                        // Update a regular property
+                        RestAPI.Content.updateContent(simonCtx, contentObj.id, {'displayName': 'bleh'}, function(err, updatedContentObj) {
                             assert.ok(!err);
-                            assert.equal(contentObj.etherpadGroupId, latestContentObj.etherpadGroupId);
-                            assert.equal(contentObj.etherpadPadId, latestContentObj.etherpadPadId);
-                            callback();
+                            assert.ok(!updatedContentObj.downloadPath);
+
+                            // Double-check the the content item didn't change.
+                            RestAPI.Content.getContent(simonCtx, contentObj.id, function(err, latestContentObj) {
+                                assert.ok(!err);
+                                assert.equal(contentObj.etherpadGroupId, latestContentObj.etherpadGroupId);
+                                assert.equal(contentObj.etherpadPadId, latestContentObj.etherpadPadId);
+                                callback();
+                            });
                         });
                     });
                 });

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -1258,6 +1258,7 @@ describe('Content', function() {
                                             RestAPI.Content.getContent(contexts['nicolaas'].restContext, contentObj.id, function(err, contentObj) {
                                                 assert.ok(!err);
                                                 assert.equal(contentObj.visibility, 'public');
+                                                assert.ok(!contentObj.downloadPath);
                                                 callback();
                                             });
                                         });
@@ -1311,6 +1312,7 @@ describe('Content', function() {
                                         RestAPI.Content.getContent(contexts['nicolaas'].restContext, contentObj.id, function(err, contentObj) {
                                             assert.ok(!err);
                                             assert.equal(contentObj.visibility, 'public');
+                                            assert.equal(contentObj.downloadPath, '/api/content/' + contentObj.id + '/download/' + contentObj.latestRevisionId);
                                             callback();
                                         });
                                     });
@@ -1355,6 +1357,7 @@ describe('Content', function() {
                                     RestAPI.Content.getContent(contexts['nicolaas'].restContext, contentObj.id, function(err, contentObj) {
                                         assert.ok(!err);
                                         assert.equal(contentObj.visibility, 'private');
+                                        assert.ok(!contentObj.downloadPath);
                                         callback();
                                     });
                                 });
@@ -1590,6 +1593,7 @@ describe('Content', function() {
                                         assert.equal(updatedContentObj.displayName, 'New Test Content 1');
                                         assert.ok(updatedContentObj.isManager);
                                         assert.equal(updatedContentObj.createdBy.id, contexts['nicolaas'].user.id);
+                                        assert.ok(!updatedContentObj.downloadPath);
                                         // Check the new name comes back
                                         checkNameAndDescription(contexts, contentObj.id, 'New Test Content 1', 'Test content description 1', function() {
                                             // Change the description
@@ -1598,6 +1602,7 @@ describe('Content', function() {
                                                 assert.equal(updatedContentObj.description, 'New test content description 1');
                                                 assert.ok(updatedContentObj.isManager);
                                                 assert.equal(updatedContentObj.createdBy.id, contexts['nicolaas'].user.id);
+                                                assert.ok(!updatedContentObj.downloadPath);
                                                 // Check the new description comes back
                                                 checkNameAndDescription(contexts, contentObj.id, 'New Test Content 1', 'New test content description 1', function() {
                                                     // Change both at same time
@@ -1607,6 +1612,7 @@ describe('Content', function() {
                                                         assert.equal(updatedContentObj.description, 'New test content description 2');
                                                         assert.ok(updatedContentObj.isManager);
                                                         assert.equal(updatedContentObj.createdBy.id, contexts['nicolaas'].user.id);
+                                                        assert.ok(!updatedContentObj.downloadPath);
                                                         // Check the new name and description come back
                                                         checkNameAndDescription(contexts, contentObj.id, 'New Test Content 2', 'New test content description 2', function() {
                                                             // Try updating it as non-manager of the content


### PR DESCRIPTION
Only files should expose these. We should also add a tests that ensure that these properties are not being returned for links and collabdocs.

Going to these URLs just produces a timeout.
