### PR TITLE
verify download content unit test is failing

### DIFF
--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -109,7 +109,7 @@ describe('Content', function() {
                     'user': createdUser,
                     'restContext': TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password')
                 };
-                if (_.keys(contexts).length === 6) {
+                if (_.keys(contexts).length === 7) {
                     callback(contexts);
                 }
             });

--- a/node_modules/oae-rest/lib/api.content.js
+++ b/node_modules/oae-rest/lib/api.content.js
@@ -414,6 +414,10 @@ var download = module.exports.download = function(restCtx, contentId, revisionId
     if (restCtx.cookieJar) {
         downloadFile();
     } else {
+        // No jar was present, create one.
+        restCtx.cookieJar = request.jar();
+
+        // If the restContext is not anonymous, we need to fill it up.
         RestUtil.fillCookieJar(restCtx, function(err) {
             if (err) {
                 return callback(err);


### PR DESCRIPTION
```
  1) Content Download content verify download content:
     Uncaught AssertionError: false == true
      at /opt/sakai/oae/repos/Hilary/node_modules/oae-content/tests/test-content.js:310:48
      at Request.<anonymous> (/opt/sakai/oae/repos/Hilary/node_modules/oae-rest/lib/api.content.js:405:17)
      at Request.EventEmitter.emit (events.js:117:20)
      at IncomingMessage.<anonymous> (/opt/sakai/oae/repos/Hilary/node_modules/request/index.js:842:12)
      at IncomingMessage.EventEmitter.emit (events.js:117:20)
      at _stream_readable.js:910:16
      at process._tickDomainCallback (node.js:459:13)
```
