### PR TITLE
Initial attempt at supporting coveralls.io

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ services:
   - redis-server
 
 script:
-  - grunt
+  - grunt test-coverage-coveralls
 
 after_failure:
   - cat tests.log | node_modules/.bin/bunyan -l info

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
     var _ = require('underscore');
     var path = require('path');
     var shell = require('shelljs');
+    var util = require('util');
     var mocha_grep = process.env['MOCHA_GREP'] || undefined;
 
     // Timeout used to determine when a test has failed
@@ -70,13 +71,6 @@ module.exports = function(grunt) {
             }
         },
         'clean': ['target/'],
-        'copy': {
-            'coverage': {
-                'files': {
-                    'target/': '**'
-                }
-            }
-        },
         'replace': {
             'check-style': {
                 'src': ['node_modules/oae-*/**/*.js'],
@@ -140,6 +134,9 @@ module.exports = function(grunt) {
         }
     });
 
+    // Override default test task to use mocha-hack
+    grunt.registerTask('test', ['mocha-hack']);
+
     // Make a task for running tests on a single module
     grunt.registerTask('test-module', 'Test a single module', function(module) {
         var config = {
@@ -155,24 +152,48 @@ module.exports = function(grunt) {
         grunt.task.run('mocha-hack:' + module);
     });
 
-    // Make a task for running jscoverage
-    grunt.registerTask('jscoverage', 'Run jscoverage on the `target` dir', function() {
-        grunt.task.requires('copy:coverage');
-        shell.exec('node node_modules/oae-tests/runner/instrument_code.js "' + __dirname + '"');
-        grunt.log.writeln('Code instrumented'.green);
+    // Runs the unit tests and dumps some coverage data
+    grunt.registerTask('test-instrumented', function(report) {
+        // If no report format was provided, we default to `lcov` which generates lcov and html
+        report = report || 'lcov';
+
+        // Get the modules that should be excluded
+        var nonOaeModules = grunt.file.expand({'filter': 'isDirectory'}, 'node_modules/*', '!node_modules/oae-*');
+        var nonOaeModulesParameters = _.map(nonOaeModules, function(module) {
+            return util.format('-x %s/\\*\\*', module);
+        });
+
+        // Exclude the tests from the coverage reports
+        var oaeModules = grunt.file.expand({'filter': 'isDirectory'}, 'node_modules/oae-*');
+        var testDirectories = _.map(oaeModules, function(directory) {
+            return util.format('-x %s/tests/\\*\\*', directory);
+        });
+
+        // Exclude the config directories
+        var configDirectories = _.map(oaeModules, function(module) {
+            return util.format('-x %s/config/\\*\\*', module);
+        });
+
+        // Build up one big set of exlusion filters
+        var excludeFilters = _.union(nonOaeModulesParameters, testDirectories, configDirectories);
+        excludeFilters.push('-x Gruntfile.js');
+
+        var cmd = util.format('node_modules/.bin/istanbul cover --verbose --dir target --no-default-excludes %s --report %s ./node_modules/grunt-cli/bin/grunt', excludeFilters.join(' '), report);
+        shell.exec(cmd);
     });
 
-    grunt.registerTask('test-instrumented', 'Runs mocha tests on the instrumented code', function() {
-        // Mocha can't write to a file and mocha-hack doesn't add that functionality, so we'll just shell.exec it here since we need the output :P
-        shell.cd('target');
-        // Set a covering environment variable, as this will be used to determine where the UI resides relative to the Hilary folder.
-        shell.env['OAE_COVERING'] = true;
-        var MODULES = grunt.file.expand({'filter': 'isDirectory'},'node_modules/oae-*/tests').join(' ');
-        var output = shell.exec('../node_modules/.bin/mocha --ignore-leaks --timeout ' + MOCHA_TIMEOUT + ' --reporter html-cov node_modules/oae-tests/runner/beforeTests.js ' + MODULES, {silent:true}).output;
-        output.to('coverage.html');
-        grunt.log.writeln('Code Coverage report generated at target/coverage.html'.cyan);
-
+    // Sends a coverage report to coveralls.io
+    grunt.registerTask('coveralls', function() {
+        // This assumes we're executing within the context of Travis CI
+        // If not, you'll have to add a .converalls.yml file with `repo_token: ...` in it
+        shell.exec('cat ./target/lcov.info | ./node_modules/coveralls/bin/coveralls.js');
     });
+
+    // Run test coverage and open the report
+    grunt.registerTask('test-coverage', ['clean', 'test-instrumented', 'showFile:target/lcov-report/index.html']);
+
+    // Run test coverage
+    grunt.registerTask('test-coverage-coveralls', ['clean', 'test-instrumented:lcovonly', 'coveralls']);
 
     // Make a task to open the browser
     grunt.registerTask('showFile', 'Open a file with the OS default viewer', function(file) {
@@ -196,13 +217,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-mocha-hack');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-text-replace');
-
-    // Override default test task to use mocha-hack
-    grunt.registerTask('test', ['mocha-hack']);
-    // Run test coverage and open the report
-    grunt.registerTask('test-coverage', ['clean', 'copy:coverage', 'jscoverage', 'test-instrumented', 'showFile:coverage.html']);
 
     // Copies the files that need to go in the release.
     // We remove the test files and the Grunt file as it could be potentially

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-
 # Open Academic Environment (OAE Project)
 
 Hilary is the back-end for the [Open Academic Environment](http://www.oaeproject.org/)
 
 ## Build status
 [![Build Status](https://travis-ci.org/oaeproject/Hilary.png?branch=master)](https://travis-ci.org/oaeproject/Hilary)
+[![Coverage Status](https://coveralls.io/repos/oaeproject/Hilary/badge.png)](https://coveralls.io/r/oaeproject/Hilary) (excluding preview processing tests)
 
 ## Quickstart Guide
 

--- a/package.json
+++ b/package.json
@@ -95,13 +95,14 @@
     "youtube-feeds": "latest"
   },
   "devDependencies": {
+    "coveralls": "latest",
     "grunt": "latest",
     "grunt-cli": "latest",
     "grunt-contrib-clean": "latest",
-    "grunt-contrib-copy": "latest",
     "grunt-contrib-jshint": "latest",
     "grunt-mocha-hack": "latest",
     "grunt-text-replace": "latest",
+    "istanbul": "latest",
     "mocha": "latest",
     "oae-release-tools": "git://github.com/oaeproject/oae-release-tools",
     "optimist": "latest"


### PR DESCRIPTION
This adds support for [coverage reports in Travis CI](https://coveralls.io).
You can see an example [here](https://coveralls.io/builds/429609).

I've included a bash script which does the proper coverage exclusion logic, but I fear my bash-fu might've let me down there as it's quite ugly.

You can run through all the steps in that script except for the last one to try it out locally. It should give you something like this at the end of your tests run:

```
...
      ✓ verify timezone validation 
      ✓ verify isGlobalAdministratorUser validation 
      ✓ verify isArray validation 
      ✓ verify isBoolean validation 
      ✓ verify isShortString validation 
      ✓ verify isMediumString validation 
      ✓ verify isLongString validation 


  861 passing (3m)


Done, without errors.
=============================================================================
Writing coverage object [/private/tmp/Hilary/coverage/coverage.json]
Writing coverage reports at [/private/tmp/Hilary/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 86.05% ( 13160/15293 )
Branches     : 73.31% ( 4703/6415 )
Functions    : 89.43% ( 2674/2990 )
Lines        : 86.06% ( 13149/15278 )
================================================================================
```

I'll probably need to add a couple of things to get this fully working, so please ignore any failures this produces (for now).
