### PR TITLE
Email subject for file comment

### DIFF
--- a/node_modules/oae-content/emailTemplates/default/notify-content-comment.meta.json.jst
+++ b/node_modules/oae-content/emailTemplates/default/notify-content-comment.meta.json.jst
@@ -1,3 +1,3 @@
 {
-    "subject": "Someone has commented on \"<%= data.activity.target.displayName %>\""
+    "subject": "<%= data.activity.actor.displayName %> has commented on \"<%= data.activity.target.displayName %>\""
 }

--- a/node_modules/oae-content/tests/test-activity.js
+++ b/node_modules/oae-content/tests/test-activity.js
@@ -1774,6 +1774,9 @@ describe('Content Activity', function() {
                                     // Sanity check that the message is to mrvisser
                                     assert.equal(message.to, mrvisser.user.email);
 
+                                    // Ensure that the subject of the email contains the poster's name
+                                    assert.notEqual(message.subject.indexOf('swappedFromPublicAlias'), -1);
+
                                     // Ensure some data expected to be in the email is there
                                     assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
                                     assert.notEqual(stringMessage.indexOf(link.profilePath), -1);

--- a/node_modules/oae-discussions/emailTemplates/default/notify-discussion-message.meta.json.jst
+++ b/node_modules/oae-discussions/emailTemplates/default/notify-discussion-message.meta.json.jst
@@ -1,3 +1,3 @@
 {
-    "subject": "Someone has posted on \"<%= data.activity.target.displayName %>\""
+    "subject": "<%= data.activity.actor.displayName %> has posted on \"<%= data.activity.target.displayName %>\""
 }

--- a/node_modules/oae-discussions/tests/test-activity.js
+++ b/node_modules/oae-discussions/tests/test-activity.js
@@ -426,6 +426,9 @@ describe('Discussion Activity', function() {
                                     // Sanity check that the email is to mrvisser
                                     assert.equal(email.to, mrvisser.user.email);
 
+                                    // Ensure that the subject of the email contains the poster's name
+                                    assert.notEqual(email.subject.indexOf('swappedFromPublicAlias'), -1);
+
                                     // Ensure some data expected to be in the email is there
                                     assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
                                     assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);


### PR DESCRIPTION
Is `Someone has commented on "The greatest file in the world"`. `Someone` should be replaced by the name of the person that commented.
