### PR TITLE
PP - Check if a http link is available on https (and vice versa)

### DIFF
--- a/node_modules/oae-preview-processor/lib/processors/link/default.js
+++ b/node_modules/oae-preview-processor/lib/processors/link/default.js
@@ -73,9 +73,8 @@ var generatePreviews = module.exports.generatePreviews = function(ctx, contentOb
         'url': contentObj.link,
         'method': 'HEAD',
         'timeout': timeouts.embeddableCheckTimeout,
-
-        // Certain webservers will not send an x-frame-options headers when a non-browser user agent is not specified
         'headers': {
+            // Certain webservers will not send an `x-frame-options` header when no browser user agent is not specified
             'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36'
         }
     };
@@ -103,13 +102,13 @@ var generatePreviews = module.exports.generatePreviews = function(ctx, contentOb
         }
 
         /*!
-         * Generates a thumbnail
+         * Generate a thumbnail
          */
         var generateThumbnail = function() {
             var path = ctx.baseDir + '/webshot.png';
             webshot.getImage(contentObj.link, path, timeouts, function (err) {
                 if (err) {
-                    log().error({'err': err, 'contentId': ctx.contentId}, 'Could not generate an image.');
+                    log().error({'err': err, 'contentId': ctx.contentId}, 'Could not generate an image');
                     return callback(err);
                 }
 
@@ -138,7 +137,7 @@ var generatePreviews = module.exports.generatePreviews = function(ctx, contentOb
 };
 
 /**
- * Checks if a link is accessible over HTTPS
+ * Check if a link is accessible over HTTPS
  *
  * @param  {String}     link                        The link to check. Note that his link should already have https: as it's protocol
  * @param  {Function}   callback                    Standard callback function

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -660,7 +660,6 @@ describe('Preview processor', function() {
                 assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
                 _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
 
-
                     // Assert that URLs that are not available on HTTPs get marked as such
                     _createContentAndWait('link', 'http://localhost:2000', null, function(restCtx, content) {
                         assert.equal(content.previews.status, 'done');


### PR DESCRIPTION
Some browsers (ex: Chrome) don't allow you to embed an iframe with an http link into an HTTPs page. The PP could do a HEAD request and check if there is an HTTPS version available
