### PR TITLE
GitHub URL not recognised as non-embeddable

### DIFF
--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -15,6 +15,7 @@
 
 var _ = require('underscore');
 var assert = require('assert');
+var express = require('express');
 var ShortId = require('shortid');
 var stream = require('stream');
 var util = require('util');
@@ -25,6 +26,43 @@ var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var RestUtil  =require('oae-rest/lib/util');
 var User = require('oae-principals/lib/model').User;
+
+/**
+ * Create a new express test server
+ *
+ * @return {Function}                         Function that returns a new express server and the port which the server is listening to
+
+ */
+var createTestServer = module.exports.createTestServer = function() {
+
+    var port = 2000 + Math.floor(Math.random()*1000);
+    var attempts = 0;
+
+    /**
+     * Try to create a webserver. Take care of port selection by trying a few times
+     */
+    var _createServer = function() {
+        attempts++;
+        if (attempts == 10) {
+            assert.fail('Could not spin up a webserver in under 10 attempts');
+        }
+
+        var server = express();
+        server.use(express.bodyParser({}));
+        
+        try {
+            server.listen(port + attempts);
+        } catch (e) {
+            // Couldn't create a server on this port, try the next one
+            return _createServer();
+        }
+
+        // A server was created, return it to the caller
+        return {'server': server, 'port': port + attempts};
+    };
+
+    return _createServer();
+};
 
 /**
  * Generate a number of random users that can be used inside of tests

--- a/node_modules/oae-tincanapi/tests/test-tincanapi.js
+++ b/node_modules/oae-tincanapi/tests/test-tincanapi.js
@@ -16,6 +16,7 @@
 var _ = require('underscore');
 var assert = require('assert');
 var express = require('express');
+var request = require('request');
 
 var ConfigTestUtil = require('oae-config/lib/test/util');
 var RestAPI = require('oae-rest');
@@ -50,19 +51,14 @@ describe('TinCanAPI', function() {
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
 
         // Create a new express application to mock a Learning Record Store
-        var app = express();
-        app.use(express.bodyParser({}));
-
-        app.post('/', function(req, res) {
+        var app = TestsUtil.createTestServer();
+        app.server.post('/', function(req, res) {
             onRequest(req);
             res.send(200);
         });
-
-        // Listen to a specific port
-        var server = app.listen(3000);
-
+        
         // Set the endpoint for the LRS
-        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, 'oae-tincanapi/lrs/endpoint', 'http://localhost:3000', function(err) {
+        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, 'oae-tincanapi/lrs/endpoint', 'http://localhost:' + app.port, function(err) {
             assert.ok(!err);
             callback();
         });


### PR DESCRIPTION
See http://collab.sakaiproject.org/pipermail/oae-dev/2013-September/003630.html

The GitHub URL in the video is not being recognized as non-embeddable. Some early testing shows that the connection is not being closed properly when doing a HEAD request.

The following response comes back from the content feed:

```
{"tenant":{"alias":"gatech","displayName":"Georgia Institute of Technology"},"id":"c:gatech:eyf1rjCLG","visibility":"public","displayName":"https://github.com/sathomas/3akai-ux/wiki/Test-Driven-Development-of-an-OAE-Widget","description":"","resourceSubType":"link","createdBy":{"tenant":{"alias":"gatech","displayName":"Georgia Institute of Technology"},"id":"u:gatech:lknvFkQkb","displayName":"Stephen Anthony Thomas","visibility":"public","picture":{"smallUri":"local:u/gatech/lk/nv/Fk/Qk/lknvFkQkb/profilepictures/small.jpg","mediumUri":"local:u/gatech/lk/nv/Fk/Qk/lknvFkQkb/profilepictures/medium.jpg","largeUri":"local:u/gatech/lk/nv/Fk/Qk/lknvFkQkb/profilepictures/large.jpg","small":"/api/download/signed?uri=local:u/gatech/lk/nv/Fk/Qk/lknvFkQkb/profilepictures/small.jpg&signature=be0e507aaea80c52eab896ede251e016309e6f7c&expires=1380618000000","medium":"/api/download/signed?uri=local:u/gatech/lk/nv/Fk/Qk/lknvFkQkb/profilepictures/medium.jpg&signature=fda538a302ca8b3b8f35447ebb5bfb4fe0425de7&expires=1380618000000","large":"/api/download/signed?uri=local:u/gatech/lk/nv/Fk/Qk/lknvFkQkb/profilepictures/large.jpg&signature=f4e8636ba889720cd0287085892ddab4af2663f4&expires=1380618000000"},"profilePath":"/user/gatech/lknvFkQkb","resourceType":"user"},"created":"1380219863698","lastModified":"1380219863713","profilePath":"/content/gatech/eyf1rjCLG","resourceType":"content","latestRevisionId":"rev:gatech:xJlG1SiAUG","link":"https://github.com/sathomas/3akai-ux/wiki/Test-Driven-Development-of-an-OAE-Widget","previews":{"status":"error","total":0},"signature":{"signature":"f573aa3a21d4d7a6bf6c8196057e37695b1b1f8c","expires":1380556800000,"lastModified":"1380219863713"},"isManager":false}
```
