### PR TITLE
`lastModified` should be managed in API instead of DAO

### DIFF
--- a/node_modules/oae-discussions/lib/internal/dao.js
+++ b/node_modules/oae-discussions/lib/internal/dao.js
@@ -19,6 +19,7 @@ var ShortId = require('shortid');
 var AuthzUtil = require('oae-authz/lib/util');
 var Cassandra = require('oae-util/lib/cassandra');
 var log = require('oae-logger').logger('discussions-dao');
+var OaeUtil = require('oae-util/lib/util');
 var TenantsAPI = require('oae-tenants');
 
 var Discussion = require('oae-discussions/lib/model').Discussion;
@@ -240,8 +241,8 @@ var _storageHashToDiscussion = function(discussionId, hash) {
         hash.displayName,
         hash.description,
         hash.visibility,
-        hash.created,
-        hash.lastModified
+        OaeUtil.getNumberParam(hash.created),
+        OaeUtil.getNumberParam(hash.lastModified)
     );
 };
 
@@ -261,8 +262,8 @@ var _createUpdatedDiscussionFromStorageHash = function(discussion, hash) {
         hash.displayName || discussion.displayName,
         hash.description || discussion.description,
         hash.visibility || discussion.visibility,
-        discussion.created,
-        hash.lastModified || discussion.lastModified
+        OaeUtil.getNumberParam(discussion.created),
+        OaeUtil.getNumberParam(hash.lastModified || discussion.lastModified)
     );
 
 };

--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -753,15 +753,15 @@ var updateGroup = module.exports.updateGroup = function(ctx, groupId, profileFie
             return callback(err);
         }
 
-        // Check if we can update this group.
+        // Check if we can update this group
         _canManage(ctx, oldGroup, function(err, canManage) {
             if (err) {
                 return callback(err);
             } else if (!canManage) {
-                return callback({'code': 401, 'msg': 'Permission denied.'});
+                return callback({'code': 401, 'msg': 'Permission denied'});
             }
 
-            profileFields.lastModified = Date.now();
+            profileFields = _.extend({}, profileFields, {'lastModified': Date.now()});
             PrincipalsDAO.updatePrincipal(groupId, profileFields, function(err) {
                 if (err) {
                     return callback(err);

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -391,27 +391,29 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
         return callback(validator.getFirstError());
     }
 
+    // Only the user themself or an admin can update a user
+    var principalResource = AuthzUtil.getResourceFromId(userId);
+    if (ctx.user().id !== userId && !ctx.user().isAdmin(principalResource.tenantAlias)) {
+        return callback({'code': 401, 'msg': 'You are not authorized to update this user\'s profile.'});
+    }
+
     // Only update existing users
     getUser(ctx, userId, function(err, oldUser) {
         if (err) {
             return callback(err);
         }
 
-        // Only the current user or an admin can update a user
-        var principalResource = AuthzUtil.getResourceFromId(userId);
-        if (ctx.user().id === userId || ctx.user().isAdmin(principalResource.tenantAlias)) {
-            PrincipalsDAO.updatePrincipal(userId, profileFields, function(err) {
-                if (err) {
-                    return callback(err);
-                }
+        // Overlay the correct lastModified date
+        profileFields = _.extend({}, profileFields, {'lastModified': Date.now()});
+        PrincipalsDAO.updatePrincipal(userId, profileFields, function(err) {
+            if (err) {
+                return callback(err);
+            }
 
-                var newUser = PrincipalsUtil.createUpdatedUser(oldUser, profileFields);
-                PrincipalsEmitter.emit(PrincipalsConstants.events.UPDATED_USER, ctx, newUser, oldUser);
-                return getUser(ctx, userId, callback);
-            });
-        } else {
-            callback({'code': 401, 'msg': 'You are not authorized to update this user\'s profile.'});
-        }
+            var newUser = PrincipalsUtil.createUpdatedUser(oldUser, profileFields);
+            PrincipalsEmitter.emit(PrincipalsConstants.events.UPDATED_USER, ctx, newUser, oldUser);
+            return getUser(ctx, userId, callback);
+        });
     });
 };
 
@@ -572,7 +574,7 @@ var getMe = module.exports.getMe = function(ctx, callback) {
 
         data.needsToAcceptTC = PrincipalsTermsAndConditionsAPI.needsToAcceptTermsAndConditions(ctx);
 
-        callback(null, data);
+        return callback(null, data);
     });
 };
 

--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -157,8 +157,6 @@ var updatePrincipal = module.exports.updatePrincipal = function(principalId, pro
         return callback(validator.getFirstError());
     }
 
-    profileFields.lastModified = Date.now();
-
     var q = Cassandra.constructUpsertCQL('Principals', 'principalId', principalId, profileFields, 'QUORUM');
     if (!q) {
         return callback({'code': 500, 'msg': 'Unable to store profile fields'});
@@ -455,7 +453,7 @@ var hashToUser = function(hash) {
         'notificationsUnread': OaeUtil.getNumberParam(hash.notificationsUnread),
         'notificationsLastRead': OaeUtil.getNumberParam(hash.notificationsLastRead),
         'acceptedTC': OaeUtil.getNumberParam(hash.acceptedTC, 0),
-        'lastModified': hash.lastModified
+        'lastModified': OaeUtil.getNumberParam(hash.lastModified)
     });
     var extra = getExtraData(user, hash);
     if (extra) {

--- a/node_modules/oae-principals/tests/test-dao.js
+++ b/node_modules/oae-principals/tests/test-dao.js
@@ -104,10 +104,10 @@ describe('Principals DAO', function() {
          * Test that verifies that restricted fields (i.e., admin:global and admin:tenant) cannot be set through
          * updatePrincipal.
          */
-        it('verifies updatePrincipal does not allow setting of restricted fields', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
+        it('verify updatePrincipal does not allow setting of restricted fields', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, mrvisser) {
                 assert.ok(!err);
-                var mrvisser = _.values(users)[0].user;
+                mrvisser = mrvisser.user;
 
                 // Sanity check valid update first
                 PrincipalsDAO.updatePrincipal(mrvisser.id, {'publicAlias': 'haha'}, function(err) {
@@ -136,6 +136,30 @@ describe('Principals DAO', function() {
                                 });
                             });
                         });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that the DAO does not update the lastModified field automatically.
+         */
+        it('verify updatePrincipal does not set the lastModified field', function(callback) {
+            // Create a user to update
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, mrvisser) {
+                assert.ok(!err);
+                mrvisser = mrvisser.user;
+
+                // Update the user using the DAO directly
+                var prevLastModified = mrvisser.lastModified;
+                PrincipalsDAO.updatePrincipal(mrvisser.id, {'publicAlias': 'haha'}, function(err) {
+                    assert.ok(!err);
+
+                    // Get the user to ensure their lastModified has not changed
+                    PrincipalsDAO.getPrincipal(mrvisser.id, function(err, mrvisserRow) {
+                        assert.ok(!err);
+                        assert.strictEqual(prevLastModified, mrvisser.lastModified);
+                        return callback();
                     });
                 });
             });


### PR DESCRIPTION
Since Library functionality is tightly bound to `lastModified`, and Library is managed at the API level (as it should be), `lastModified` should also be managed at API level.

It is currently managed at DAO layer of Principals. Please look at Discussions and Content as well.

Leaving it the way it is introduces risk that library entries aren't correctly cleaned from libraries. Pushing Library down to DAO layer is dangerous because other modules such as activity will use it to perform non-substantial updates such as increasing notifications counts.
