### PR TITLE
Using an HTTP mediacore url in an HTTPS instance results in the videos not showing

### DIFF
--- a/node_modules/oae-mediacore/config/config.js
+++ b/node_modules/oae-mediacore/config/config.js
@@ -18,15 +18,15 @@ var Fields = require('oae-config/lib/fields');
 module.exports = {
     'title': 'OAE MediaCore Module',
     'mediacore': {
-        'name': 'MediaCore configuration',
-        'description': 'Configuration for the MediaCore preview processor',
+        'name': 'MediaCore Configuration',
+        'description': 'Configuration for MediaCore media processing',
         'elements': {
-            'enabled': new Fields.Bool('Enabled', 'Process videos with MediaCore', false, {
+            'enabled': new Fields.Bool('Enabled', 'Process audio and video uploads with MediaCore', false, {
                 'tenantOverride': false,
                 'suppress': true,
                 'globalAdminOnly': true
             }),
-            'url': new Fields.Text('URL', 'The MediaCore URL', '', {
+            'url': new Fields.Text('URL', 'The MediaCore URL (e.g., https://mysite.mediacore.tv)', '', {
                 'tenantOverride': false,
                 'suppress': true,
                 'globalAdminOnly': true
@@ -41,7 +41,7 @@ module.exports = {
                 'suppress': true,
                 'globalAdminOnly': true
             }),
-            'collectionId': new Fields.Text('CollectionId', 'The MediaCore Collection Id', '', {
+            'collectionId': new Fields.Text('CollectionId', 'The MediaCore Collection ID', '', {
                 'tenantOverride': false,
                 'suppress': true,
                 'globalAdminOnly': true


### PR DESCRIPTION
For example, using http://nicolaasmatthijs.mediacore.tv while bug-bashing on https://oae.oae-qa0.oaeproject.org.

Not sure what the best way is to handle this. Since OAE uses a secret key to communicate with MediaCore, there isn't really a case where we want this to be HTTP. We could look at the back-end config to determine if HTTP should be promoted to HTTPS at runtime.
