### PR TITLE
Unnecessary beforeEach in test-groups.js

### DIFF
--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -42,7 +42,7 @@ describe('Groups', function() {
     /**
      * Function that will create a user that will be used inside of the tests
      */
-    beforeEach(function(callback) {
+    before(function(callback) {
         // Create all the REST contexts before each test
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);


### PR DESCRIPTION
The oae-principals/tests/test-groups.js file seems to use an unnecessary beforeEach function that fills up the rest contexts and creates a test user before each individual test. It looks like changing this to a `before` function should work.
