### PR TITLE
Cross-tenant interaction bugs

### DIFF
--- a/node_modules/oae-content/lib/searches/relatedcontent.js
+++ b/node_modules/oae-content/lib/searches/relatedcontent.js
@@ -75,8 +75,7 @@ module.exports = function(ctx, opts, callback) {
         var typeFilter = SearchUtil.filterTerm('_type', SearchConstants.resourceMappingName);
         var resourceTypeFilter = SearchUtil.filterTerm('resourceType', SearchConstants.general.RESOURCE_TYPE_CONTENT);
 
-        // If we are including external resources, we will need to know the tenants for which we can interact so we can properly filter out joinable groups
-        // the tenant restrictions will stop us from being able to actually join
+        // In order to properly filter the search results we will need to know which tenants we can interact with.
         var interactingTenantAliases = TenantsUtil.getAllTenantsForInteraction(ctx.tenant().alias);
 
         // This base filter gets applied to the query unconditionally.

--- a/node_modules/oae-content/tests/test-relatedcontent.js
+++ b/node_modules/oae-content/tests/test-relatedcontent.js
@@ -401,16 +401,18 @@ describe('Related content', function() {
                     assert.ok(!err);
 
                     // Search for it in the cam tenant.
-                    RestAPI.Search.search(loggedinCamRestContexts[1], 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], null, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(loggedinCamRestContexts[1], 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'includeExternal': true}, function(err, results) {
                         assert.ok(!err);
-                        var privateDocs = _.filter(results.results, function(searchDoc) { return searchDoc.tenant.alias === privateTenant.alias; });
-                        assert.equal(privateDocs.length, 0);
+                        var docsFromPrivateTenant = _.filter(results.results, function(searchDoc) { return searchDoc.tenant.alias === privateTenant.alias; });
+                        assert.equal(docsFromPrivateTenant.length, 0);
+                        var docsFromCamTenant = _.filter(results.results, function(searchDoc) { return searchDoc.tenant.alias === global.oaeTests.tenants.cam.alias; });
+                        assert.ok(docsFromCamTenant.length > 0);
 
                         // Searching in the private tenant shouldn't return any documents from the Cambridge tenant.
-                        RestAPI.Search.search(privateTenantAdminRestCtx, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], null, function(err, results) {
+                        RestAPI.Search.search(privateTenantAdminRestCtx, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'includeExternal': true}, function(err, results) {
                             assert.ok(!err);
-                            var camDocs = _.filter(results.results, function(searchDoc) { return searchDoc.tenant.alias === global.oaeTests.tenants.cam.alias; });
-                            assert.equal(camDocs.length, 0);
+                            var docsFromCamTenant = _.filter(results.results, function(searchDoc) { return searchDoc.tenant.alias === global.oaeTests.tenants.cam.alias; });
+                            assert.equal(docsFromCamTenant.length, 0);
                             callback();
                         });
                     });

--- a/node_modules/oae-search/lib/searches/general.js
+++ b/node_modules/oae-search/lib/searches/general.js
@@ -117,8 +117,7 @@ var _search = function(ctx, opts, callback) {
     // This base filter gets applied to the query unconditionally.
     var baseFilter = SearchUtil.filterAnd(typeFilter, resourceTypeFilter);
 
-    // If we are including external resources, we will need to know the tenants for which we can interact so we can properly filter out joinable groups
-    // the tenant restrictions will stop us from being able to actually join
+    // In order to properly filter the search results we will need to know which tenants we can interact with.
     var interactingTenantAliases = TenantsUtil.getAllTenantsForInteraction(ctx.tenant().alias);
 
 

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -865,18 +865,24 @@ describe('General Search', function() {
                     RestAPI.Content.createLink(publicTenant.publicUser.restCtx, uniqueString, uniqueString, 'public', 'http://www.oaeproject.org/',  [], [], function(err, contentOnPublicTenant) {
                         assert.ok(!err);
 
-                        // Users from private tenants cannot show up.
-                        searchForResource(publicTenant.publicUser.restCtx, contentOnPrivateTenant, false, function() {
-                            searchForResource(publicTenant.publicUser.restCtx, contentOnPrivateTenant, false, function() {
-                                searchForResource(publicTenant.publicUser.restCtx, contentOnPrivateTenant, false, function() {
-                                    searchForResource(publicTenant.anonymousRestCtx, contentOnPrivateTenant, false, function() {
+                        // Do some sanity checks first, to make sure the content items are indexed.
+                        searchForResource(privateTenant.publicUser.restCtx, contentOnPrivateTenant, true, function() {
+                            searchForResource(publicTenant.publicUser.restCtx, contentOnPublicTenant, true, function() {
 
-                                        // When searching from the private tenant, users from other tenants cannot show up.
-                                        searchForResource(privateTenant.publicUser.restCtx, contentOnPublicTenant, false, function() {
-                                            searchForResource(privateTenant.publicUser.restCtx, contentOnPublicTenant, false, function() {
+                                // Users from private tenants cannot show up.
+                                searchForResource(publicTenant.publicUser.restCtx, contentOnPrivateTenant, false, function() {
+                                    searchForResource(publicTenant.publicUser.restCtx, contentOnPrivateTenant, false, function() {
+                                        searchForResource(publicTenant.publicUser.restCtx, contentOnPrivateTenant, false, function() {
+                                            searchForResource(publicTenant.anonymousRestCtx, contentOnPrivateTenant, false, function() {
+
+                                                // When searching from the private tenant, users from other tenants cannot show up.
                                                 searchForResource(privateTenant.publicUser.restCtx, contentOnPublicTenant, false, function() {
-                                                    searchForResource(privateTenant.anonymousRestCtx, contentOnPublicTenant, false, function() {
-                                                        callback();
+                                                    searchForResource(privateTenant.publicUser.restCtx, contentOnPublicTenant, false, function() {
+                                                        searchForResource(privateTenant.publicUser.restCtx, contentOnPublicTenant, false, function() {
+                                                            searchForResource(privateTenant.anonymousRestCtx, contentOnPublicTenant, false, function() {
+                                                                callback();
+                                                            });
+                                                        });
                                                     });
                                                 });
                                             });
@@ -1189,18 +1195,24 @@ describe('General Search', function() {
         it('verify users from non-permeable tenants do not show up in external searches', function(callback) {
             TestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant, publicTenant1, privateTenant, privateTenant1) {
 
-                // Users from private tenants cannot show up.
-                searchForResource(publicTenant.publicUser.restCtx, privateTenant.publicUser.user, false, function() {
-                    searchForResource(publicTenant.publicUser.restCtx, privateTenant.loggedinUser.user, false, function() {
-                        searchForResource(publicTenant.publicUser.restCtx, privateTenant.privateUser.user, false, function() {
-                            searchForResource(publicTenant.anonymousRestCtx, privateTenant.privateUser.user, false, function() {
+                // Do some sanity checks first, to make sure the users are indexed.
+                searchForResource(privateTenant.publicUser.restCtx, privateTenant.publicUser.user, true, function() {
+                    searchForResource(publicTenant.publicUser.restCtx, publicTenant.publicUser.user, true, function() {
 
-                                // When searching from the private tenant, users from other tenants cannot show up.
-                                searchForResource(privateTenant.publicUser.restCtx, publicTenant.publicUser.user, false, function() {
-                                    searchForResource(privateTenant.publicUser.restCtx, publicTenant.loggedinUser.user, false, function() {
-                                        searchForResource(privateTenant.publicUser.restCtx, publicTenant.privateUser.user, false, function() {
-                                            searchForResource(privateTenant.anonymousRestCtx, publicTenant.publicUser.user, false, function() {
-                                                callback();
+                        // Users from private tenants cannot show up.
+                        searchForResource(publicTenant.publicUser.restCtx, privateTenant.publicUser.user, false, function() {
+                            searchForResource(publicTenant.publicUser.restCtx, privateTenant.loggedinUser.user, false, function() {
+                                searchForResource(publicTenant.publicUser.restCtx, privateTenant.privateUser.user, false, function() {
+                                    searchForResource(publicTenant.anonymousRestCtx, privateTenant.privateUser.user, false, function() {
+
+                                        // When searching from the private tenant, users from other tenants cannot show up.
+                                        searchForResource(privateTenant.publicUser.restCtx, publicTenant.publicUser.user, false, function() {
+                                            searchForResource(privateTenant.publicUser.restCtx, publicTenant.loggedinUser.user, false, function() {
+                                                searchForResource(privateTenant.publicUser.restCtx, publicTenant.privateUser.user, false, function() {
+                                                    searchForResource(privateTenant.anonymousRestCtx, publicTenant.publicUser.user, false, function() {
+                                                        callback();
+                                                    });
+                                                });
                                             });
                                         });
                                     });
@@ -1733,18 +1745,24 @@ describe('General Search', function() {
         it('verify groups from non-permeable tenants do not show up in external searches', function(callback) {
             TestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant, publicTenant1, privateTenant, privateTenant1) {
 
-                // Users from private tenants cannot show up.
-                searchForResource(publicTenant.publicUser.restCtx, privateTenant.publicGroup, false, function() {
-                    searchForResource(publicTenant.publicUser.restCtx, privateTenant.loggedinGroup, false, function() {
-                        searchForResource(publicTenant.publicUser.restCtx, privateTenant.privateGroup, false, function() {
-                            searchForResource(publicTenant.anonymousRestCtx, privateTenant.privateGroup, false, function() {
+                // Do some sanity checks first, to make sure the groups are indexed.
+                searchForResource(privateTenant.publicUser.restCtx, privateTenant.publicUser.user, true, function() {
+                    searchForResource(publicTenant.publicUser.restCtx, publicTenant.publicUser.user, true, function() {
 
-                                // When searching from the private tenant, users from other tenants cannot show up.
-                                searchForResource(privateTenant.publicUser.restCtx, publicTenant.publicGroup, false, function() {
-                                    searchForResource(privateTenant.publicUser.restCtx, publicTenant.loggedinGroup, false, function() {
-                                        searchForResource(privateTenant.publicUser.restCtx, publicTenant.privateGroup, false, function() {
-                                            searchForResource(privateTenant.anonymousRestCtx, publicTenant.publicGroup, false, function() {
-                                                callback();
+                        // Users from private tenants cannot show up.
+                        searchForResource(publicTenant.publicUser.restCtx, privateTenant.publicGroup, false, function() {
+                            searchForResource(publicTenant.publicUser.restCtx, privateTenant.loggedinGroup, false, function() {
+                                searchForResource(publicTenant.publicUser.restCtx, privateTenant.privateGroup, false, function() {
+                                    searchForResource(publicTenant.anonymousRestCtx, privateTenant.privateGroup, false, function() {
+
+                                        // When searching from the private tenant, users from other tenants cannot show up.
+                                        searchForResource(privateTenant.publicUser.restCtx, publicTenant.publicGroup, false, function() {
+                                            searchForResource(privateTenant.publicUser.restCtx, publicTenant.loggedinGroup, false, function() {
+                                                searchForResource(privateTenant.publicUser.restCtx, publicTenant.privateGroup, false, function() {
+                                                    searchForResource(privateTenant.anonymousRestCtx, publicTenant.publicGroup, false, function() {
+                                                        callback();
+                                                    });
+                                                });
                                             });
                                         });
                                     });


### PR DESCRIPTION
When I'm on a permeable tenant, search is returning results from non-permeable tenants. Search results should only contain items from the current tenant and other permeable tenants (if the current tenant is permeable).
