### PR TITLE
Telemetry GET / POST telemetry data coming up 'undefined' for the path

### DIFF
--- a/node_modules/oae-telemetry/lib/api.js
+++ b/node_modules/oae-telemetry/lib/api.js
@@ -174,18 +174,17 @@ module.exports.request = function(req, res) {
         return;
     }
 
-    // Create telemetry names for request method count, request path count and request time
-    var methodCountName = util.format('%s.count', req.method);
-    var requestCountName = util.format('%s.%s.count', req.method, req.telemetryUrl);
-    var requestTimeName = util.format('%s.%s.time', req.method, req.telemetryUrl);
+    // Count all requests per method type
+    serverTelemetry.incr(util.format('%s.count', req.method));
 
-    // Increase the amount of `method` requests.
-    serverTelemetry.incr(methodCountName);
-
-    // Do some time measuring.
+    // Do some time measuring
     var start = Date.now();
-    res.on('header', function(header){
+    res.on('header', function(header) {
         if (req.telemetryUrl) {
+            // Build the per-path telemetry keys for count and time
+            var requestCountName = util.format('%s.%s.count', req.method, req.telemetryUrl);
+            var requestTimeName = util.format('%s.%s.time', req.method, req.telemetryUrl);
+
             // Record the count and response time for the request
             serverTelemetry.incr(requestCountName);
             serverTelemetry.appendDuration(requestTimeName, start);


### PR DESCRIPTION
Not sure how this happened, but it's in the latest release. Likely a regression as a result of the telemetry count work, I can't spot it at first glance.

Another possibility is a change in the order of middleware being bound in the request lifecycle.

How to reproduce:
1. Enable telemetry in config.js and have it print to the console on a publish interval of 1 second
2. Start your server and browse the application
3. Look at the console, you'll find entries for GET`undefined.count and GET`undefined.time but nothing for the actual paths
