### PR TITLE
Tincan API test failures

### DIFF
--- a/node_modules/oae-tincanapi/lib/api.js
+++ b/node_modules/oae-tincanapi/lib/api.js
@@ -104,35 +104,26 @@ var _processActivities = function(routedActivities) {
  * @see /node_modules/oae-tincanapi/lib/constants.js
  * 
  * @param  {String}     verb    OAE activity verb that needs to be mapped to a TinCan API verb
- * @return {VerbModel}    		Mapped TinCan API verb
+ * @return {VerbModel}          Mapped TinCan API verb
  * @api private
  */
 var _mapVerb = function(oaeVerb) {
-
     var verb = null;
 
-    switch (oaeVerb) {
-        case ActivityConstants.verbs.ADD:
-            verb = TinCanAPIConstants.verbs.ADDED;
-            break;
-        case ActivityConstants.verbs.CREATE:
-            verb = TinCanAPIConstants.verbs.CREATED;
-            break;
-        case ActivityConstants.verbs.JOIN:
-            verb = TinCanAPIConstants.verbs.JOINED;
-            break;
-        case ActivityConstants.verbs.POST:
-            verb = TinCanAPIConstants.verbs.POSTED;
-            break;
-        case ActivityConstants.verbs.SHARE:
-            verb = TinCanAPIConstants.verbs.SHARED;
-            break;
-        case ActivityConstants.verbs.UPDATE:
-            verb = TinCanAPIConstants.verbs.UPDATED;
-            break;
-        default:
-        	verb = TinCanAPIConstants.verbs.DEFAULT;
-        	break;
+    if (oaeVerb === ActivityConstants.verbs.ADD) {
+        verb = TinCanAPIConstants.verbs.ADDED;
+    } else if (oaeVerb === ActivityConstants.verbs.CREATE) {
+        verb = TinCanAPIConstants.verbs.CREATED;
+    } else if (oaeVerb === ActivityConstants.verbs.JOIN) {
+        verb = TinCanAPIConstants.verbs.JOINED;
+    } else if (oaeVerb === ActivityConstants.verbs.POST) {
+        verb = TinCanAPIConstants.verbs.POSTED;
+    } else if (oaeVerb === ActivityConstants.verbs.SHARE) {
+        verb = TinCanAPIConstants.verbs.SHARED;
+    } else if (oaeVerb === ActivityConstants.verbs.UPDATE) {
+        verb = TinCanAPIConstants.verbs.UPDATED;
+    } else {
+        verb = TinCanAPIConstants.verbs.DEFAULT;
     }
 
     return new TinCanModel.TinCanVerb(verb.id, verb.display);

--- a/node_modules/oae-tincanapi/lib/constants.js
+++ b/node_modules/oae-tincanapi/lib/constants.js
@@ -25,8 +25,8 @@ TinCanAPIConstants.verbs = {
         'display': 'created'
     },
     'DEFAULT': {
-    	'id': 'http://adlnet.gov/expapi/verbs/interacted',
-    	'display': 'interacted'
+        'id': 'http://adlnet.gov/expapi/verbs/interacted',
+        'display': 'interacted'
     },
     'JOINED': {
         'id': 'http://oaeproject.org/expapi/verbs/joined',

--- a/node_modules/oae-tincanapi/tests/test-tincanapi.js
+++ b/node_modules/oae-tincanapi/tests/test-tincanapi.js
@@ -82,64 +82,76 @@ describe('TinCanAPI', function() {
      * Test that verifies that TinCan API statements are sent to a configurable LRS.
      */
     it('verify post TinCan statements', function(callback) {
-
-        // First enable LRS since the default value is false
-        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, 'oae-tincanapi/lrs/enabled', true, function(err) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
             assert.ok(!err);
 
-            // Create a test user
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
+            var testUser = _.values(users)[0];
+
+            // Collect any existing activities so they will not interfere with this test
+            ActivityTestsUtil.collectAndGetActivityStream(testUser.restContext, null, null, function(err, activityStream) {
                 assert.ok(!err);
 
-                _.each(users, function(user, id) {
-                    var userCtx = user.restContext;
+                // Enable sending activities to the LRS as the default value is false
+                ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, 'oae-tincanapi/lrs/enabled', true, function(err) {
+                    assert.ok(!err);
 
+                    var testLinks = {};
                     var activitiesCollected = false;
-                    var testLinks = [];
-                    var testUser = user;
+                    var tincanChecked = false;
 
+                    // Define the function that will get executed when our dummy LRS receives a request
+                    // This should only happen when we trigger an activity collection cycle at the end of the test
                     onRequest = function(req) {
 
                         // Check each activity if it matches the original
                         _.each(req.body, function(val, key) {
                             assert.equal(val.actor.name, testUser.user.displayName);
-                            assert.equal(val.object.id, testLinks[key].id);
-                            assert.equal(val.object.definition.name['en-US'], testLinks[key].displayName);
-                            assert.equal(val.object.definition.description['en-US'], testLinks[key].description);
+                            assert.ok(testLinks[val.object.id]);
+                            assert.equal(val.object.definition.name['en-US'], testLinks[val.object.id].displayName);
+                            assert.equal(val.object.definition.description['en-US'], testLinks[val.object.id].description);
                         });
 
-                        if (activitiesCollected) {
+                        tincanChecked = true;
+
+                        // Because of the async nature of collecting activities and submitting them to the LRS
+                        // it's possible that the `collectAndGetActivityStream` callback hasn't been called yet
+                        if (tincanChecked && activitiesCollected) {
                             callback();
                         }
                     };
 
                     // Create a new link
-                    RestAPI.Content.createLink(userCtx, 'Link1', 'The first link', 'public', 'http://www.google.be', [], [], function(err, link) {
+                    RestAPI.Content.createLink(testUser.restContext, 'Link1', 'The first link', 'public', 'http://www.google.be', [], [], function(err, link) {
                         assert.ok(!err);
 
                         // Store the created link
-                        testLinks.push(link);
+                        testLinks[link.id] = link;
 
                         // Create a new link
-                        RestAPI.Content.createLink(userCtx, 'Link2', 'The second link', 'private', 'http://www.google.fr', [], [], function(err, link) {
+                        RestAPI.Content.createLink(testUser.restContext, 'Link2', 'The second link', 'private', 'http://www.google.fr', [], [], function(err, link) {
                             assert.ok(!err);
 
                             // Store the created link
-                            testLinks.push(link);
+                            testLinks[link.id] = link;
 
                             // Create a new link
-                            RestAPI.Content.createLink(userCtx, 'Link3', 'The third link', 'public', 'http://www.google.nl', [], [], function(err, link) {
+                            RestAPI.Content.createLink(testUser.restContext, 'Link3', 'The third link', 'public', 'http://www.google.nl', [], [], function(err, link) {
                                 assert.ok(!err);
 
                                 // Store the created link
-                                testLinks.push(link);
+                                testLinks[link.id] = link;
 
-                                // Force an activity collection cycle
-                                ActivityTestsUtil.collectAndGetActivityStream(userCtx, null, null, function(err, activityStream) {
+                                // Force an activity collection cycle that will send the activities to our dummy LRS
+                                // The test will be ended there
+                                ActivityTestsUtil.collectAndGetActivityStream(testUser.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
-
                                     activitiesCollected = true;
-                                    callback();
+
+                                    // Because of the async nature of collecting activities and submitting them to the LRS
+                                    // it's possible that the activities submitted to the LRS haven't been checked for correctness yet
+                                    if (tincanChecked && activitiesCollected) {
+                                        callback();
+                                    }
                                 });
                             });
                         });
@@ -153,31 +165,27 @@ describe('TinCanAPI', function() {
      * Test that verifies that no statements are posted when the LRS is disabled
      */
     it('verify TinCan integration enabled', function(callback) {
-
-        // First enable LRS since the default value is false
-        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, 'oae-tincanapi/lrs/enabled', false, function(err) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
             assert.ok(!err);
 
-            // Create a test user
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
+            var testUser = _.values(users)[0];
+
+            // Collect any existing activities so they will not interfere with this test
+            ActivityTestsUtil.collectAndGetActivityStream(testUser.restContext, null, null, function(err, activityStream) {
                 assert.ok(!err);
 
-                _.each(users, function(user, id) {
-                    var userCtx = user.restContext;
+                onRequest = function(req) {
+                    assert.fail(null, null, 'No statements should be sent when LRS integration is disabled');
+                };
 
-                    onRequest = function(req) {
-                        assert.fail(null, null, 'No statements should be sent when LRS integration is disabled');
-                    };
+                // Create a new link
+                RestAPI.Content.createLink(testUser.restContext, 'Link1', 'The first link', 'public', 'http://www.google.be', [], [], function(err, link) {
+                    assert.ok(!err);
 
-                    // Create a new link
-                    RestAPI.Content.createLink(userCtx, 'Link1', 'The first link', 'public', 'http://www.google.be', [], [], function(err, link) {
+                    // Force the activities
+                    ActivityTestsUtil.collectAndGetActivityStream(testUser.restContext, null, null, function(err, activityStream) {
                         assert.ok(!err);
-
-                        // Force the activities
-                        ActivityTestsUtil.collectAndGetActivityStream(userCtx, null, null, function(err, activityStream) {
-                            assert.ok(!err);
-                            callback();
-                        });
+                        callback();
                     });
                 });
             });
@@ -188,61 +196,68 @@ describe('TinCanAPI', function() {
      * Test that verifies if statements are (not) sent when activities are received from multiple tenants with different LRS-enabled values
      */
     it('verify permeable tenant TinCan statements', function(callback) {
-
-        // First enable the LRS integration for the camTenant since the default value is false
-        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, 'oae-tincanapi/lrs/enabled', true, function(err) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
             assert.ok(!err);
 
-            // Create a new user for the CamTenant
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, camUsers) {
+            var camUser = _.values(users)[0];
+
+            // Collect any existing activities so they will not interfere with this test
+            ActivityTestsUtil.collectAndGetActivityStream(camUser.restContext, null, null, function(err, activityStream) {
                 assert.ok(!err);
 
-                // Store the camUser
-                var camUser = camUsers[Object.keys(camUsers)[0]];
-                var camUserCtx = camUser.restContext;
-
-                var activitiesCollected = false;
-                var tincanSent = false;
-
-                onRequest = function(req) {
-
-                    // Check each activity if it matches the original
-                    _.each(req.body, function(val, key) {
-                        assert.equal(val.actor.name, camUser.user.displayName);
-                        assert.equal(val.actor.account.name, camUser.user.publicAlias);
-                    });
-
-                    if (activitiesCollected) {
-                        callback();
-                    }
-                };
-
-                // Create a new link for the CamTenant
-                RestAPI.Content.createLink(camUserCtx, 'Link1', 'The first link', 'public', 'http://www.google.be', [], [], function(err, link) {
+                // Enable sending activities to the LRS as the default value is false
+                // Note that we only enable it for the Cambridge tenant
+                ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, 'oae-tincanapi/lrs/enabled', true, function(err) {
                     assert.ok(!err);
 
-                    // Create a new user for the GTTenant
-                    TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, gtUsers) {
+                    var activitiesCollected = false;
+                    var tincanChecked = false;
+                    var tincanSent = false;
+
+                    // Define the function that will get executed when our dummy LRS receives a request
+                    // This should only happen when we trigger an activity collection cycle at the end of the test
+                    onRequest = function(req) {
+
+                        // Check each activity if it matches the original
+                        _.each(req.body, function(val, key) {
+                            assert.equal(val.actor.name, camUser.user.displayName);
+                            assert.equal(val.actor.account.name, camUser.user.publicAlias);
+                        });
+
+                        tincanChecked = true;
+
+                        // Because of the async nature of collecting activities and submitting them to the LRS
+                        // it's possible that the `collectAndGetActivityStream` callback hasn't been called yet
+                        if (tincanChecked && activitiesCollected) {
+                            callback();
+                        }
+                    };
+
+                    // Create a new link on the cambridge tenant
+                    RestAPI.Content.createLink(camUser.restContext, 'Link1', 'The first link', 'public', 'http://www.google.be', [], [], function(err, link) {
                         assert.ok(!err);
 
-                        // Store the gtUser
-                        var gtUser = gtUsers[Object.keys(gtUsers)[0]];
-                        var gtUserCtx = gtUser.restContext;
-
-                        // Create a new link for the GTTenant
-                        RestAPI.Content.createLink(gtUserCtx, 'Link2', 'The second link', 'private', 'http://www.google.nl', [], [], function(err, link) {
+                        // Create a new user for the GTTenant
+                        TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, gtUsers) {
                             assert.ok(!err);
 
-                            // Force the activities for the camUser                     
-                            ActivityTestsUtil.collectAndGetActivityStream(camUserCtx, null, null, function(err, activityStream) {
+                            // Store the gtUser
+                            var gtUser = _.values(users)[0];
+
+                            // Create a new link for the GTTenant
+                            RestAPI.Content.createLink(gtUser.restContext, 'Link2', 'The second link', 'private', 'http://www.google.nl', [], [], function(err, link) {
                                 assert.ok(!err);
 
-                                // Force the activities for the gtUser
-                                ActivityTestsUtil.collectAndGetActivityStream(gtUserCtx, null, null, function(err, activityStream) {
+                                // Force an activity collection cycle. It doesn't really matter which restContext we pass in, as that is only used to retrieve the activity stream
+                                ActivityTestsUtil.collectAndGetActivityStream(camUser.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
-
                                     activitiesCollected = true;
-                                    callback();
+
+                                    // Because of the async nature of collecting activities and submitting them to the LRS
+                                    // it's possible that the activities submitted to the LRS haven't been checked for correctness yet
+                                    if (tincanChecked && activitiesCollected) {
+                                        callback();
+                                    }
                                 });
                             });
                         });


### PR DESCRIPTION
There are a couple issues in the tincan API tests. Here are my failures:

**Grunt style check:**

```
Running "jshint:files" (jshint) task
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L107:C26] W099: Mixed spaces and tabs.
 * @return {VerbModel}        Mapped TinCan API verb
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L115:C9] W015: Expected 'case' to have an indentation at 5 instead at 9.
        case ActivityConstants.verbs.ADD:
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L116:C13] W015: Expected 'verb' to have an indentation at 9 instead at 13.
            verb = TinCanAPIConstants.verbs.ADDED;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L117:C13] W015: Expected 'break' to have an indentation at 9 instead at 13.
            break;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L118:C9] W015: Expected 'case' to have an indentation at 5 instead at 9.
        case ActivityConstants.verbs.CREATE:
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L119:C13] W015: Expected 'verb' to have an indentation at 9 instead at 13.
            verb = TinCanAPIConstants.verbs.CREATED;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L120:C13] W015: Expected 'break' to have an indentation at 9 instead at 13.
            break;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L121:C9] W015: Expected 'case' to have an indentation at 5 instead at 9.
        case ActivityConstants.verbs.JOIN:
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L122:C13] W015: Expected 'verb' to have an indentation at 9 instead at 13.
            verb = TinCanAPIConstants.verbs.JOINED;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L123:C13] W015: Expected 'break' to have an indentation at 9 instead at 13.
            break;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L124:C9] W015: Expected 'case' to have an indentation at 5 instead at 9.
        case ActivityConstants.verbs.POST:
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L125:C13] W015: Expected 'verb' to have an indentation at 9 instead at 13.
            verb = TinCanAPIConstants.verbs.POSTED;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L126:C13] W015: Expected 'break' to have an indentation at 9 instead at 13.
            break;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L127:C9] W015: Expected 'case' to have an indentation at 5 instead at 9.
        case ActivityConstants.verbs.SHARE:
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L128:C13] W015: Expected 'verb' to have an indentation at 9 instead at 13.
            verb = TinCanAPIConstants.verbs.SHARED;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L129:C13] W015: Expected 'break' to have an indentation at 9 instead at 13.
            break;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L130:C9] W015: Expected 'case' to have an indentation at 5 instead at 9.
        case ActivityConstants.verbs.UPDATE:
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L131:C13] W015: Expected 'verb' to have an indentation at 9 instead at 13.
            verb = TinCanAPIConstants.verbs.UPDATED;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L132:C13] W015: Expected 'break' to have an indentation at 9 instead at 13.
            break;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L133:C9] W015: Expected 'default' to have an indentation at 5 instead at 9.
        default:
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L134:C8] W099: Mixed spaces and tabs.
          verb = TinCanAPIConstants.verbs.DEFAULT;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L134:C13] W015: Expected 'verb' to have an indentation at 9 instead at 13.
          verb = TinCanAPIConstants.verbs.DEFAULT;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L135:C8] W099: Mixed spaces and tabs.
          break;
Linting node_modules/oae-tincanapi/lib/api.js ...ERROR
[L135:C13] W015: Expected 'break' to have an indentation at 9 instead at 13.
          break;
Linting node_modules/oae-tincanapi/lib/constants.js ...ERROR
[L28:C4] W099: Mixed spaces and tabs.
      'id': 'http://adlnet.gov/expapi/verbs/interacted',
Linting node_modules/oae-tincanapi/lib/constants.js ...ERROR
[L29:C4] W099: Mixed spaces and tabs.
      'display': 'interacted'
```

**Unit tests:**

```
TinCanAPI
    ◦ verify post TinCan statements: AssertionError: "random-user-l1exRFZfnZ" == "random-user-gyxm2sWz2Z"
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:105:36
    at Array.forEach (native)
    at Function._.each._.forEach (/Users/branden/Source/oaeproject/Hilary/node_modules/underscore/underscore.js:79:11)
    at onRequest (/Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:104:27)
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:57:13
    at callbacks (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:164:37)
    at param (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:138:11)
    at pass (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:145:5)
    at Router._dispatch (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:173:5)
    at Object.router (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:33:10)
AssertionError: "random-user-e1emYFWf2b" == "random-user-gyxm2sWz2Z"
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:105:36
    at Array.forEach (native)
    at Function._.each._.forEach (/Users/branden/Source/oaeproject/Hilary/node_modules/underscore/underscore.js:79:11)
    at onRequest (/Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:104:27)
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:57:13
    at callbacks (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:164:37)
    at param (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:138:11)
    at pass (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:145:5)
    at Router._dispatch (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:173:5)
    at Object.router (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:33:10)
AssertionError: "random-user-g1VlEKbG2Z" == "random-user-gyxm2sWz2Z"
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:105:36
    at Array.forEach (native)
    at Function._.each._.forEach (/Users/branden/Source/oaeproject/Hilary/node_modules/underscore/underscore.js:79:11)
    at onRequest (/Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:104:27)
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-tincanapi/tests/test-tincanapi.js:57:13
    at callbacks (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:164:37)
    at param (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:138:11)
    at pass (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:145:5)
    at Router._dispatch (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:173:5)
    at Object.router (/Users/branden/Source/oaeproject/Hilary/node_modules/express/lib/router/index.js:33:10)
```
1. The style checks should be fixed
2. The assertion failures are getting spit out to the console rather than bubbling up an exception. I think the express error handler is swallowing these and this is the default reaction
3. I think you need to collect _before_ performing the activities, as the assertion failure we are seeing here is likely related to having more than just the activities in this test getting collected and verified
4. Unnecessary `_.each` wrapping the users object, it is only 1 user object
5. I don't think executing the callback inside of `onRequest` is necessary in both places
6. Trailing whitespace in this file (line 236)
