### PR TITLE
numerous unit test failures after elasticsearch upgrade to 0.90.6

### DIFF
--- a/node_modules/oae-search/lib/api.js
+++ b/node_modules/oae-search/lib/api.js
@@ -418,29 +418,41 @@ var _handleIndexDocumentTask = function(data, callback) {
                     if (allDocs.length > 1) {
                         var ops = SearchUtil.createBulkIndexOperations(allDocs);
                         client.bulk(ops, function(err) {
-                            if (!err) {
-                                log().info('Successfully indexed %s documents.', allDocs.length);
+                            if (err) {
+                                log().error({'err': err, 'ops': ops}, 'Error indexing %s documents', allDocs.length);
+                            } else {
+                                log().debug('Successfully indexed %s documents', allDocs.length);
                             }
+
                             return callback(err);
                         });
                     } else if (allDocs.length === 1) {
                         var doc = allDocs[0];
-                        var opts = {'parent': doc['_parent']};
                         var id = doc.id;
+                        var opts = {};
+
+                        if (doc['_parent']) {
+                            opts.parent = doc['_parent'];
+                        }
 
                         delete doc['_parent'];
                         delete doc.id;
+                        client.index(doc['_type'], id, doc, opts, function(err) {
+                            if (err) {
+                                log().error({'err': err, 'id': id, 'doc': doc, 'opts': opts}, 'Error indexing a document');
+                            }
 
-                        client.index(doc['_type'], id, doc, opts, callback);
+                            return callback(err);
+                        });
                     } else {
-                        callback();
+                        return callback();
                     }
                 });
             });
         });
     } else {
         log().warn('Ignoring %s documents of type "%s", which do not have an associated document producer.', data.resources.length, resourceType);
-        callback();
+        return callback();
     }
 };
 

--- a/node_modules/oae-search/lib/internal/elasticsearch.js
+++ b/node_modules/oae-search/lib/internal/elasticsearch.js
@@ -209,7 +209,7 @@ var search = module.exports.search = function(query, options, callback) {
  * @param  {Object}    callback.err    An error that occurred, if any
  */
 var index = module.exports.index = function(typeName, id, doc, options, callback) {
-    log().trace({ 'typeName': typeName, 'id': id, 'document': doc, 'options': options }, 'Indexing a document.');
+    log().trace({ 'typeName': typeName, 'id': id, 'document': doc, 'options': options }, 'Indexing a document');
     return _exec('index', client.index(index, typeName, doc, id, options), callback);
 };
 

--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -228,10 +228,13 @@ var createBulkIndexOperations = module.exports.createBulkIndexOperations = funct
         var meta = {
             'index': {
                 '_type': doc['_type'] || SearchConstants.resourceMappingName,
-                '_id': doc['id'],
-                '_parent': doc['_parent']
+                '_id': doc['id']
             }
         };
+
+        if (doc['_parent']) {
+            meta.index['_parent'] = doc['_parent'];
+        }
 
         // These meta attributes have been promoted and shouldn't be on the core doc anymore
         delete doc.id;


### PR DESCRIPTION
After upgrading elasticsearch to 0.90.6 the tests take ~23 minutes to complete and I've seen anywhere between 4 to 30 test failures, usually starting with search failures followed by timeout failures. Elasticsearch 0.90.1 and 0.90.5 both work fine.
