### PR TITLE
Intermittent cleaner test failure

### DIFF
--- a/node_modules/oae-util/tests/test-cleaner.js
+++ b/node_modules/oae-util/tests/test-cleaner.js
@@ -66,15 +66,17 @@ describe('Content', function() {
          */
         it('verify files get removed', function(callback) {
             Cleaner.start(dir, 1);
-            Cleaner.on('cleaned', function(cleanedDir) {
+            var onCleaned = function(cleanedDir) {
                 if (cleanedDir === dir) {
                     fs.readdir(dir, function(err, files) {
                         assert.ok(!err);
                         assert.equal(files.length, 0);
                         callback();
                     });
+                    Cleaner.removeListener('cleaned', onCleaned);
                 }
-            });
+            };
+            Cleaner.on('cleaned', onCleaned);
         });
 
         /**
@@ -90,7 +92,7 @@ describe('Content', function() {
             // Stop removing immediately (ie: run only once)
             Cleaner.stop(dir);
 
-            Cleaner.on('cleaned', function(cleanedDir) {
+            var onCleaned = function(cleanedDir) {
                 if (cleanedDir === dir) {
                     fs.readdir(dir, function(err, files) {
                         assert.ok(!err);
@@ -98,8 +100,10 @@ describe('Content', function() {
                         assert.equal(files[0], 'd');
                         callback();
                     });
+                    Cleaner.removeListener('cleaned', onCleaned);
                 }
-            });
+            };
+            Cleaner.on('cleaned', onCleaned);
         });
     });
 });


### PR DESCRIPTION
```
  1) Content Cleaner verify only old files get removed:

      actual expected

      /tmp/oae/tests

  AssertionError: "/tmp/oae" == "/tmp/oae/tests"
      at EventEmitter.<anonymous> (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/tests/test-cleaner.js:93:24)
      at EventEmitter.g (events.js:192:14)
      at EventEmitter.emit (events.js:96:17)
      at cleanDirectory (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/lib/cleaner.js:81:21)
      at checkFiles (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/lib/cleaner.js:127:16)
      at checkFiles (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/lib/cleaner.js:135:9)
      at checkFile (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/lib/cleaner.js:112:13)
      at Object.oncomplete (fs.js:297:15)
```

I think this is because the test assumes there is only cleaner running, which is not the case. There are 3 other cleaner processes running:
- General temporary files
- Uploaded files
- Preview files
