### PR TITLE
Incorporate README feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Hilary back-end is written completely in JavaScript, powered by Node.js.
 
 Download the latest version of [Apache Cassandra](http://cassandra.apache.org/) and extract it to a directory of your choice.
 
-Create the following directories and set the owner:
+Create the following directories and set the owner to be the user that will be running Cassandra:
 
 ```
 sudo mkdir -p /var/log/cassandra
@@ -242,7 +242,7 @@ Where "admin.oae.com" is the hostname that we will use to access the global admi
 
 Open the `config.js` file in the root of the Hilary directory. This file contains a JavaScript object that represents the configuration for your server.
 
-* Configure the `config.files.uploadDir` property to point to a directory that exists. This is where files such as profile pictures, content bodies, previews, etc... will be stored
+* Configure the `config.files.uploadDir` property to point to a directory that exists. The reference to this directory should not have a trailing slash. This directory is used to store files such as profile pictures, content bodies, previews, etc...
 * Ensure that the property `config.server.globalAdminHost` is configured to the same host name you set for your global admin host in /etc/hosts
 * Configure the `config.etherpad.apikey` property to the API Key that can be found in `your-etherpad-dir/APIKEY.txt`
 
@@ -258,7 +258,7 @@ Find the "nginx.conf" template file located in the nginx folder of the 3akai-ux 
 * Replace `<%= nginxConf.NGINX_USER %>` and `<%= nginxConf.NGINX_GROUP %>` with the OS user and group that the nginx process should run as
 * Replace `<%= nginxConf.NGINX_HOSTNAME %>` with the same value you configured for the global administration server host in `/etc/hosts` (the one whose current value would be "admin.oae.com"). **Note:** The `server_name` property for the *user tenant server* further down the configuration file should remain set to "*".
 * Replace all instances of `<%= nginxConf.UX_HOME %>` with the full absolute path to your cloned 3akai-ux directory (e.g., /Users/branden/oae/3akai-ux) or the 3akai-ux production build directory (e.g., /Users/branden/oae/3akai-ux/target/optimized)
-* Replace `<%= nginxConf.LOCAL_FILE_STORAGE_DIRECTORY %>` with the full absolute path that you configured for file storage in the `Hilary config.js` step
+* Replace `<%= nginxConf.LOCAL_FILE_STORAGE_DIRECTORY %>` with the full absolute path that you configured as the `localStorageDirectory` in the `files` section of the  Hilary `config.js` file. This path should not have a trailing slash
 
 When you have finished making changes to the nginx.conf file, start Nginx:
 
@@ -281,6 +281,8 @@ Now we're ready to start the app server. You can do so by going into the Hilary 
 ```
 node app.js | node_modules/.bin/bunyan
 ```
+
+To start it in the background, you can run: `node app.js | node_modules/.bin/bunyan &`. An [upstart script](https://github.com/oaeproject/puppet-hilary/blob/master/modules/hilary/templates/upstart_hilary.conf.erb) can also be used to spawn and manage Hilary as a daemon process. The benefit of tying into upstart is that you get first-class support from deployment tools like MCollective and Puppet.
 
 The server is now running and you can access the administration UI at http://admin.oae.com/!
 

--- a/config.js
+++ b/config.js
@@ -90,7 +90,7 @@ tmpDir += '/oae';
  * @param  {Object}    cleaner                  Holds configuration properties for the cleaning job that removes lingering files in the upload directory.
  * @param  {Boolean}   cleaner.enabled          Whether or not the cleaning job should run.
  * @param  {Number}    cleaner.interval         Files that haven't been accessed in this amount (of seconds) should be removed.
- * @param  {String}    localStorageDirectory    The directory where the local storage backend can store its files. By default, the files get stored on the same level as the Hilary directory. This directory will not be used when Amazon S3 file storage is used.
+ * @param  {String}    localStorageDirectory    The directory where the local storage backend can store its files. By default, the files get stored on the same level as the Hilary directory. Note: the absolute path to this directory should also be configured in the Nginx config file. This directory will not be used when Amazon S3 file storage is used.
  */
 config.files = {
     'tmpDir': tmpDir,


### PR DESCRIPTION
README feedback from Rob Williams (AAR):

```
- Directory references in the config files shouldn’t end with “/”

- The nginx.conf configuration instructions say the following:
Replace <%= nginxConf.LOCAL_FILE_STORAGE_DIRECTORY %> with the full absolute path that you configured for file storage in the Hilary config.js step
…however, the configuration of this parameter is never described in the config.js section.  I had assumed that it was referring to the config.files.uploadDir in that section.  It would clear things up if  config.files.localStorageDirectory was mentioned in the config.js section, and referred to by name in the nginx.conf instructions to clarify.

- Under ‘Starting the Server’ it could use instructions on how to run the node command as a background process (similar to the instructions for the other apps).

- In the ‘Apache Cassandra’ section, when setting permissions for ‘whoami’, it would help to specifically state that ‘whoami’ should be the user who will be starting Cassandra.  It’s easy to come to that conclusion if you know chmod, but I’ve been tripped up in other docs before because their ‘fake user’ looked an awful lot like a command parameter J
```
