### PR TITLE
Intermittent test failure: verify leaf delete on a non-leaf node soft deletes the message

### DIFF
--- a/node_modules/oae-messagebox/lib/api.js
+++ b/node_modules/oae-messagebox/lib/api.js
@@ -81,7 +81,7 @@ var createMessage = module.exports.createMessage = function(messageBoxId, create
         }
 
         // Make sure we have a unique create timestamp
-        _lockUniqueTimestamp(Date.now(), function(created, lockToken) {
+        _lockUniqueTimestamp(Date.now(), replyToMessageId, function(created, lockKey, lockToken) {
 
             // Data that will be output in diagnostic error messages
             var diagnosticData = {
@@ -148,7 +148,7 @@ var createMessage = module.exports.createMessage = function(messageBoxId, create
                     return callback(null, message);
                 });
             });
-            Locking.release(created, lockToken, function(){});
+            Locking.release(lockKey, lockToken, function(){});
         });
     });
 };
@@ -157,22 +157,25 @@ var createMessage = module.exports.createMessage = function(messageBoxId, create
  * Lock a unique timestamp
  *
  * @param  {Integer}       timestamp           The timestamp you'd like to try to lock (ms since unix epoch
+ * @param  {String}        id                  An id to provide context for the lock
  * @param  {Function}      callback            Standard callback function
  * @param  {Object}        callback.timestamp  The timestamp we actually got
+ * @param  {Object}        callback.key        The key we used to acquire the lock
  * @param  {String}        callback.lockToken  The lockToken that can be used to release this lock
  */
-var _lockUniqueTimestamp = function(timestamp, callback) {
-    Locking.acquire(timestamp, 1, function(err, lockToken) {
+var _lockUniqueTimestamp = function(timestamp, id, callback) {
+    var key = 'oae-messagebox:' + id + ':' + timestamp;
+    Locking.acquire(key, 1, function(err, lockToken) {
         if (err) {
             // This should only occur if Redis is down, just return the requested ts
             return callback(timestamp, lockToken);
         }
         if (!lockToken) {
             // Someone else has the requested ts, try to lock one ms later
-            return lockUniqueTimestamp(timestamp + 1);
+            return lockUniqueTimestamp(timestamp + 1, id, callback);
         }
         // Successful lock, return the details
-        return callback(timestamp, lockToken);
+        return callback(timestamp, key, lockToken);
     });
 };
 


### PR DESCRIPTION
```
[0m  1) Messagebox #deleteMessage verify leaf delete on a non-leaf node soft deletes the message:
[0m[31m     Uncaught AssertionError: {
    "a1": {
        "id": "msg-box-test-0.9950088497716933#1374853928293",
        "messageBoxId": "msg-box-test-0.9950088497716933",
        "threadKey": "1374853928293|",
        "body": "A1",
        "createdBy": "u:camtest:foo",
        "created": "1374853928293",
        "level": 0,
        "replyTo": null
    },
    "a2": {
        "id": "msg-box-test-0.9950088497716933#1374853928296",
        "messageBoxId": "msg-box-test-0.9950088497716933",
        "threadKey": "1374853928293#1374853928296|",
        "body": "A2",
        "createdBy": "u:camtest:foo",
        "created": "1374853928296",
        "level": 1,
        "replyTo": "1374853928293"
    },
    "a3": {
        "id": "msg-box-test-0.9950088497716933#1374853928299",
        "messageBoxId": "msg-box-test-0.9950088497716933",
        "threadKey": "1374853928296#1374853928299|",
        "body": "A3",
        "createdBy": "u:camtest:foo",
        "created": "1374853928299",
        "level": 1,
        "replyTo": "1374853928296"
    },
    "a4": {
        "id": "msg-box-test-0.9950088497716933#1374853928301",
        "messageBoxId": "msg-box-test-0.9950088497716933",
        "threadKey": "1374853928293#1374853928301|",
        "body": "A4",
        "createdBy": "u:camtest:foo",
        "created": "1374853928301",
        "level": 1,
        "replyTo": "1374853928293"
    },
    "b1": {
        "id": "msg-box-test-0.9950088497716933#1374853928296",
        "messageBoxId": "msg-box-test-0.9950088497716933",
        "threadKey": "1374853928296|",
        "body": "B1",
        "createdBy": "u:camtest:foo",
        "created": "1374853928296",
        "level": 0,
        "replyTo": null
    },
    "c1": {
        "id": "msg-box-test-0.9950088497716933#1374853928297",
        "messageBoxId": "msg-box-test-0.9950088497716933",
        "threadKey": "1374853928297|",
        "body": "C1",
        "createdBy": "u:camtest:foo",
        "created": "1374853928297",
        "level": 0,
        "replyTo": null
    }
}[0m[90m
      at setupMessages (/home/travis/build/oaeproject/Hilary/node_modules/oae-messagebox/tests/test-messagebox.js:95:44)
      at Function._.each._.forEach (/home/travis/build/oaeproject/Hilary/node_modules/underscore/underscore.js:87:24)
      at setupMessages (/home/travis/build/oaeproject/Hilary/node_modules/oae-messagebox/tests/test-messagebox.js:93:35)
      at module.exports.createMessage (/home/travis/build/oaeproject/Hilary/node_modules/oae-messagebox/lib/api.js:146:24)
      at executeQuery (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/lib/cassandra.js:734:9)
      at onReturn (/home/travis/build/oaeproject/Hilary/node_modules/helenus/lib/connection.js:448:7)
      at onReturn (/home/travis/build/oaeproject/Hilary/node_modules/helenus/lib/connection.js:379:7)
      at exports.Connection.connection.addListener.self.transport.receiver.client._reqs.(anonymous function) (/home/travis/build/oaeproject/Hilary/node_modules/helenus/node_modules/helenus-thrift/lib/thrift/connection.js:80:11)
      at Object.CassandraClient.recv_execute_cql_query (/home/travis/build/oaeproject/Hilary/node_modules/helenus/lib/cassandra/Cassandra.js:8295:12)
      at exports.Connection (/home/travis/build/oaeproject/Hilary/node_modules/helenus/node_modules/helenus-thrift/lib/thrift/connection.js:83:37)
```

This happens when multiple comments with the same comment created time get created due to fast creation.

One fix is to include nanoseconds in the created time -- although there will still be a race condition. Another solution is to "lock" a timestamp in Redis for ~1 second on each creation. If the timestamp is already locked by another request, increment the millis by 1 and try again. Continue trying until you get a timestamp lock. That should ensure you never have conflicts.
