### PR TITLE
Fixing path splitting so it works on Windows as well

### DIFF
--- a/node_modules/oae-ui/lib/api.js
+++ b/node_modules/oae-ui/lib/api.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var events = require('events');
 var fs = require('fs');
 var less = require('less');
+var path = require('path');
 var readdirp = require('readdirp');
 var util = require('util');
 var watch = require('watch');
@@ -179,10 +180,9 @@ var cacheWidgetManifests = function() {
     // Cache all of the widget config files under node_modules
     readdirp({ 'root': uiDirectory + '/node_modules/', 'directoryFilter': ['!.bin'], 'fileFilter': 'manifest.json' })
         .on('data', function (entry) {
-            // Extract the widget id from the path, which is expected to be the final part of
-            // the path. We split on backward slash (\) for Windows and forward slash (/) for
-            // other operating systems
-            var widgetId = entry.parentDir.split(/[\\/]/).pop();
+            // Extract the widget id from the path, which is expected
+            // to be the final part of the path
+            var widgetId = entry.parentDir.split(path.sep).pop();
             try {
                 var manifestContent = fs.readFileSync(entry.fullPath).toString('utf8');
                 widgetManifestCache[widgetId] = JSON.parse(manifestContent);


### PR DESCRIPTION
Fix the /api/ui/widgets feed when running the system on Windows.
