### PR TITLE
Add ability to configure admin server IP for preview processor requests

### DIFF
--- a/config.js
+++ b/config.js
@@ -61,18 +61,18 @@ config.redis = {
  *
  * Configuration namespace for servers.
  *
- * @param  {String}     appServerInternalAddress    The hostname on which the server can be reached by oae services such as the preview processor.
- * @param  {String}     globalAdminAlias            The tenant alias that will be used for the global admins.
- * @param  {String}     globalAdminHost             The hostname on which the global admin server can be reached by users.
- * @param  {Number}     globalAdminPort             The network port on which the global admin express server can run.
- * @param  {Number}     tenantPort                  The network port on which the tenant express server can run.
- * @param  {Boolean}    useHttps                    Whether or not the server is accessible via HTTPS. Hilary will *not* expose an HTTPS server, it's up to a frontend server such as Apache or Nginx to deal with the actual delivery of HTTPS traffic. This flag is mainly used to generate correct backlinks to the web application.
+ * @param  {String}     globalAdminAlias         The tenant alias that will be used for the global admins.
+ * @param  {String}     globalAdminHost          The hostname on which the global admin server can be reached by users.
+ * @param  {Number}     globalAdminPort          The network port on which the global admin express server can run.
+ * @param  {String}     serverInternalAddress    The hostname on which the server can be reached by oae services such as the preview processor.
+ * @param  {Number}     tenantPort               The network port on which the tenant express server can run.
+ * @param  {Boolean}    useHttps                 Whether or not the server is accessible via HTTPS. Hilary will *not* expose an HTTPS server, it's up to a frontend server such as Apache or Nginx to deal with the actual delivery of HTTPS traffic. This flag is mainly used to generate correct backlinks to the web application.
  */
 config.servers = {
-    'appServerInternalAddress': undefined,
     'globalAdminAlias': 'admin',
     'globalAdminHost': 'admin.oae.com',
     'globalAdminPort': 2000,
+    'serverInternalAddress': undefined,
     'tenantPort': 2001,
     'useHttps': false
 };

--- a/node_modules/oae-preview-processor/lib/model.js
+++ b/node_modules/oae-preview-processor/lib/model.js
@@ -44,7 +44,7 @@ var extensionRegex = /^[a-zA-Z]+$/;
  */
 var PreviewContext = module.exports.PreviewContext = function(config, contentId, revisionId) {
     var protocol = (config.servers.useHttps ? 'https' : 'http');
-    var host = config.servers.appServerInternalAddress || config.servers.globalAdminHost;
+    var host = config.servers.serverInternalAddress || config.servers.globalAdminHost;
     var globalRestContext = new RestContext(protocol + '://' + host, config.previews.credentials.username, config.previews.credentials.password, config.servers.globalAdminHost);
 
     var _thumbnailPath = null;
@@ -95,18 +95,18 @@ var PreviewContext = module.exports.PreviewContext = function(config, contentId,
         // Log in via signed auth, and get a new RestContext.
         RestAPI.Admin.getSignedToken(globalRestContext, tenantAlias, function(err, token) {
             if (err) {
-                log().error({'err': err, 'contentId': contentId}, 'We could not log in on the the tenant. The status of the content item will not be set.');
+                log().error({'err': err, 'contentId': contentId}, 'We could not get a signed token for the tenant. The status of the content item will not be set.');
                 return callback(err);
             }
 
             // Use internal address if configured
-            var host = config.servers.appServerInternalAddress || token.host;
+            var host = config.servers.serverInternalAddress || token.host;
             var restCtx = new RestContext(token.protocol + '://' + host, null, null, token.host);
 
             // Perform the actual login.
             RestAPI.Admin.loginWithSignedToken(restCtx, token, function(err, body, response) {
                 if (err) {
-                    log().error({'err': err, 'contentId': contentId}, 'We could not log in on the the tenant. The status of the content item will not be set.');
+                    log().error({'err': err, 'contentId': contentId}, 'We could not log in on the tenant. The status of the content item will not be set.');
                     return callback(err);
                 } else if (response.statusCode !== 302) {
                     return callback({'code': response.statusCode, 'msg': 'Unexpected response code'});


### PR DESCRIPTION
It should be possible to configure a `config.servers.globalAdminIP` in config.js that can be used for the preview processor HTTP requests inside of  `oae-preview-processor/lib/model.js`.

The request Host header would still be correctly set to the globalAdminHost, which is already set in the RestContext parameters.
