### PR TITLE
HTTP module defaults to rejectUnauthorized: true

### DIFF
--- a/config.js
+++ b/config.js
@@ -61,12 +61,13 @@ config.redis = {
  *
  * Configuration namespace for servers.
  *
- * @param  {String}     globalAdminAlias         The tenant alias that will be used for the global admins
- * @param  {String}     globalAdminHost          The hostname on which the global admin server can be reached by users
- * @param  {Number}     globalAdminPort          The network port on which the global admin express server can run
- * @param  {String}     [serverInternalAddress]  The internal hostname on which the server can be reached by OAE services such as the preview processor
- * @param  {Number}     tenantPort               The network port on which the tenant express server can run
- * @param  {Boolean}    useHttps                 Whether or not the server is accessible via HTTPS. Hilary will *not* expose an HTTPS server, it's up to a frontend server such as Apache or Nginx to deal with the actual delivery of HTTPS traffic. This flag is mainly used to generate correct backlinks to the web application
+ * @param  {String}     globalAdminAlias            The tenant alias that will be used for the global admins
+ * @param  {String}     globalAdminHost             The hostname on which the global admin server can be reached by users
+ * @param  {Number}     globalAdminPort             The network port on which the global admin express server can run
+ * @param  {String}     [serverInternalAddress]     The internal hostname on which the server can be reached by OAE services such as the preview processor
+ * @param  {Number}     tenantPort                  The network port on which the tenant express server can run
+ * @param  {Boolean}    useHttps                    Whether or not the server is accessible via HTTPS. Hilary will *not* expose an HTTPS server, it's up to a frontend server such as Apache or Nginx to deal with the actual delivery of HTTPS traffic. This flag is mainly used to generate correct backlinks to the web application
+ * @param  {Boolean}    [strictHttps]               Whether or not the server is using a valid SSL certificate. If `true`, any attempts to connect to the REST apis that results in an invalid certificate should result in an error and not be ignored. If `false`, it is expected that the server will not return a valid certificate. Default: `true`
  */
 config.servers = {
     'globalAdminAlias': 'admin',
@@ -74,7 +75,8 @@ config.servers = {
     'globalAdminPort': 2000,
     'serverInternalAddress': null,
     'tenantPort': 2001,
-    'useHttps': false
+    'useHttps': false,
+    'strictHttps': true
 };
 
 var tmpDir = process.env.TMP || process.env.TMPDIR || process.env.TEMP || '/tmp' || process.cwd();

--- a/node_modules/oae-authentication/tests/test-auth-local.js
+++ b/node_modules/oae-authentication/tests/test-auth-local.js
@@ -647,7 +647,10 @@ describe('Authentication', function() {
         it('verify create user with non-local loginId', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var userId = TestsUtil.generateTestUserId();
-            var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, userId, 'password');
+            var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, {
+                'username': userId,
+                'userPassword': 'password'
+            });
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, userId);
             AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
                 assert.ok(!err);

--- a/node_modules/oae-authentication/tests/test-signed.js
+++ b/node_modules/oae-authentication/tests/test-signed.js
@@ -130,7 +130,7 @@ describe('Authentication', function() {
                     'userId': userId
                 };
 
-                var restCtx = new RestContext('http://' + global.oaeTests.tenants.localhost.host, null, null, global.oaeTests.tenants.localhost.host);
+                var restCtx = new RestContext('http://' + global.oaeTests.tenants.localhost.host, {'hostHeader': global.oaeTests.tenants.localhost.host});
                 RestAPI.Admin.loginWithSignedToken(restCtx, token, function(err) {
                     assert.ok(!err);
                     RestAPI.User.getMe(restCtx, function(err, user) {

--- a/node_modules/oae-preview-processor/lib/model.js
+++ b/node_modules/oae-preview-processor/lib/model.js
@@ -45,7 +45,14 @@ var extensionRegex = /^[a-zA-Z]+$/;
 var PreviewContext = module.exports.PreviewContext = function(config, contentId, revisionId) {
     var protocol = (config.servers.useHttps ? 'https' : 'http');
     var host = config.servers.serverInternalAddress || config.servers.globalAdminHost;
-    var globalRestContext = new RestContext(protocol + '://' + host, config.previews.credentials.username, config.previews.credentials.password, config.servers.globalAdminHost);
+    var strictSSL = config.servers.strictHttps;
+
+    var globalRestContext = new RestContext(protocol + '://' + host, {
+        'username': config.previews.credentials.username,
+        'userPassword': config.previews.credentials.password,
+        'hostHeader': config.servers.globalAdminHost,
+        'strictSSL': strictSSL
+    });
 
     var _thumbnailPath = null;
     var _previews = [];
@@ -101,7 +108,7 @@ var PreviewContext = module.exports.PreviewContext = function(config, contentId,
 
             // Use internal address if configured
             var host = config.servers.serverInternalAddress || token.host;
-            var restCtx = new RestContext(token.protocol + '://' + host, null, null, token.host);
+            var restCtx = new RestContext(token.protocol + '://' + host, {'hostHeader': token.host, 'strictSSL': strictSSL});
 
             // Perform the actual login
             RestAPI.Admin.loginWithSignedToken(restCtx, token, function(err, body, response) {

--- a/node_modules/oae-rest/lib/api.admin.js
+++ b/node_modules/oae-rest/lib/api.admin.js
@@ -69,9 +69,8 @@ var loginOnTenant = module.exports.loginOnTenant = function(globalRestCtx, tenan
             return callback(err);
         }
 
-        // Create a new rest context and jar for this tenant.
-        // There is no need to pass in a password
-        var restCtx = new RestContext(token.protocol + '://' + token.host, null, null, token.host);
+        // Create a new rest context and jar for this tenant. There is no need to pass in a password as we aren't using local authentication
+        var restCtx = new RestContext(token.protocol + '://' + token.host, {'hostHeader': token.host, 'strictSSL': globalRestCtx.strictSSL});
 
         // Perform the actual login.
         loginWithSignedToken(restCtx, token, function(err, body, response) {

--- a/node_modules/oae-rest/lib/api.content.js
+++ b/node_modules/oae-rest/lib/api.content.js
@@ -352,7 +352,8 @@ var download = module.exports.download = function(restCtx, contentId, revisionId
         var requestParams = {
             'url': url,
             'method': 'GET',
-            'jar': restCtx.cookieJar
+            'jar': restCtx.cookieJar,
+            'strictSSL': restCtx.strictSSL
         };
         if (restCtx.hostHeader) {
             requestParams.headers = {

--- a/node_modules/oae-rest/lib/model.js
+++ b/node_modules/oae-rest/lib/model.js
@@ -17,21 +17,26 @@
  * REST Context object used to represent a tenant on which a REST request is done, as well as
  * the user creditentials of the user performing the action.
  *
- * @param  {String}      host            The URL of the tenant on which the request is done. This should include the protocol (e.g. http://gt.oae.com) and should not have a trailing slash.
- * @param  {String}      username        The username of the user performing the REST request. This should be null if the current user is anonymous.
- * @param  {String}      userPassword    The password of the user performing the REST request. This should be null if the current user is anonymous.
- * @param  {String}      [hostHeader]    The host header that should be sent on the REST request. This can be set to avoid having to set up the actual hosts on a development environment. When this is set, the host should be the direct URL to the tenant express server
- * @param  {String}      [refererHeader] The referer header that should be sent on the REST request. By default it will be set as the target host of the request
+ * @param  {String}     host                    The URL of the tenant on which the request is done. This should include the protocol (e.g. http://gt.oae.com) and should not have a trailing slash.
+ * @param  {Object}     [opts]                  Optional parameters for the request
+ * @param  {String}     [opts.username]         The username of the user performing the REST request. This should be null if the current user is anonymous.
+ * @param  {String}     [opts.userPassword]     The password of the user performing the REST request. This should be null if the current user is anonymous.
+ * @param  {String}     [opts.hostHeader]       The host header that should be sent on the REST request. This can be set to avoid having to set up the actual hosts on a development environment. When this is set, the host should be the direct URL to the tenant express server
+ * @param  {String}     [opts.refererHeader]    The referer header that should be sent on the REST request. By default it will be set as the target host of the request
+ * @param  {Boolean}    [opts.strictSSL]        If `true`, will throw an error for invalid HTTPS certs (e.g., self-signed). Default: `true`
  */
-var RestContext = module.exports.RestContext = function(host, username, userPassword, hostHeader, refererHeader) {
+var RestContext = module.exports.RestContext = function(host, opts) {
     var that = {};
 
+    opts = opts || {};
+
     that.host = host;
-    that.username = username;
-    that.userPassword = userPassword;
-    that.hostHeader = hostHeader;
-    that.refererHeader = refererHeader;
+    that.username = opts.username;
+    that.userPassword = opts.userPassword;
+    that.hostHeader = opts.hostHeader;
+    that.refererHeader = opts.refererHeader;
     that.cookieJar = null;
+    that.strictSSL = (opts.strictSSL !== false);
 
     return that;
 };

--- a/node_modules/oae-rest/lib/util.js
+++ b/node_modules/oae-rest/lib/util.js
@@ -114,18 +114,19 @@ var fillCookieJar = module.exports.fillCookieJar = function(restCtx, callback) {
 var _RestRequest = function(restCtx, url, method, data, callback) {
     module.exports.emit('request', restCtx, url, method, data);
 
-    var requestParams = {
+    var requestOpts = {
         'url': restCtx.host + url,
         'method': method,
-        'jar': restCtx.cookieJar
+        'jar': restCtx.cookieJar,
+        'strictSSL': restCtx.strictSSL
     };
 
-    requestParams.headers = requestParams.headers || {};
+    requestOpts.headers = requestOpts.headers || {};
 
     var referer = restCtx.host + '/';
     if (restCtx.hostHeader) {
         // Set the host header so the app server can determine the tenant.
-        requestParams.headers.host = restCtx.hostHeader;
+        requestOpts.headers.host = restCtx.hostHeader;
 
         // Grab the protocol from the host to create a referer header value.
         var protocol = restCtx.host.split(':')[0];
@@ -137,7 +138,7 @@ var _RestRequest = function(restCtx, url, method, data, callback) {
         referer = restCtx.refererHeader;
     }
 
-    requestParams.headers.referer = referer;
+    requestOpts.headers.referer = referer;
 
     // Expand values and check if we're uploading something (with a stream.)
     // API users need to pass in uploads (=streams) via a function as we do some other things
@@ -175,13 +176,13 @@ var _RestRequest = function(restCtx, url, method, data, callback) {
         });
 
         if (method === 'GET') {
-            requestParams.qs = data;
+            requestOpts.qs = data;
         } else if (!hasStream && method === 'POST') {
-            requestParams.form = data;
+            requestOpts.form = data;
         }
     }
 
-    var req = request(requestParams, function(err, response, body) {
+    var req = request(requestOpts, function(err, response, body) {
         if (err) {
             emitter.emit('error', err);
             return callback({'code': 500, 'msg': 'Something went wrong trying to contact the server: ' + err});

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -45,7 +45,11 @@ var generateTestUsers = module.exports.generateTestUsers = function(restCtx, tot
         }
         createdUsers[userObj.id] = {
             'user': userObj,
-            'restContext': new RestContext(restCtx.host, username, 'password', restCtx.hostHeader)
+            'restContext': new RestContext(restCtx.host, {
+                'username': username,
+                'userPassword': 'password',
+                'hostHeader': restCtx.hostHeader
+            })
         };
         if (_.keys(createdUsers).length === total) {
             callback(null, createdUsers);
@@ -224,7 +228,11 @@ var generateTestGroupId = module.exports.generateTestGroupId = function(seed) {
  * @return {RestContext}                     Rest Context object that represents the anonymous or logged in user user on the provided tenant
  */
 var createTenantRestContext = module.exports.createTenantRestContext = function(host, username, password) {
-    return new RestContext('http://localhost:2001', username, password, host);
+    return new RestContext('http://localhost:2001', {
+        'username': username,
+        'userPassword': password,
+        'hostHeader': host
+    });
 };
 
 /**
@@ -246,7 +254,10 @@ var createTenantAdminRestContext = module.exports.createTenantAdminRestContext =
  * @return {RestContext}                     Rest Context object that represents the anonymous or logged in user on the global admin server
  */
 var createGlobalRestContext = module.exports.createGlobalRestContext = function(username, password) {
-    return new RestContext('http://localhost:2000', username, password);
+    return new RestContext('http://localhost:2000', {
+        'username': username,
+        'userPassword': password
+    });
 };
 
 /**


### PR DESCRIPTION
It appears this breaks the PP in test environments with self-signed certs:

http://grokbase.com/t/gg/nodejs/134be1stp7/problem-upgrading-to-v0-10-using-mikels-request-module-with-self-signed-certs

We will want to have a configuration for this
