### PR TITLE
Bump node-slideshare github revision

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "request": "latest",
     "shelljs": "latest",
     "shortid": "latest",
-    "slideshare": "git://github.com/simong/node-slideshare#url-parse",
+    "slideshare": "git://github.com/oaeproject/node-slideshare",
     "temp": "latest",
     "timezone-js": "latest",
     "underscore": "latest",


### PR DESCRIPTION
Pretty sure SlideShare stopped accepting HTML bodies in GET requests all of a sudden, and the slideshare units are now broken for me. I've submit a PR to our node-slideshare parent clone, but have cloned an oaeproject repo in the meantime with this commit: https://github.com/oaeproject/node-slideshare/commit/137858c7d83df4ba2f7202266b36bdc41fac35bb
