### PR TITLE
Build Failure: multiparty now always returns arrays for parameters

### DIFF
--- a/node_modules/oae-activity/lib/rest.js
+++ b/node_modules/oae-activity/lib/rest.js
@@ -35,6 +35,7 @@ var ActivityAPI = require('oae-activity');
 var _handleGetActivities = function(activityStreamId, req, res) {
     var limit = OaeUtil.getNumberParam(req.query.limit, 10, 1, 25);
     var start = req.query.start;
+
     ActivityAPI.getActivityStream(req.ctx, activityStreamId, start, limit, function(err, activityStream) {
         if (err) {
             return res.send(err.code, err.msg);

--- a/node_modules/oae-content/lib/internal/util.js
+++ b/node_modules/oae-content/lib/internal/util.js
@@ -26,6 +26,8 @@ var TenantsUtil = require('oae-tenants/lib/util');
 var ContentConfig = require('oae-config').config('oae-content');
 var ContentConstants = require('oae-content/lib/constants').ContentConstants;
 
+var log = require('oae-logger').logger('oae-content-util');
+
 /**
  * Get the storage backend for a uri, if the uri is unspecified it will return the default backend
  * for a tenant. If the backend could not be found, this will throw an error! The uri will be checked

--- a/node_modules/oae-content/lib/rest.js
+++ b/node_modules/oae-content/lib/rest.js
@@ -27,6 +27,7 @@ var ContentConstants = require('./constants').ContentConstants;
  * Create a new piece of content
  */
 OAE.tenantRouter.on('post', '/api/content/create', function(req, res) {
+
     // Pick the managers and viewers off the request
     var additionalMembers = {};
     if (req.body.managers) {

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -290,6 +290,7 @@ describe('Content', function() {
          */
         it('verify download content', function(callback) {
             setUpUsers(function(contexts) {
+
                 // Create a piece of content
                 RestAPI.Content.createFile(contexts['nicolaas'].restContext, 'Test Content 1', 'Test content description 1', 'private', getFileStream, [], [], function(err, contentObj) {
                     assert.ok(!err);
@@ -300,9 +301,9 @@ describe('Content', function() {
                         assert.ok(!err);
                         assert.equal(contentObj.downloadPath, '/api/content/' + contentObj.id + '/download/' + contentObj.latestRevisionId);
 
-                        // Download it.
-                        // The App servers don't really stream anything.
-                        // In the tests we're using local storage, so this should result in a 204 (empty body) with the link in the x-accel-redirect header.
+                        // Download it
+                        // The App servers don't really stream anything
+                        // In the tests we're using local storage, so this should result in a 204 (empty body) with the link in the x-accel-redirect header
                         var path = temp.path();
                         RestAPI.Content.download(contexts['nicolaas'].restContext, contentObj.id, null, path, function(err, response) {
                             assert.ok(!err);
@@ -319,7 +320,7 @@ describe('Content', function() {
                                 RestAPI.Content.shareContent(contexts['nicolaas'].restContext, contentObj.id, [contexts['simon'].user.id], function(err) {
                                     assert.ok(!err);
 
-                                    // Simon should now be able to fetch it.
+                                    // Simon should now be able to fetch it
                                     path = temp.path();
                                     RestAPI.Content.download(contexts['simon'].restContext, contentObj.id, null, path, function(err, response) {
                                         assert.ok(!err);
@@ -327,6 +328,7 @@ describe('Content', function() {
                                         assert.ok(headerKeys.indexOf('x-accel-redirect') !== -1);
                                         assert.ok(headerKeys.indexOf('x-sendfile') !== -1);
                                         assert.ok(headerKeys.indexOf('x-lighttpd-send-file') !== -1);
+
                                         callback();
                                     });
                                 });

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -645,7 +645,9 @@ describe('Preview processor', function() {
                         assert.ok(content.previews.smallUrl);
                         _verifySignedUriDownload(restCtx, content.previews.smallUrl, function() {
                             assert.ok(content.previews.mediumUrl);
-                            _verifySignedUriDownload(restCtx, content.previews.mediumUrl, callback);
+                            _verifySignedUriDownload(restCtx, content.previews.mediumUrl, function() {
+                                return server.close(callback);
+                            });
                         });
                     });
                 });

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -40,11 +40,12 @@ var User = require('oae-principals/lib/model').User;
 var createTestServer = module.exports.createTestServer = function(callback, _attempts) {
     _attempts = _attempts || 0;
     if (_attempts === 10) {
-        assert.fail('Could not spin up a webserver in 10 attempts');
+        assert.fail('Could not start a test web server in 10 attempts');
     }
 
     var port = 2500 + Math.floor(Math.random() * 1000);
     var app = express();
+
     app.use(express.urlencoded());
     app.use(express.json());
     app.use(multipart());

--- a/node_modules/oae-tincanapi/tests/test-tincanapi.js
+++ b/node_modules/oae-tincanapi/tests/test-tincanapi.js
@@ -38,9 +38,11 @@ describe('TinCanAPI', function() {
     // Rest context that can be used every time we need to make a request as a gt tenant admin
     var gtAdminRestContext = null;
 
+    var server = null;
+
     /**
-    * Initializes the admin REST contexts
-    */
+     * Initializes the admin REST contexts
+     */
     before(function(callback) {
 
         // Fill up the global admin rest context
@@ -51,15 +53,15 @@ describe('TinCanAPI', function() {
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
 
         // Create a new express application to mock a Learning Record Store
-        TestsUtil.createTestServer(function(app, server, port) {
-
-            app.post('/', function(req, res) {
+        TestsUtil.createTestServer(function(_app, _server, _port) {
+            server = _server;
+            _app.post('/', function(req, res) {
                 onRequest(req);
                 res.send(200);
             });
             
             // Set the endpoint for the LRS
-            ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-tincanapi/lrs/endpoint': 'http://localhost:' + port}, function(err) {
+            ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-tincanapi/lrs/endpoint': 'http://localhost:' + _port}, function(err) {
                 assert.ok(!err);
                 callback();
             });
@@ -67,13 +69,20 @@ describe('TinCanAPI', function() {
     });
 
     /**
-    * Disables the LRS for the tenant after each test
-    */
-    afterEach(function(callback){
+     * Disables the LRS for the tenant after each test
+     */
+    afterEach(function(callback) {
         ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-tincanapi/lrs/enabled': false}, function(err) {
             assert.ok(!err);
-            callback();
+            return callback();
         });
+    });
+
+    /**
+     * Close the tin can api mock LRS
+     */
+    after(function(callback) {
+        return server.close(callback);
     });
 
     /**

--- a/node_modules/oae-util/lib/middleware/multipart.js
+++ b/node_modules/oae-util/lib/middleware/multipart.js
@@ -92,7 +92,7 @@ module.exports = function(formOptions) {
 
                 if (_.isArray(value)) {
                     // If the user uploaded multiple files for a key, map them all to the simple file object
-                    req.files[key] = _.map(_mapToFile);
+                    req.files[key] = _.map(value, _mapToFile);
                 } else {
                     req.files[key] = _mapToFile(value);
                 }

--- a/node_modules/oae-util/lib/signature.js
+++ b/node_modules/oae-util/lib/signature.js
@@ -31,7 +31,6 @@ var init = module.exports.init = function(signingConfig) {
     signKey = signingConfig.key;
 
     if (signKey === 'The default signing key, please change me.') {
-        // TODO: This will most likely end-up in bootstrap.log, which might be overlooked, console.log?
         var warningMessage = 'You are using the default key to sign URLs, this is *NOT* secure and should be changed immediately.\n';
         warningMessage += 'The system will continue to function, but it is strongly recommended that you change your key.\n';
         log().warn(warningMessage);

--- a/node_modules/oae-util/tests/test-server.js
+++ b/node_modules/oae-util/tests/test-server.js
@@ -15,9 +15,11 @@
 
 var _ = require('underscore');
 var assert = require('assert');
+var fs = require('fs');
 
 var OaeServer = require('oae-util/lib/server');
 var RestAPI = require('oae-rest');
+var RestUtil = require('oae-rest/lib/util');
 var TestsUtil = require('oae-tests');
 
 describe('OAE Server', function() {
@@ -117,6 +119,39 @@ describe('OAE Server', function() {
                         });
                     });
                 });
+            });
+        });
+    });
+
+    describe('Multipart Uploads', function() {
+
+        /**
+         * Utility method that returns a file stream
+         *
+         * @return {Stream}     A file stream
+         */
+        var getFileStream = function() {
+            return fs.createReadStream(__dirname + '/data/banditos.txt');
+        };
+
+        /**
+         * Test that verifies multiple files can be uploaded in the same request parameter
+         */
+        it('verify multiple files can be uploaded in the same request parameter', function(callback) {
+            TestsUtil.createTestServer(function(app, server, port) {
+
+                app.post('/testUploadFiles', function(request, response) {
+                    assert.ok(_.isArray(request.files.testFiles));
+                    assert.strictEqual(request.files.testFiles.length, 2);
+                    assert.equal(request.files.testFiles[0].name, 'banditos.txt');
+                    assert.equal(request.files.testFiles[1].name, 'banditos.txt');
+
+                    response.send(200);
+                    server.close(callback);
+                });
+
+                var opts = {'method': 'POST', 'url': 'http://localhost:' + port + '/testUploadFiles'};
+                RestUtil.request(opts, {'testFiles': [getFileStream, getFileStream]});
             });
         });
     });


### PR DESCRIPTION
This is changed in multiparty 3. We should sniff out single-element arrays and instead use the original value to keep it consistent with other request parsers.
