### PR TITLE
allow express to accept POSTs up to the limit we set in nginx

### DIFF
--- a/config.js
+++ b/config.js
@@ -93,6 +93,7 @@ tmpDir += '/oae';
  * @param  {Boolean}   cleaner.enabled          Whether or not the cleaning job should run.
  * @param  {Number}    cleaner.interval         Files that haven't been accessed in this amount (of seconds) should be removed.
  * @param  {String}    localStorageDirectory    The directory where the local storage backend can store its files. By default, the files get stored on the same level as the Hilary directory. Note: the absolute path to this directory should also be configured in the Nginx config file. This directory will not be used when Amazon S3 file storage is used.
+ * @param  {String}    limit                    The maximum file upload size, accepted formats look like "5mb", "200kb", "1gb"
  */
 config.files = {
     'tmpDir': tmpDir,
@@ -102,7 +103,7 @@ config.files = {
         'interval': 2*60*60
     },
     'localStorageDirectory': '../files',
-    'maxSize': '4096mb'
+    'limit': '4096mb'
 };
 
 // The configuration that can be used to generate secure HTTP cookies.

--- a/node_modules/oae-util/lib/server.js
+++ b/node_modules/oae-util/lib/server.js
@@ -55,9 +55,6 @@ module.exports.setupServer = function(port, _config) {
     // Signing of the cookie will be done by the session middleware.
     app.use(express.cookieParser());
 
-    // Set the maximum file upload size
-    app.use(express.limit(config.files.maxSize));
-
     // The bodyParser will parse the following type of requests:
     // * application/json
     // * urlencoded (regular POST requests)


### PR DESCRIPTION
I found that the default express maximum upload size is significantly lower than the 4G we set in nginx (I got an error on something like a 160M file). This seems to fix it.
