### PR TITLE
Not all SlideShare URLs generate preview

### DIFF
--- a/node_modules/oae-preview-processor/lib/processors/link/slideshare.js
+++ b/node_modules/oae-preview-processor/lib/processors/link/slideshare.js
@@ -17,7 +17,9 @@ var _ = require('underscore');
 var crypto = require('crypto');
 var parseString = require('xml2js').parseString;
 var request = require('request');
+var url = require('url');
 var util = require('util');
+var SlideShare = require('slideshare');
 
 var IO = require('oae-util/lib/io');
 var log = require('oae-logger').logger('oae-preview-processor');
@@ -32,18 +34,18 @@ var SLIDES_REGEX = /^http(s)?:\/\/(www\.)?slideshare\.net\/(\w+)\/(\w+)/;
  * @borrows Interface.test as SlideShareProcessor.test
  */
 var test = module.exports.test = function(ctx, contentObj, callback) {
-    // Don't bother with non-link content items.
+    // Don't bother with non-link content items
     if (contentObj.resourceSubType !== 'link') {
         return callback(null, -1);
     }
 
-    // Check if we're configured to deal with slideshare urls.
+    // Check if we're configured to deal with SlideShare urls
     var config = _getConfig();
     if (!config.apiKey || !config.sharedSecret) {
         return callback(null, -1);
     }
 
-    // Check if they are SlideShare urls.
+    // Check if they are SlideShare urls
     if (SLIDES_REGEX.test(contentObj.link)) {
         return callback(null, 10);
     } else {
@@ -57,56 +59,45 @@ var test = module.exports.test = function(ctx, contentObj, callback) {
 var generatePreviews = module.exports.generatePreviews = function(ctx, contentObj, callback) {
     var config = _getConfig();
 
-    // Do an API request first.
-    // See http://www.slideshare.net/developers/documentation for more info.
-    // Essentially each API call should look like:
-    //     https://www.slideshare.net/api/2/<api method>?<method parameters>&api_key=<api key>&hash=<sha1(secret + ts)>&ts=<ts>
-    var ts = Math.round(Date.now() / 1000);
-    var shasum = crypto.createHash('sha1');
-    shasum.update(config.sharedSecret + ts);
-    var hash = shasum.digest('hex');
-    var apiUrl = util.format('https://www.slideshare.net/api/2/get_slideshow?slideshow_url=%s&api_key=%s&hash=%s&ts=%s', contentObj.link, config.apiKey, hash, ts);
-    request(apiUrl, function(err, response, body) {
-        if (err || response.statusCode !== 200) {
-            return callback(err || {'code': response.statusCode, 'msg': body});
+    var ss = new SlideShare(config.apiKey, config.sharedSecret);
+    ss.getSlideshowByURL(contentObj.link, function(response) {
+        if (!response || response.SlideShareServiceError) {
+            log().error({'err': response.SlideShareServiceError}, 'Failed to interact with the SlideShare API');
+            return callback({'code': 500, 'msg': 'Failed to interact with the SlideShare API'});
+
+        // Ignore this image if it has no thumbnail
+        } else if (!response.Slideshow || !response.Slideshow.ThumbnailURL) {
+            return callback(null, true);
         }
 
-        // Get Thumbnail url.
-        parseString(body, function (err, result) {
-            if (err || result.SlideShareServiceError) {
-                return callback(err || {'code': 500, 'msg': result.SlideShareServiceError.Message});
+        var result = response.Slideshow;
 
-            // Ignore this image if it has no thumbnail.
-            } else if (!(result.Slideshow && result.Slideshow.ThumbnailURL && result.Slideshow.ThumbnailURL.length > 0)) {
-                return callback(null, true);
+        // Try to get some optional metadata about this slideshow such as the title and/or description
+        var opts = {};
+        if (result.Title && result.Title.length > 0) {
+            opts.displayName = result.Title[0];
+        }
+        if (result.Description && result.Description.length > 0) {
+            opts.description = result.Description[0];
+        }
+
+        // Download the thumbnail
+        var imageUrl = 'http:' + result.ThumbnailURL[0];
+        var path = ctx.baseDir + '/slideshare.jpg';
+        PreviewUtil.downloadRemoteFile(imageUrl, path, function(err, path) {
+            if (err) {
+                return callback(err);
             }
 
-            var opts = {};
-            if (result.Slideshow && result.Slideshow.Title && result.Slideshow.Title.length > 0) {
-                opts.displayName = result.Slideshow.Title[0];
-            }
-            if (result.Slideshow && result.Slideshow.Description && result.Slideshow.Description.length > 0) {
-                opts.description = result.Slideshow.Description[0];
-            }
-
-            // Download it.
-            var imageUrl = 'http:' + result.Slideshow.ThumbnailURL[0];
-            var path = ctx.baseDir + '/slideshare.jpg';
-            PreviewUtil.downloadRemoteFile(imageUrl, path, function(err, path) {
-                if (err) {
-                    return callback(err);
-                }
-
-                LinkProcessorUtil.generatePreviewsFromImage(ctx, path, opts, callback);
-            });
+            LinkProcessorUtil.generatePreviewsFromImage(ctx, path, opts, callback);
         });
     });
 };
 
 /**
- * Get the SlideShare API values that have been configured in the Admin UI.
+ * Get the SlideShare API values that have been configured in the Admin UI
  *
- * @return {Object} The apiKey and sharedSecret from the Admin UI.
+ * @return {Object} The apiKey and sharedSecret from the Admin UI
  * @api private
  */
 var _getConfig = function() {

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -576,7 +576,7 @@ describe('Preview processor', function() {
                 return callback();
             }
 
-            _createContentAndWait('link', 'http://www.slideshare.net/nicolaasmatthijs/apereo-oae-state-of-the-project', null, function(restCtx, content) {
+            _createContentAndWait('link', 'http://www.slideshare.net/nicolaasmatthijs/apereo-oae-state-of-the-project?search_from=3', null, function(restCtx, content) {
                 assert.equal(content.previews.status, 'done');
                 // Verify the displayName and description are set.
                 assert.equal(content.displayName, 'Apereo OAE - State of the project');

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "request": "latest",
     "shelljs": "latest",
     "shortid": "latest",
+    "slideshare": "git://github.com/simong/node-slideshare#url-parse",
     "temp": "latest",
     "timezone-js": "latest",
     "underscore": "latest",


### PR DESCRIPTION
The URL `http://www.slideshare.net/nicolaasmatthijs/apereo-oae-state-of-the-project` generates a preview as expected. However, `http://www.slideshare.net/nicolaasmatthijs/apereo-oae-state-of-the-project?from_search=3` does not generate a preview.

Unfortunately, all SlideShare presentations that you get to from the search interface now have the `from_search` parameter. 
