### PR TITLE
Build Failure: Timezones

### DIFF
--- a/node_modules/oae-util/lib/validator.js
+++ b/node_modules/oae-util/lib/validator.js
@@ -215,8 +215,7 @@ Validator.prototype.isBoolean = function(val) {
  */
 Validator.prototype.isValidTimeZone = function() {
     try {
-        var date = new tz.Date(this.str);
-        if (date.getTimezone() === null) {
+        if (!tz.timezone.zones[this.str] || this.str.indexOf('/') === -1) {
             throw new Error();
         }
     } catch (error) {

--- a/node_modules/oae-util/tests/test-validator.js
+++ b/node_modules/oae-util/tests/test-validator.js
@@ -351,6 +351,7 @@ describe('Utilities', function() {
 
             // None of those ogre timezones either.
             validateTimeZone('SfajslhfafhjlksahjklafT', false);
+            validateTimeZone('Sfajslhfafhj/lksahjklafT', false);
             callback();
         });
 


### PR DESCRIPTION
This appears to be failing in Travis:

```

[0m  1) Utilities Validator verify timezone validation:
[0m[31m     AssertionError: Failed on EST[0m[90m
      at validateTimeZone (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/tests/test-validator.js:321:24)
      at Context.<anonymous> (/home/travis/build/oaeproject/Hilary/node_modules/oae-util/tests/test-validator.js:348:13)
      at Test.Runnable.run (/home/travis/build/oaeproject/Hilary/node_modules/mocha/lib/runnable.js:194:15)
      at Runner.runTest (/home/travis/build/oaeproject/Hilary/node_modules/mocha/lib/runner.js:372:10)
      at /home/travis/build/oaeproject/Hilary/node_modules/mocha/lib/runner.js:448:12
      at next (/home/travis/build/oaeproject/Hilary/node_modules/mocha/lib/runner.js:297:14)
      at /home/travis/build/oaeproject/Hilary/node_modules/mocha/lib/runner.js:307:7
      at next (/home/travis/build/oaeproject/Hilary/node_modules/mocha/lib/runner.js:245:23)
      at Object._onImmediate (/home/travis/build/oaeproject/Hilary/node_modules/mocha/lib/runner.js:274:5)
      at processImmediate [as _immediateCallback] (timers.js:330:15)
```
