### PR TITLE
Changing link target doesn't generate a new preview

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -1269,7 +1269,7 @@ var _updateFileBody = function(ctx, contentId, file, callback) {
                 opts.latestRevisionId = revision.revisionId;
 
                 // We have to set the previews status back to pending
-                opts.previews = {'status': 'pending'};
+                opts.previews = {'status': ContentConstants.previews.PENDING};
                 ContentDAO.Content.updateContent(contentObj, opts, true, function(err, updatedContentObj) {
                     if (err) {
                         return callback(err);
@@ -1545,6 +1545,15 @@ var updateContentMetadata = module.exports.updateContentMetadata = function(ctx,
             return callback(err);
         } else if (!canManage) {
             return callback({'code': 401, 'msg': 'You are not allowed to manage this piece of content'});
+        }
+
+        if (profileFields.link) {
+            if (oldContentObj.resourceSubType !== 'link') {
+                return callback({'code': 400, 'msg': 'This piece of content is not a link'});
+            } else if (profileFields.link !== oldContentObj.link) {
+                // Reset the previews object so we don't show the old preview items while the new link is still being processed
+                profileFields.previews = {'status': ContentConstants.previews.PENDING};
+            }
         }
 
         ContentDAO.Content.updateContent(oldContentObj, profileFields, true, function(err, newContentObj) {

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -2052,6 +2052,32 @@ describe('Content', function() {
         });
 
         /**
+         * Test that verifies you cannot update the link property on non-link content items
+         */
+        it('verify the link property cannot be updated on non-link content items', function(callback) {
+            setUpUsers(function(contexts) {
+                RestAPI.Content.createFile(contexts['nicolaas'].restContext, 'Test Content 2', 'Test content description 2', 'public', getFileStream, [], [], function(err, contentObj) {
+                    assert.ok(!err);
+                    assert.ok(contentObj.id);
+                    RestAPI.Content.updateContent(contexts['nicolaas'].restContext, contentObj.id, {'link': 'http://www.google.com'}, function(err, updatedContentObj) {
+                        assert.ok(err);
+                        assert.equal(err.code, 400);
+
+                        RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 1', 'Test content description 1', 'public', [], [], function(err, contentObj) {
+                            assert.ok(!err);
+                            assert.ok(contentObj);
+                            RestAPI.Content.updateContent(contexts['nicolaas'].restContext, contentObj.id, {'link': 'http://www.google.com'}, function(err, updatedContentObj) {
+                                assert.ok(err);
+                                assert.equal(err.code, 400);
+                                callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that validates validation for file updates
          */
         it('verify file update validation', function(callback) {

--- a/node_modules/oae-content/tests/test-previews.js
+++ b/node_modules/oae-content/tests/test-previews.js
@@ -406,6 +406,46 @@ describe('File previews', function() {
     });
 
     /**
+     * A test that verifies that link updates result in a resetted previews object
+     */
+    it('verify updating a link resets the previews object', function(callback) {
+        TestsUtil.generateTestUsers(globalAdminOnTenantRestContext, 1, function(err, users) {
+            assert.ok(!err);
+
+            var contexts = {};
+            var keys = Object.keys(users);
+            contexts['nicolaas'] = users[keys[0]];
+
+            RestAPI.Content.createLink(contexts['nicolaas'].restContext, 'Test Content 1', 'Test content description 1', 'public', 'http://www.oaeproject.org/', [], [], function(err, contentObj) {
+                assert.ok(!err);
+
+                // Verify that a new link results in an empty previews object
+                RestAPI.Content.updateContent(contexts['nicolaas'].restContext, contentObj.id, {'link' : 'http://www.google.com'}, function(err) {
+                    assert.ok(!err);
+                    RestAPI.Content.getContent(contexts['nicolaas'].restContext, contentObj.id, function(err, contentObj) {
+                        assert.ok(!err);
+                        assert.equal(contentObj.previews.status, 'pending');
+
+                        // Verify that an update with the same link doesn't change the previews object
+                        // First, set the status to done manually so we can verify a no-change on a non-update
+                        RestAPI.Content.setPreviewItems(globalAdminOnTenantRestContext, contentObj.id, contentObj.latestRevisionId, 'done', {}, {}, {}, {}, function(err) {
+                            assert.ok(!err);
+                            RestAPI.Content.updateContent(contexts['nicolaas'].restContext, contentObj.id, {'link' : 'http://www.google.com'}, function(err) {
+                                assert.ok(!err);
+                                RestAPI.Content.getContent(contexts['nicolaas'].restContext, contentObj.id, function(err, contentObj) {
+                                    assert.ok(!err);
+                                    assert.equal(contentObj.previews.status, 'done');
+                                    callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    /**
      * Verifies that the request parameters when downloading a preview are validated.
      */
     it('verify preview download parameter validation', function(callback) {


### PR DESCRIPTION
If you create a link then change where it points the old thumbnails are still used.
