### PR TITLE
Error reprocessing preview of revision that is different mime-type than the latest revision

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -1970,6 +1970,10 @@ var _getRevision = function(ctx, contentObj, revisionId, callback) {
         });
     } else {
         ContentDAO.Revisions.getRevision(revisionId, function(err, revisionObj) {
+            if (err) {
+                return callback(err);
+            }
+
             // Double check that this revision is really attached to the specified contentId.
             // This is to counter that someone tries to get the revision of a piece of content he has no access to.
             // Ex: Alice has access to c:cam:aliceDoc but not to c:cam:bobDoc which has revision rev:cam:foo

--- a/node_modules/oae-preview-processor/lib/model.js
+++ b/node_modules/oae-preview-processor/lib/model.js
@@ -148,7 +148,7 @@ var PreviewContext = module.exports.PreviewContext = function(config, contentId,
         // as this path could end up in commands that need to be executed.
         // We will tack on the extension if-and-only-if that extension only exists out of a-zA-Z characters.
         var extension = 'unknown';
-        var name = that.content.filename;
+        var name = that.revision.filename;
         if (name.lastIndexOf('.') !== -1) {
             var ext = name.substr(name.lastIndexOf('.') + 1);
             if (ext !== '' && extensionRegex.test(ext)) {
@@ -157,7 +157,7 @@ var PreviewContext = module.exports.PreviewContext = function(config, contentId,
         }
 
         var path = that.baseDir + '/' + safeContentId + '.' + extension;
-        log().trace({'contentId': contentId}, 'Downloading %s to %s', that.content.filename, path);
+        log().trace({'contentId': contentId}, 'Downloading %s to %s', that.revision.filename, path);
         RestAPI.Content.download(that.tenantRestContext, contentId, revisionId, path, function(err) {
             if (err) {
                 log().error({'err': err, 'contentId': contentId}, 'Error trying to download the file.');

--- a/node_modules/oae-preview-processor/lib/processors/file/images.js
+++ b/node_modules/oae-preview-processor/lib/processors/file/images.js
@@ -28,7 +28,7 @@ var PreviewUtil = require('oae-preview-processor/lib/util');
  * @borrows Interface.test as Images.test
  */
 var test = module.exports.test = function(ctx, contentObj, callback) {
-    if (contentObj.resourceSubType === 'file' && PreviewConstants.TYPES.IMAGE.indexOf(contentObj.mime) !== -1) {
+    if (contentObj.resourceSubType === 'file' && PreviewConstants.TYPES.IMAGE.indexOf(ctx.revision.mime) !== -1) {
         callback(null, 10);
     } else {
         callback(null, -1);

--- a/node_modules/oae-preview-processor/lib/processors/file/office.js
+++ b/node_modules/oae-preview-processor/lib/processors/file/office.js
@@ -70,7 +70,7 @@ var init = module.exports.init = function(config, callback) {
  * @borrows Interface.test as Office.test
  */
 var test = module.exports.test = function(ctx, contentObj, callback) {
-    if (contentObj.resourceSubType === 'file' && PreviewConstants.TYPES.OFFICE.indexOf(contentObj.mime) !== -1) {
+    if (contentObj.resourceSubType === 'file' && PreviewConstants.TYPES.OFFICE.indexOf(ctx.revision.mime) !== -1) {
         callback(null, 10);
     } else {
         callback(null, -1);

--- a/node_modules/oae-preview-processor/lib/processors/file/pdf.js
+++ b/node_modules/oae-preview-processor/lib/processors/file/pdf.js
@@ -62,7 +62,7 @@ var init = module.exports.init = function(config, callback) {
  * @borrows Interface.test as PDF.test
  */
 var test = module.exports.test = function(ctx, contentObj, callback) {
-    if (contentObj.resourceSubType === 'file' && PreviewConstants.TYPES.PDF.indexOf(contentObj.mime) !== -1) {
+    if (contentObj.resourceSubType === 'file' && PreviewConstants.TYPES.PDF.indexOf(ctx.revision.mime) !== -1) {
         callback(null, 10);
     } else {
         callback(null, -1);

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -136,7 +136,11 @@ describe('Preview processor', function() {
                     assert.ok(!err);
 
                     // The processor who returns 30 should be on top.
-                    PreviewAPI.getProcessor(null, contentObj, function(err, processor) {
+                    var mockCtx = {
+                        'content': contentObj,
+                        'revision': {}
+                    };
+                    PreviewAPI.getProcessor(mockCtx, contentObj, function(err, processor) {
                         assert.ok(!err);
                         assert.equal(processor.testval, 30);
 
@@ -730,6 +734,75 @@ describe('Preview processor', function() {
                 assert.equal(content.previews.status, 'ignored');
                 assert.ok(!content.previews.thumbnailUrl);
                 callback();
+            });
+        });
+
+        /**
+         * Verifies that the PP looks at the mime type of the revision rather than looking at the mime type that sits
+         * on the content object.
+         * This is an important distinction as `content.mime` points to the mimetype of the *latest* revision which is
+         * not necessarily the revision the PP might be processing.
+         */
+        it('verify a piece of content with multiple revisions of different mime types get processed correctly', function(callback) {
+            // Ignore this test if the PP is disabled.
+            if (!defaultConfig.previews.enabled) {
+                return callback();
+            }
+
+            // Disable the PP first, so we can generate 2 revisions without the PP starting at the first one.
+            PreviewAPI.disable(function(err) {
+                assert.ok(!err);
+
+                // Create a piece of content with 2 separate mime types.
+                MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_GENERATE_PREVIEWS, function() {
+                    TestsUtil.generateTestUsers(signedAdminRestContext, 1, function(err, response) {
+                        assert.ok(!err);
+                        var restCtx = _.values(response)[0].restContext;
+
+                        // Create the initial revision as a zip file.
+                        // We use zip as this gets ignored by the PP so the unit test can end within the test timeout time.
+                        RestAPI.Content.createFile(restCtx, 'Test Content 1', 'Test content description 1', 'private', getZipStream,  [], [], function(err, contentObj) {
+                            assert.ok(!err);
+
+                            // Create the second revision as an image file.
+                            RestAPI.Content.updateFileBody(restCtx, contentObj.id, getImageStream, function(err, updatedContentObj) {
+                                assert.ok(!err);
+
+                                // Purge the pending previews from the queue
+                                _purgePreviewsQueue(function(err) {
+                                    assert.ok(!err);
+
+                                    // Enable previews so we can handle the reprocessing
+                                    PreviewAPI.enable(function(err) {
+                                        assert.ok(!err);
+
+                                        // Re-process the revisions
+                                        RestAPI.Previews.reprocessPreview(signedAdminRestContext, contentObj.id, contentObj.latestRevisionId, function(err) {
+                                            assert.ok(!err);
+                                            RestAPI.Previews.reprocessPreview(signedAdminRestContext, contentObj.id, updatedContentObj.latestRevisionId, function(err) {
+                                                assert.ok(!err);
+                                                MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_GENERATE_PREVIEWS, function() {
+
+                                                    // The revisions should've been processed, fetch their metadata.
+                                                    RestAPI.Content.getRevision(restCtx, contentObj.id, contentObj.latestRevisionId, function(err, revision) {
+                                                        assert.ok(!err);
+                                                        assert.equal(revision.previews.status, 'ignored');
+
+                                                        RestAPI.Content.getRevision(restCtx, contentObj.id, updatedContentObj.latestRevisionId, function(err, revision) {
+                                                            assert.ok(!err);
+                                                            assert.equal(revision.previews.status, 'done');
+                                                            callback();
+                                                        });
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
             });
         });
 


### PR DESCRIPTION
The error is:

```
[2013-07-31T15:37:25.457Z] ERROR: oae-preview-processor/3773 on release0: Could not split the PDF. (contentId=c:oae:TT9x-Wj7-f, stdout="")
    Error: Command failed: Error: Unable to find file.
    Error: Failed to open PDF file: 
       /tmp/previews/c-oae-TT9x-Wj7-f/c-oae-TT9x-Wj7-f.pdf
    Errors encountered.  No output created.
    Done.  Input errors, so no output created.

        at ChildProcess.exithandler (child_process.js:548:15)
        at ChildProcess.EventEmitter.emit (events.js:99:17)
        at maybeClose (child_process.js:646:16)
        at Process._handle.onexit (child_process.js:688:5)
    --
    stderr: Error: Unable to find file.
    Error: Failed to open PDF file: 
       /tmp/previews/c-oae-TT9x-Wj7-f/c-oae-TT9x-Wj7-f.pdf
    Errors encountered.  No output created.
    Done.  Input errors, so no output created.
```

This was reproduced in the oae-release0 environment following today's bug bash. Steps:
1. Find a content item that was uploaded from the 0.2.0 version
2. Go into the FS and remove the previews from the original revision. This is to ensure the previews later get regenerated properly
3. Reprocess the preview by POSTing the following in the admin tenant: `$.post('/api/content/c:oae:TT9x-Wj7-f/revision/rev:oae:VVf9z-8HHQM/reprocessPreview');`
4. The above error appears in the logs and previews aren't processed
