### PR TITLE
Host header should be compared case-insensitive

### DIFF
--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -274,6 +274,7 @@ var updateTenant = module.exports.updateTenant = function(ctx, alias, tenantUpda
             validator.check(updateValue, {'code': 400, 'msg': 'A displayName cannot be empty'}).notEmpty();
         } else if (updateField === 'host') {
             validator.check(updateValue, {'code': 400, 'msg': 'A hostname cannot be empty'}).notEmpty();
+            validator.check(getTenantByHost(updateValue), {'code': 400, 'msg': 'The hostname has already been taken'}).isNull();
         }
     });
     if (validator.hasErrors()) {
@@ -395,7 +396,7 @@ var _copyTenant = function(tenant) {
         return null;
     }
 
-    return new Tenant(tenant.alias, tenant.displayName, tenant.host.toLowerCase(), {
+    return new Tenant(tenant.alias, tenant.displayName, tenant.host, {
         'active': tenant.active,
         'deleted': tenant.deleted,
         'isGlobalAdminServer': tenant.isGlobalAdminServer

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -220,25 +220,6 @@ describe('Tenants', function() {
             assert.ok(!tenant);
             callback();
         });
-
-        /**
-         * Test that verifies that a tenant can be retrieved using an uppercase host name
-         */
-        it('verify get tenant uppercase host', function(callback) {
-            RestAPI.Tenants.createTenant(globalAdminRestContext, 'uppercaseget', 'Uppercase University', 'uPPerCasEunIverSIty.oae.com', function(err) {
-                assert.ok(!err);
-
-                // Verify that the tenant can be accessed with an uppercase host name
-                var uppercaseRestContext = TestsUtil.createTenantRestContext('uPPerCasEunIverSIty.oae.com');
-                RestAPI.Tenants.getTenant(uppercaseRestContext, null, function(err, tenant) {
-                    assert.ok(!err);
-                    assert.ok(tenant);
-                    assert.equal(tenant.alias, 'uppercaseget');
-                    assert.equal(tenant.host, 'uppercaseuniversity.oae.com');
-                    callback();
-                });
-            });
-        });
     });
 
 
@@ -324,14 +305,14 @@ describe('Tenants', function() {
         });
 
         /**
-         * Test that verifies that an uppercase host name for a tenant is lowercased
+         * Test that verifies that an uppercase host name for a tenant is lowercased and a tenant can be retrieved using an uppercase host name
          */
         it('verify create tenant uppercase host', function(callback) {
             RestAPI.Tenants.createTenant(globalAdminRestContext, 'uppercasepost', 'Uppercase', 'uPPerCasE.oae.com', function(err) {
                 assert.ok(!err);
 
                 // Verify that the existing tenant is still running
-                var uppercaseRestContext = TestsUtil.createTenantRestContext('uppercase.oae.com');
+                var uppercaseRestContext = TestsUtil.createTenantRestContext('uPPerCasE.oae.com');
                 RestAPI.Tenants.getTenant(uppercaseRestContext, null, function(err, tenant) {
                     assert.ok(!err);
                     assert.ok(tenant);
@@ -644,7 +625,13 @@ describe('Tenants', function() {
                                 RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'alias': 'foobar', 'displayName': 'Anglia Ruskin University'}, function(err) {
                                     assert.ok(err);
                                     assert.equal(err.code, 400);
-                                    callback();
+
+                                    // Verify updating to host that's already used
+                                    RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'host': 'caMBriDGe.oae.com'}, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 400);
+                                        callback();
+                                    });
                                 });
                             });
                         });


### PR DESCRIPTION
Currently if the host header you put for a tenant has an upper case, it will never be resolvable by a browser because browsers lower-case.

We should validate that all host headers are lower-case when they are provided, and do case-insensitive checks against host headers that are provided by the client when identifying the tenant.
