### PR TITLE
Locale-related unit test failure

### DIFF
--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -348,8 +348,7 @@ describe('Users', function() {
                     assert.ok(meData.anon);
                     assert.equal(meData.locale.locale, 'en_US');
 
-                    // We don't provide "international" versions of languages currently
-                    // this is because of https://github.com/jed/locale/issues/13
+                    // If you just say a language without specifying the country we'll give you some form of that language
                     var acceptLanguageRestContext = new RestContext('http://localhost:2001', {
                         'hostHeader': global.oaeTests.tenants.cam.host,
                         'additionalHeaders': { 'Accept-Language': 'en' }
@@ -357,7 +356,7 @@ describe('Users', function() {
                     RestAPI.User.getMe(acceptLanguageRestContext, function(err, meData) {
                         assert.ok(!err);
                         assert.ok(meData.anon);
-                        assert.ok(!meData.locale);
+                        assert.equal(meData.locale.locale.substring(0,2), 'en');
                         callback();
                     });
                 });


### PR DESCRIPTION
`verify anonymous locale` is failing

Now that https://github.com/jed/locale/pull/13 has been merged and released, we can probably change the logic in that test?

Assigning to @stuartf 
