### PR TITLE
Avoiding race conditions in test-io by moving IO functions in the fs.stat callback

### DIFF
--- a/node_modules/oae-util/tests/test-io.js
+++ b/node_modules/oae-util/tests/test-io.js
@@ -35,17 +35,17 @@ describe('IO', function() {
             fs.stat(destFile, function(err) {
                 assert.ok(err);
                 assert.equal(err.code, 'ENOENT');
-            });
 
-            IO.copyFile(sourceFile, destFile, function(err) {
-                assert.ok(!err);
-                // Verify that the source and dest files contain the same data
-                IO.readFile(sourceFile, function(err, sourceText) {
+                IO.copyFile(sourceFile, destFile, function(err) {
                     assert.ok(!err);
-                    IO.readFile(destFile, function(err, destText){
+                    // Verify that the source and dest files contain the same data
+                    IO.readFile(sourceFile, function(err, sourceText) {
                         assert.ok(!err);
-                        assert.equal(sourceText, destText);
-                        callback();
+                        IO.readFile(destFile, function(err, destText){
+                            assert.ok(!err);
+                            assert.equal(sourceText, destText);
+                            callback();
+                        });
                     });
                 });
             });
@@ -66,15 +66,15 @@ describe('IO', function() {
                 // Verify that the source file is removed
                 fs.stat(sourceFile, function(err){
                     assert.equal(err.code, 'ENOENT');
-                });
 
-                // Verify that the source and dest files contain the same data
-                IO.readFile(datadir + 'banditos.txt', function(err, sourceText) {
-                    assert.ok(!err);
-                    IO.readFile(destFile, function(err, destText){
+                    // Verify that the source and dest files contain the same data
+                    IO.readFile(datadir + 'banditos.txt', function(err, sourceText) {
                         assert.ok(!err);
-                        assert.equal(sourceText, destText);
-                        fs.unlink(destFile, callback);
+                        IO.readFile(destFile, function(err, destText){
+                            assert.ok(!err);
+                            assert.equal(sourceText, destText);
+                            fs.unlink(destFile, callback);
+                        });
                     });
                 });
             });


### PR DESCRIPTION
This is a partial fix for https://github.com/oaeproject/Hilary/issues/549.
Not really sure yet why the signature test is failing.
