### PR TITLE
Support https requests

### DIFF
--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -832,7 +832,8 @@ var getSignedToken = module.exports.getSignedToken = function(ctx, tenantAlias, 
         var signature = Signature.createExpiringSignature(tenantAlias, expires, userId);
 
         // Return an object that the clients can use to construct an URL to redirect the user to.
-        var token = new Token(signature.expires, tenant.host, signature.signature, userId);
+        var protocol = (OaeServer.useHttps() ? 'https' : 'http');
+        var token = new Token(signature.expires, protocol, tenant.host, signature.signature, userId);
         callback(null, token);
     });
 };

--- a/node_modules/oae-authentication/lib/model.js
+++ b/node_modules/oae-authentication/lib/model.js
@@ -34,13 +34,15 @@ var LoginId = module.exports.LoginId = function(tenantAlias, provider, externalI
  * An object that represents a token that can be used to log into a tenant.
  *
  * @param  {Number}     expires     Timestamp (in ms since epoch) when the signature expires.
+ * @param  {String}     protocol    The protocol on which the tenant is exposed. This will not be part of the signature.
  * @param  {String}     host        The tenant host for which the signature is valid
  * @param  {String}     signature   A signature that's valid for this host, userId and tenant.
  * @param  {String}     userId      The userId that needs to be passed to the tenant endpoint; this is the user that will be logged in.
  */
-var Token = module.exports.Token = function(expires, host, signature, userId) {
+var Token = module.exports.Token = function(expires, protocol, host, signature, userId) {
     var that = {};
     that.expires = expires;
+    that.protocol = protocol;
     that.host = host;
     that.signature = signature;
     that.userId = userId;

--- a/node_modules/oae-preview-processor/lib/model.js
+++ b/node_modules/oae-preview-processor/lib/model.js
@@ -43,7 +43,8 @@ var extensionRegex = /^[a-zA-Z]+$/;
  * @return {PreviewContext}                 A PreviewContext object.
  */
 var PreviewContext = module.exports.PreviewContext = function(config, contentId, revisionId) {
-    var globalRestContext = new RestContext('http://' + config.servers.globalAdminHost, config.previews.credentials.username, config.previews.credentials.password, config.servers.globalAdminHost);
+    var protocol = (config.servers.useHttps ? 'https' : 'http');
+    var globalRestContext = new RestContext(protocol + '://' + config.servers.globalAdminHost, config.previews.credentials.username, config.previews.credentials.password, config.servers.globalAdminHost);
 
     var _thumbnailPath = null;
     var _previews = [];

--- a/node_modules/oae-rest/lib/api.admin.js
+++ b/node_modules/oae-rest/lib/api.admin.js
@@ -71,7 +71,7 @@ var loginOnTenant = module.exports.loginOnTenant = function(globalRestCtx, tenan
 
         // Create a new rest context and jar for this tenant.
         // There is no need to pass in a password
-        var restCtx = new RestContext('http://' + token.host, null, null, token.host);
+        var restCtx = new RestContext(token.protocol + '://' + token.host, null, null, token.host);
 
         // Perform the actual login.
         loginWithSignedToken(restCtx, token, function(err, body, response) {

--- a/node_modules/oae-rest/lib/util.js
+++ b/node_modules/oae-rest/lib/util.js
@@ -124,8 +124,12 @@ var _RestRequest = function(restCtx, url, method, data, callback) {
 
     var referer = restCtx.host + '/';
     if (restCtx.hostHeader) {
-        referer = 'http://' + restCtx.hostHeader + '/';
+        // Set the host header so the app server can determine the tenant.
         requestParams.headers.host = restCtx.hostHeader;
+
+        // Grab the protocol from the host to create a referer header value.
+        var protocol = restCtx.host.split(':')[0];
+        referer = protocol + '://' + restCtx.hostHeader + '/';
     }
 
     // If a referer was explicitly set, we use that


### PR DESCRIPTION
The oae-rest module should not assume http as the default protocol.
The following should happen:
- [ ] The RestContext constructor should have an option that allows you to specify if `https` should be used
- [x] `RestAPI.Admin.loginOnTenant` should use the same http protocol setting as the global admin rest context
- [x] The preview processor should be protocol agnostic
- [ ] Optionally rename `userId` to `username`
