### PR TITLE
As a viewer of a private content item, I have UI options to share it with others. Hilary gives 401

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -135,7 +135,7 @@ var getFullContentProfile = module.exports.getFullContentProfile = function(ctx,
 };
 
 /**
- * Adds the `isManager` flag, `createdBy` user object and the `latestRevision` in case it's a collaborative document.
+ * Adds the `isManager` flag, `createdBy` user object, `canShare` flag and the `latestRevision` in case it's a collaborative document.
  *
  * @param  {Context}    ctx                         Standard context object, representing the currently logged in user and its tenant
  * @param  {Content}    contentObj                  The content object to add the extra profile information on.
@@ -155,18 +155,27 @@ var _getFullContentProfile = function(ctx, contentObj, isManager, callback) {
         }
         contentObj.createdBy = createdBy;
 
-        // If the content item is a collaborative document, add the revision data.
-        if (contentObj.resourceSubType === 'collabdoc') {
-            _getRevision(ctx, contentObj, contentObj.latestRevisionId, function(err, revision) {
-                if (err) {
-                    return callback(err);
-                }
-                contentObj.latestRevision = revision;
+        // Check if the user can share this content item
+        _canShareContent(ctx, contentObj, null, function(err, canShare, illegalPrincipalIds) {
+            if (err) {
+                return callback(err);
+            } else {
+                contentObj.canShare = canShare;
+            }
+
+            // If the content item is a collaborative document, add the revision data.
+            if (contentObj.resourceSubType === 'collabdoc') {
+                _getRevision(ctx, contentObj, contentObj.latestRevisionId, function(err, revision) {
+                    if (err) {
+                        return callback(err);
+                    }
+                    contentObj.latestRevision = revision;
+                    callback(null, contentObj);
+                });
+            } else {
                 callback(null, contentObj);
-            });
-        } else {
-            callback(null, contentObj);
-        }
+            }
+        });
     });
 };
 
@@ -685,7 +694,7 @@ var shareContent = module.exports.shareContent = function(ctx, contentId, princi
  *
  * @param  {Context}    ctx                             The context of the current request
  * @param  {Content}    contentObj                      The content to test for access
- * @param  {String[]}   principalIds                    The principalIds with which the user wishes to share the discussion
+ * @param  {String[]}   principalIds                    The principalIds with which the user wishes to share the content
  * @param  {Function}   callback                        Invoked when the process completes
  * @param  {Object}     callback.err                    An error that occurred, if any
  * @param  {Boolean}    callback.canShare               `true` if the user in context is allowed to perform this share operation. `false` otherwise

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -168,9 +168,10 @@ describe('Content', function() {
      * @param  {Boolean}            expectAccess        Whether or not we expect the current user to have access to the piece of content
      * @param  {Boolean}            expectManager       Whether or not we expect the current user to be able to manage the piece of content
      * @param  {Boolean}            expectInLibrary     Whether or not we expect the current user to see the item in the creator's library
+     * @param  {Boolean}            expectCanShare      Whether or not we expect the current user to be allowed to share the content
      * @param  {Function}           callback            Standard callback function executed when all checks have finished
      */
-    var checkPieceOfContent = function(restCtx, libraryToCheck, contentObj, expectAccess, expectManager, expectInLibrary, callback) {
+    var checkPieceOfContent = function(restCtx, libraryToCheck, contentObj, expectAccess, expectManager, expectInLibrary, expectCanShare, callback) {
         // Check whether the content can be retrieved
         RestAPI.Content.getContent(restCtx, contentObj.id, function(err, retrievedContent) {
             if (expectAccess) {
@@ -191,6 +192,7 @@ describe('Content', function() {
                 assert.equal(retrievedContent.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
                 // Check if the canManage check is appropriate
                 assert.equal(retrievedContent.isManager, expectManager);
+                assert.equal(retrievedContent.canShare, expectCanShare);
             } else {
                 assert.ok(err);
                 assert.ok(!retrievedContent);
@@ -1570,11 +1572,11 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                         // Get the piece of content as a different logged in user
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, true, true, function() {
                             // Get the piece of content as an anonymous user
-                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, true, callback);
+                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, true, false, callback);
                         });
                     });
                 });
@@ -1593,11 +1595,11 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                         // Get the piece of content as a different logged in user
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, true, true, function() {
                             // Get the piece of content as an anonymous user
-                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, callback);
+                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
                         });
                     });
                 });
@@ -1616,11 +1618,11 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                         // Get the piece of content as a different logged in user
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, function() {
                             // Get the piece of content as an anonymous user
-                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, callback);
+                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
                         });
                     });
                 });
@@ -1640,15 +1642,15 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                         // Get the piece of content as another manager
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
                             // Get the piece of content as a viewer
-                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, function() {
+                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, false, function() {
                                 // Get the piece of content as a non-member
-                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, function() {
+                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, function() {
                                     // Get the piece of content as an anonymous user
-                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, callback);
+                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
                                 });
                             });
                         });
@@ -1670,15 +1672,15 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                         // Get the piece of content as another manager
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
                             // Get the piece of content as a viewer
-                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, function() {
+                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, false, function() {
                                 // Get the piece of content as a non-member
-                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, function() {
+                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, function() {
                                     // Get the piece of content as an anonymous user
-                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, callback);
+                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
                                 });
                             });
                         });
@@ -1700,15 +1702,15 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                         // Get the piece of content as another manager
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
                             // Get the piece of content as a viewer
-                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, function() {
+                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, false, function() {
                                 // Get the piece of content as a non-member
-                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, function() {
+                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, function() {
                                     // Get the piece of content as an anonymous user
-                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, callback);
+                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
                                 });
                             });
                         });
@@ -2444,42 +2446,42 @@ describe('Content', function() {
                 assert.ok(!err);
                 assert.ok(contentObj.id);
                 // Get the piece of content as the creator
-                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                     // Make a user a manager and make a user a member
                     var permissions = {};
                     permissions[contexts['simon'].user.id] = 'manager';
                     permissions[contexts['bert'].user.id] = 'viewer';
                     RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                         assert.ok(!err);
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, function() {
-                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
+                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, (privacy !== 'private'), function() {
                                 // Share the content with another user
                                 RestAPI.Content.shareContent(contexts['simon'].restContext, contentObj.id, [contexts['stuart'].user.id], function(err) {
                                     assert.ok(!err);
-                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, function() {
+                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, (privacy !== 'private'), function() {
                                         // Try to delete the content as an anonymous user
                                         RestAPI.Content.deleteContent(anonymousRestContext, contentObj.id, function(err) {
                                             assert.ok(err);
                                             // Check that it is still around
-                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                                                 // Try to delete the content as a logged in user
                                                 RestAPI.Content.deleteContent(contexts['anthony'].restContext, contentObj.id, function(err) {
                                                     assert.ok(err);
                                                     // Check that it is still around
-                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                                                         // Try to delete the content as a content member
                                                         RestAPI.Content.deleteContent(contexts['stuart'].restContext, contentObj.id, function(err) {
                                                             assert.ok(err);
                                                             // Check that it is still around
-                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                                                                 // Try to delete the content as a content manager
                                                                 RestAPI.Content.deleteContent(contexts['nicolaas'].restContext, contentObj.id, function(err) {
                                                                     assert.ok(!err);
                                                                     // Check to see if the manager, a member, a logged in user and the anonymous user still have access
-                                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, function() {
-                                                                        checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, false, false, false, function() {
-                                                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, function() {
-                                                                                checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, function() {
+                                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, function() {
+                                                                        checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, false, false, false, false, function() {
+                                                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, function() {
+                                                                                checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, function() {
                                                                                     // Check roles api for the role on the content for a manager, a member and a logged in user
                                                                                     AuthzAPI.getAllRoles(contexts['nicolaas'].user.id, contentObj.id, function(err, roles) {
                                                                                         assert.equal(roles.length, 0);
@@ -2590,7 +2592,7 @@ describe('Content', function() {
                 assert.ok(contentObj.id);
 
                 // Get the piece of content as the person who created the content
-                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                     // Check the list of content members
                     RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
                         assert.ok(!err);
@@ -2611,7 +2613,7 @@ describe('Content', function() {
                             RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                                 assert.ok(!err);
                                 // Get the piece of content as the newly added manager
-                                checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, function() {
+                                checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
                                     RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
                                         assert.ok(!err);
                                         assert.equal(members.results.length, 2);
@@ -2628,7 +2630,7 @@ describe('Content', function() {
                                         RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                                             assert.ok(!err);
                                             // Get the piece of content as the added member
-                                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, function() {
+                                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, true, (privacy !== 'private'), function() {
                                                 RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
                                                     assert.ok(!err);
                                                     assert.equal(members.results.length, 3);
@@ -2647,7 +2649,7 @@ describe('Content', function() {
                                                     RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                                                         assert.ok(err);
                                                         // Get the piece of content as the member that was part of the invalid setPermissions
-                                                        checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, privacy === 'private' ? false : true, false, false, function() {
+                                                        checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), function() {
                                                             RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
                                                                 assert.ok(!err);
                                                                 assert.equal(members.results.length, 3);
@@ -2665,7 +2667,7 @@ describe('Content', function() {
                                                                 RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                                                                     assert.ok(!err);
                                                                     // Get the piece of content as the removed manager
-                                                                    checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, privacy === 'private' ? false : true, false, false, function() {
+                                                                    checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), function() {
                                                                         RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
                                                                             assert.ok(!err);
                                                                             assert.equal(members.results.length, 2);
@@ -2716,9 +2718,9 @@ describe('Content', function() {
             setUpUsers(function(contexts) {
                 setUpContentPermissions(contexts, 'public', function(contentObj) {
                     // Get the piece of content as a non-associated user
-                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, function() {
+                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, true, function() {
                         // Get the piece of content as an anonymous user
-                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, true, callback);
+                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, true, false, callback);
                     });
                 });
             });
@@ -2731,9 +2733,9 @@ describe('Content', function() {
             setUpUsers(function(contexts) {
                 setUpContentPermissions(contexts, 'loggedin', function(contentObj) {
                     // Get the piece of content as a non-associated user
-                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, function() {
+                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, true, function() {
                         // Get the piece of content as an anonymous user
-                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, callback);
+                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
                     });
                 });
             });
@@ -2746,9 +2748,9 @@ describe('Content', function() {
             setUpUsers(function(contexts) {
                 setUpContentPermissions(contexts, 'private', function(contentObj) {
                     // Get the piece of content as a non-associated user
-                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, function() {
+                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, function() {
                         // Get the piece of content as an anonymous user
-                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, callback);
+                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
                     });
                 });
             });
@@ -3126,7 +3128,7 @@ describe('Content', function() {
                 assert.ok(!err);
                 assert.ok(contentObj.id);
                 // Get the piece of content as the creator
-                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, function() {
+                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
                     RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
                         assert.ok(!err);
                         assert.equal(members.results.length, 1);
@@ -3153,16 +3155,17 @@ describe('Content', function() {
          * @param  {Boolean}        expectManager       Whether or not we expect that user 2 will be able to manage the content after it's been shared with him
          * @param  {Boolean}        expectInLibrary     Whether or not we expect user 2 to be able to see the content in his library after it's been shared with him
          * @param  {Object}         expectedMembers     JSON object representing the members that are expected to be on the content item after sharing. The keys represent the member ids and the values represent the role they should have.
+         * @param  {Boolean}         expectCanShare      Whether or not we expect user 2 to be able to share the content with further users
          * @param  {Function}       callback            Standard callback function
          */
-        var testSharing = function(contentObj, sharer, shareWith, expectShare, expectAccess, expectManager, expectInLibrary, expectedMembers, callback) {
+        var testSharing = function(contentObj, sharer, shareWith, expectShare, expectAccess, expectManager, expectInLibrary, expectedMembers, expectCanShare, callback) {
             RestAPI.Content.shareContent(sharer.restContext, contentObj.id, [shareWith.user.id], function(err) {
                 if (expectShare) {
                     assert.ok(!err);
                 } else {
                     assert.ok(err);
                 }
-                checkPieceOfContent(shareWith.restContext, shareWith.user ? shareWith.user.id : null, contentObj, expectAccess, expectManager, expectInLibrary, function() {
+                checkPieceOfContent(shareWith.restContext, shareWith.user ? shareWith.user.id : null, contentObj, expectAccess, expectManager, expectInLibrary, expectCanShare , function() {
                     RestAPI.Content.getMembers(shareWith.restContext, contentObj.id, null, null, function(err, members) {
                         if (expectedMembers) {
                             assert.ok(!err);
@@ -3192,21 +3195,21 @@ describe('Content', function() {
                     var expectedMembers = {};
                     expectedMembers[contexts['nicolaas'].user.id] = 'manager';
                     expectedMembers[contexts['simon'].user.id] = 'viewer';
-                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, function() {
+                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, true, function() {
 
                         // Share as content member
                         expectedMembers[contexts['anthony'].user.id] = 'viewer';
-                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, true, expectedMembers, function() {
+                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, true, expectedMembers, true, function() {
 
                             // Share as other user, add to own library
                             expectedMembers[contexts['stuart'].user.id] = 'viewer';
-                            testSharing(contentObj, contexts['anthony'], contexts['stuart'], true, true, false, true, expectedMembers, function() {
+                            testSharing(contentObj, contexts['anthony'], contexts['stuart'], true, true, false, true, expectedMembers, true, function() {
 
                                 // Share with the content manager, making sure that he's still the content manager after sharing
-                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], false, true, true, true, expectedMembers, function() {
+                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], false, true, true, true, expectedMembers, true, function() {
 
                                     // Share as anonymous
-                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, expectedMembers, callback);
+                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, expectedMembers, true, callback);
                                 });
                             });
                         });
@@ -3228,21 +3231,21 @@ describe('Content', function() {
                     var expectedMembers = {};
                     expectedMembers[contexts['nicolaas'].user.id] = 'manager';
                     expectedMembers[contexts['simon'].user.id] = 'viewer';
-                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, function() {
+                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, true, function() {
 
                         // Share as content member
                         expectedMembers[contexts['anthony'].user.id] = 'viewer';
-                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, true, expectedMembers, function() {
+                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, true, expectedMembers, true, function() {
 
                             // Share as other user, add to own library
                             expectedMembers[contexts['stuart'].user.id] = 'viewer';
-                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], true, true, false, true, expectedMembers, function() {
+                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], true, true, false, true, expectedMembers, true, function() {
 
                                 // Share with the content manager, making sure that he's still the content manager after sharing
-                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], false, true, true, true, expectedMembers, function() {
+                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], false, true, true, true, expectedMembers, true, function() {
 
                                     // Share as anonymous
-                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, expectedMembers, callback);
+                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, expectedMembers, true, callback);
                                 });
                             });
                         });
@@ -3264,19 +3267,19 @@ describe('Content', function() {
                     var expectedMembers = {};
                     expectedMembers[contexts['nicolaas'].user.id] = 'manager';
                     expectedMembers[contexts['simon'].user.id] = 'viewer';
-                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, function() {
+                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, false, function() {
 
                         // Share as content member
-                        testSharing(contentObj, contexts['simon'], contexts['anthony'], false, false, false, false, null, function() {
+                        testSharing(contentObj, contexts['simon'], contexts['anthony'], false, false, false, false, null, false, function() {
 
                             // Share as other user, add to own library
-                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], false, false, false, false, null, function() {
+                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], false, false, false, false, null, false, function() {
 
                                 // Share with the content manager, making sure that he's still the content manager after sharing
-                                testSharing(contentObj, contexts['simon'], contexts['nicolaas'], false, true, true, true, expectedMembers, function() {
+                                testSharing(contentObj, contexts['simon'], contexts['nicolaas'], false, true, true, true, expectedMembers, true, function() {
 
                                     // Share as anonymous
-                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, false, false, false, null, callback);
+                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, false, false, false, null, false, callback);
                                 });
                             });
                         });
@@ -3299,16 +3302,16 @@ describe('Content', function() {
                         assert.ok(!err);
 
                         // Check that these people have access
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, true, function() {
-                            checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, true, false, true, function() {
-                                checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, function() {
-                                    checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, true, false, function() {
+                            checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, true, false, true, false, function() {
+                                checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, false, function() {
+                                    checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, function() {
 
                                         // Share with multiple people, of which some are invalid users
                                         toShare = [contexts['anthony'].user.id, 'u:cam:nonExistingUser'];
                                         RestAPI.Content.shareContent(contexts['nicolaas'].restContext, contentObj.id, toShare, function(err) {
                                             assert.ok(err);
-                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, callback);
+                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, callback);
                                         });
                                     });
                                 });
@@ -3369,9 +3372,9 @@ describe('Content', function() {
                 RestAPI.Content.updateMembers(contexts['anthony'].restContext, contentObj.id, permissions, function(err) {
                     assert.ok(!err);
                     // Check that UI Dev Team, Bert, Nico and Simon have member access
-                    checkPieceOfContent(contexts['bert'].restContext, groups['ui-team'].id, contentObj, true, false, true, function() {
-                        checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, function() {
-                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, false, function() {
+                    checkPieceOfContent(contexts['bert'].restContext, groups['ui-team'].id, contentObj, true, false, true, (privacy !== 'private'), function() {
+                        checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
+                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
                                 // Check that it shows in UI Dev Team's library
                                 RestAPI.Content.getLibrary(contexts['nicolaas'].restContext, groups['ui-team'].id, null, 10, function(err, contentItems) {
                                     assert.ok(!err);
@@ -3398,16 +3401,16 @@ describe('Content', function() {
                                                         assert.ok(!err);
                                                         assert.equal(contentItems.results.length, 0);
                                                         // Check that Stuart doesn't have access
-                                                        checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, privacy === 'private' ? false : true, false, false, function() {
+                                                        checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), function() {
                                                             // Check that Branden doesn't have access
-                                                            checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, privacy === 'private' ? false : true, false, false, function() {
+                                                            checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), function() {
 
                                                                 // Share with the OAE Team group
                                                                 RestAPI.Content.shareContent(contexts['anthony'].restContext, contentObj.id, [groups['oae-team'].id], function(err) {
                                                                     // Check that Stuart has access
-                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, function() {
+                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
                                                                         // Check that Branden has access
-                                                                        checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, function() {
+                                                                        checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
                                                                             // Check that it shows in OAE Team and UI Dev team's library and not in the Back-End Team's library
                                                                             RestAPI.Content.getLibrary(contexts['anthony'].restContext, groups['oae-team'].id, null, 10, function(err, contentItems) {
                                                                                 assert.ok(!err);
@@ -3427,9 +3430,9 @@ describe('Content', function() {
                                                                                         RestAPI.Content.updateMembers(contexts['anthony'].restContext, contentObj.id, permissions, function(err) {
                                                                                             assert.ok(!err);
                                                                                             // Check that Simon and Branden are manager, check that Stuart is not a manager
-                                                                                            checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, function() {
-                                                                                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, true, false, function() {
-                                                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, function() {
+                                                                                            checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
+                                                                                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, true, false, true, function() {
+                                                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
 
                                                                                                         // Remove permission for Back-end team manager and OAE Team
                                                                                                         permissions = {};
@@ -3438,9 +3441,9 @@ describe('Content', function() {
                                                                                                         RestAPI.Content.updateMembers(contexts['anthony'].restContext, contentObj.id, permissions, function(err) {
                                                                                                             assert.ok(!err);
                                                                                                             // Check that Branden no longer has access, but Simon and Nico still do
-                                                                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, function() {
-                                                                                                                checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, true, function() {
-                                                                                                                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, privacy === 'private' ? false : true, false, false, callback);
+                                                                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
+                                                                                                                checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, true, (privacy !== 'private'), function() {
+                                                                                                                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), callback);
                                                                                                                 });
                                                                                                             });
                                                                                                         });


### PR DESCRIPTION
The backend should provide the standard `canShare` property on the full content profile to help the UI with this logic.

Also, the same issue happens on the UI for discussions, and its `canShare` is there for the UI to use
