### PR TITLE
TinCan API issues

### DIFF
--- a/node_modules/oae-tincanapi/config/tincanapi.js
+++ b/node_modules/oae-tincanapi/config/tincanapi.js
@@ -22,8 +22,8 @@ module.exports = {
         'description': 'Learning Record Store configuration',
         'elements': {
             'enabled': new Fields.Bool('LRS enabled', 'Learning Record Store integration enabled for tenant', false, {'suppress': true}),
-            'appid': new Fields.Text('LRS App ID', 'The LRS application ID', '3HQ4Q12B57', {'suppress': true}),
-            'appsecret': new Fields.Text('LRS App Secret', 'The LRS application Secret', 'Wzoy9WJEqTYpf2E3pAjJTYAzZSmvpT3WO3iF4g3d', {'suppress': true}),
+            'username': new Fields.Text('LRS username', 'The LRS username', '3HQ4Q12B57', {'suppress': true}),
+            'password': new Fields.Text('LRS password', 'The LRS password', 'Wzoy9WJEqTYpf2E3pAjJTYAzZSmvpT3WO3iF4g3d', {'suppress': true}),
             'endpoint': new Fields.Text('LRS URL', 'The TinCan API REST endpoint', 'https://cloud.scorm.com/tc/3HQ4Q12B57/statements', {'suppress': true})
         }
     }

--- a/node_modules/oae-tincanapi/lib/api.js
+++ b/node_modules/oae-tincanapi/lib/api.js
@@ -150,8 +150,8 @@ var sendStatementsToLRS = module.exports.sendActivitiesToLRS = function(statemen
             'url': TinCanConfig.getValue(tenantAlias, 'lrs', 'endpoint'),
             'timeout': config.timeout,
             'auth': {
-                'user': TinCanConfig.getValue(tenantAlias, 'lrs', 'appid'),
-                'pass': TinCanConfig.getValue(tenantAlias, 'lrs', 'appsecret'),
+                'user': TinCanConfig.getValue(tenantAlias, 'lrs', 'username'),
+                'pass': TinCanConfig.getValue(tenantAlias, 'lrs', 'password'),
                 'sendImmediately': true
             },
             'headers': {


### PR DESCRIPTION
The TinCan API integration was tested by Alan Berg and he reported the following problems:

```
I have set up a reference implementation (https://github.com/adlnet/ADL_LRS) of an LRS over SSL at https://draco.ic.uva.nl
The LRS supports OAUTH and basic auth. 

You can self register at: https://draco.ic.uva.nl/xapi/register/

I added details to the QA server:

Under the Learning Record Store Configuration

The LRS application ID OAE_STREAM_1
The LRS application secret: Added the server secret. Would prefer the input box as a password box and not text.
API REST POINT: https://draco.ic.uva.nl/xapi/statements

(note:The REST point expects a header with version 1 of X-Experience-API-Version)

Saved configuration, but did not restart the tenant.

I created a user (alanberg) and uploaded a couple of files etc. 

On the OAE server the recent activity showed only the first event. No events were seen by draco or attempts in the webserver log file.

Questions:

1) Has the recent activity in OAE stopped because of failing to make a connection to the LRS
2) What is the meaning of:
     The LRS application ID
     The LRS application secret
     The LRS application secret - Is this the server secret or one generated for OAUTH
3) What is the authentication method
4) Should I restart the tenant
```

It would be good to investigate what the issue is. Let me know if there is anything else you need from Alan.
