### PR TITLE
Prevent DTrace error from showing up

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "youtube-feeds": "latest"
   },
   "devDependencies": {
+    "dtrace-provider": "latest",
     "grunt": "latest",
     "grunt-cli": "latest",
     "grunt-contrib-clean": "latest",


### PR DESCRIPTION
`[Error: Cannot find module './DTraceProviderBindings']` was showing in the logs every time I started the server. Everything still seemed to work, but this seemed to get rid of the warning.
