### PR TITLE
Intermittent test failure: Library Search User Libraries verify only self and admin can see private user library items

### DIFF
--- a/node_modules/oae-tests/runner/beforeTests.js
+++ b/node_modules/oae-tests/runner/beforeTests.js
@@ -67,6 +67,8 @@ config.mq.purgeQueuesOnStartup = true;
 
 config.search.index.name = 'oaetest';
 config.search.index.settings.number_of_shards = 1;
+config.search.index.settings.number_of_replicas = 0;
+config.search.index.settings.store = {'type': 'memory'};
 config.search.index.destroyOnStartup = true;
 
 // Disable the poller so it only collects manually


### PR DESCRIPTION
```
AssertionError: 0 == 1
      at RestAPI.User.createUser.RestAPI.User.createUser.RestAPI.Group.createGroup.RestAPI.User.createUser.membership (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/oae-content/tests/test-library-search.js:226:52)
      at module.exports.searchAll (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/oae-search/lib/test/util.js:43:28)
      at Request._callback (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/oae-rest/lib/util.js:202:16)
      at Request.init.self.callback (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/request/index.js:148:22)
      at Request.EventEmitter.emit (events.js:91:17)
      at Request.onResponse (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/request/index.js:891:14)
      at Request.EventEmitter.emit (events.js:115:20)
      at IncomingMessage.Request.onResponse.buffer (/Users/nicolaas/Desktop/SakaiOAE/ui/newOAE/Hilary/node_modules/request/index.js:842:12)
      at IncomingMessage.EventEmitter.emit (events.js:115:20)
      at IncomingMessage._emitEnd (http.js:366:10)
```
