### PR TITLE
Intermittent search test failure: verify searching discussion library

### DIFF
--- a/node_modules/oae-discussions/tests/test-library-search.js
+++ b/node_modules/oae-discussions/tests/test-library-search.js
@@ -42,20 +42,21 @@ describe('Discussion Library Search', function() {
                 var simong = _.values(users)[0];
 
                 // Create 2 discussions
-                var randomTextA = TestsUtil.generateRandomText(5);
-                var randomTextB = TestsUtil.generateRandomText(5);
+                var randomTextA = TestsUtil.generateRandomText(25);
+                var randomTextB = TestsUtil.generateRandomText(25);
                 RestAPI.Discussions.createDiscussion(simong.restContext, randomTextA, randomTextA, 'public', null, null, function(err, discussionA) {
                     assert.ok(!err);
                     RestAPI.Discussions.createDiscussion(simong.restContext, randomTextB, randomTextB, 'public', null, null, function(err, discussionB) {
                         assert.ok(!err);
 
-                        // Only the A discussion should return
+                        // Ensure that the randomTextA discussion returns and scores better than randomTextB
                         SearchTestsUtil.searchAll(simong.restContext, 'discussion-library', [simong.user.id], {'q': randomTextA}, function(err, results) {
                             assert.ok(!err);
-                            assert.equal(results.total, 1);
-                            assert.equal(results.results.length, 1);
-                            var doc = _.find(results.results, function(result) { return result.id === discussionA.id; });
+                            assert.ok(results.results);
+
+                            var doc = results.results[0];
                             assert.ok(doc);
+                            assert.equal(doc.id, discussionA.id);
                             assert.equal(doc.displayName, randomTextA);
                             assert.equal(doc.description, randomTextA);
                             callback();


### PR DESCRIPTION
```
[0m  1) Discussion Library Search Library search verify searching through a discussion library:
[0m[31m     Uncaught [0m[90m
  AssertionError: 2 == 1
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-discussions/tests/test-library-search.js:55:36
      at module.exports.searchAll.MqTestsUtil.whenTasksEmpty.MqTestsUtil.whenTasksEmpty.getMoreResults (/home/travis/build/oaeproject/Hilary/node_modules/oae-search/lib/test/util.js:58:36)
      at Request._callback (/home/travis/build/oaeproject/Hilary/node_modules/oae-rest/lib/util.js:202:16)
      at Request.init.self.callback (/home/travis/build/oaeproject/Hilary/node_modules/request/index.js:148:22)
      at Request.EventEmitter.emit (events.js:99:17)
      at Request.onResponse (/home/travis/build/oaeproject/Hilary/node_modules/request/index.js:891:14)
      at Request.EventEmitter.emit (events.js:126:20)
      at IncomingMessage.Request.onResponse.buffer (/home/travis/build/oaeproject/Hilary/node_modules/request/index.js:842:12)
      at IncomingMessage.EventEmitter.emit (events.js:126:20)
      at IncomingMessage._emitEnd (http.js:367:10)
```

This uses random text to try and test certain discussions don't match. This test can probably just ensure an expected match _does_ return with a higher score, not so much that something falls below the score threshold because that is flakey.
