### PR TITLE
includeExternal flag should trump the user's global admin status in search requests

### DIFF
--- a/node_modules/oae-content/lib/searches/relatedcontent.js
+++ b/node_modules/oae-content/lib/searches/relatedcontent.js
@@ -34,7 +34,7 @@ var BOOST_FACTORS = {
 /**
  * A search that searches for related content items to a specified content item.
  * This search will search trough public content items (or loggedin ones local to the current tenant.)
- * Setting the includeExternal flag to true, allows you to find related content in other tenants as well.
+ * Setting the scope flag to 'all', allows you to find related content in other tenants as well.
  * This will mostly happen on account of the displayName.
  * Content items who have a thumbnail or a description or are also created by the creator of the base piece of content will get boosted.
  * By default this feed only returns 5 items.
@@ -42,7 +42,7 @@ var BOOST_FACTORS = {
  * @param  {Context}        ctx                     The context of the current request
  * @param  {Object}         opts                    General search options
  * @param  {String[]}       opts.pathParams         An array with 1 string. That string should be the ID of the piece of content that will act as the base content item.
- * @param  {String}         [opts.includeExternal]  Whether or not to include content from other tenants ('true' or 'false') (Default: 'false')
+ * @param  {String}         [opts.scope]            Specifies if the search is cross-tenant. Can be `all`. (Default: null)
  * @param  {Function}       callback                Invoked when the process completes
  * @param  {Object}         callback.err            An error that occurred, if any
  * @param  {SearchResult}   callback.results        An object that represents the results of the query
@@ -50,8 +50,8 @@ var BOOST_FACTORS = {
 module.exports = function(ctx, opts, callback) {
     // Sanitize custom search options
     opts = opts || {};
-    opts.includeExternal = (opts.includeExternal === 'true');
     opts.limit = OaeUtil.getNumberParam(opts.limit, 5, 1, 25);
+    opts.scope = opts.scope || null;
     var contentId = (opts.pathParams && opts.pathParams.length > 0) ? opts.pathParams[0] : null;
 
     var validator = new Validator();
@@ -85,10 +85,10 @@ module.exports = function(ctx, opts, callback) {
         var baseFilter = SearchUtil.filterAnd(typeFilter, resourceTypeFilter);
 
         if (ctx.user() && ctx.user().isGlobalAdmin()) {
-            // The user is a global admin
+            // As the user is a global admin, we get everything from the current tenant or everything from all tenants depending on the value of `scope`
             filter = SearchUtil.filterAnd(
                 baseFilter,
-                (!opts.includeExternal) ? SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias) : null
+                (opts.scope !== 'all') ? SearchUtil.filterTerm('tenantAlias', opts.scope || ctx.tenant().alias) : null
             );
 
         } else if (ctx.user()) {
@@ -97,8 +97,8 @@ module.exports = function(ctx, opts, callback) {
                 baseFilter,
                 SearchUtil.filterAnd(
 
-                    // Only resources from the current tenant will be included when include external has not been specified
-                    (!opts.includeExternal) ? SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias) : null,
+                    // Only resources from the current tenant will be included when `scope` has not been specified
+                    (opts.scope !== 'all') ? SearchUtil.filterTerm('tenantAlias', opts.scope || ctx.tenant().alias) : null,
 
                     // This or statement applies visibility restrictions
                     SearchUtil.filterOr(
@@ -106,12 +106,10 @@ module.exports = function(ctx, opts, callback) {
                         // Public resources from the current tenant should always be included. If external results should be included, resources from
                         // other permeable tenants should be included as well
                         SearchUtil.filterAnd(
-
-                            // Include private or public resources in results, depending whether the user is a global admin or not
                             SearchUtil.filterTerm('visibility', AuthzConstants.visibility.PUBLIC),
                             SearchUtil.filterOr(
                                 SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias),
-                                (opts.includeExternal && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
+                                (opts.scope && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
                             )
                         ),
 
@@ -129,14 +127,14 @@ module.exports = function(ctx, opts, callback) {
                 baseFilter,
 
                 // Limit to the current tenant unless specified otherwise
-                (!opts.includeExternal) ? SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias) : null,
+                (opts.scope !== 'all') ? SearchUtil.filterTerm('tenantAlias', opts.scope || ctx.tenant().alias) : null,
 
                 // Public resources from the current tenant and other permeable tenants should be included
                 SearchUtil.filterAnd(
                     SearchUtil.filterTerm('visibility', AuthzConstants.visibility.PUBLIC),
                     SearchUtil.filterOr(
                         SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias),
-                        (opts.includeExternal && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
+                        (opts.scope && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
                     )
                 )
             );

--- a/node_modules/oae-content/tests/test-relatedcontent.js
+++ b/node_modules/oae-content/tests/test-relatedcontent.js
@@ -213,7 +213,7 @@ describe('Related content', function() {
             checkResults(results, 1, contentItems.BY_TENANT.CAM.PUBLIC, _.union(contentItems.BY_TENANT.CAM.LOGGEDIN, contentItems.BY_TENANT.CAM.PRIVATE, contentItems.BY_TENANT.GT.PUBLIC, contentItems.BY_TENANT.GT.LOGGEDIN, contentItems.BY_TENANT.GT.PRIVATE));
 
             // When we include the GT tenant, he can see the 1 (other) item in his own tenant + 2 in the GT tenant
-            RestAPI.Search.search(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'includeExternal': true}, function(err, results) {
+            RestAPI.Search.search(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'scope': 'all'}, function(err, results) {
                 assert.ok(!err);
                 checkResults(results, 3, _.union(contentItems.BY_TENANT.CAM.PUBLIC, contentItems.BY_TENANT.GT.PUBLIC), _.union(contentItems.BY_TENANT.CAM.LOGGEDIN, contentItems.BY_TENANT.CAM.PRIVATE, contentItems.BY_TENANT.GT.LOGGEDIN, contentItems.BY_TENANT.GT.PRIVATE) );
                 callback();
@@ -231,7 +231,7 @@ describe('Related content', function() {
             checkResults(results, 2, _.union(contentItems.BY_TENANT.CAM.PUBLIC, contentItems.BY_TENANT.CAM.LOGGEDIN), _.union(contentItems.BY_TENANT.CAM.PRIVATE, contentItems.BY_TENANT.GT.PUBLIC, contentItems.BY_TENANT.GT.LOGGEDIN, contentItems.BY_TENANT.GT.PRIVATE) );
 
             // When we include the GT tenant, he can see the 1 (other) public item + 1 loggedin item in his own tenant + 2 public ones in the GT tenant
-            RestAPI.Search.search(loggedinCamRestContexts[1], 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'includeExternal': true}, function(err, results) {
+            RestAPI.Search.search(loggedinCamRestContexts[1], 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'scope': 'all'}, function(err, results) {
                 assert.ok(!err);
                 checkResults(results, 4, _.union(contentItems.BY_TENANT.CAM.PUBLIC, contentItems.BY_TENANT.CAM.LOGGEDIN, contentItems.BY_TENANT.GT.PUBLIC), _.union(contentItems.BY_TENANT.CAM.PRIVATE, contentItems.BY_TENANT.GT.LOGGEDIN, contentItems.BY_TENANT.GT.PRIVATE) );
                 callback();
@@ -375,7 +375,7 @@ describe('Related content', function() {
      * Verify the limit request parameter gets handled properly.
      */
     it('verify limit handling', function(callback) {
-        SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'limit': 1, 'includeExternal': true}, function(err, data) {
+        SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'limit': 1, 'scope': 'all'}, function(err, data) {
             assert.ok(!err);
 
             // This user has access to 7 related contents.
@@ -383,19 +383,19 @@ describe('Related content', function() {
             assert.equal(data.total, 7);
             assert.equal(data.results.length, 1);
 
-            SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'limit': 2, 'includeExternal': true}, function(err, data) {
+            SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'limit': 2, 'scope': 'all'}, function(err, data) {
                 assert.ok(!err);
                 assert.equal(data.total, 7);
                 assert.equal(data.results.length, 2);
 
                 // The default limit is 5 and should be fallen back to when the
                 // request parameter has been omitted or is not an int.
-                SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'limit': 'non-numeric', 'includeExternal': true}, function(err, data) {
+                SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'limit': 'non-numeric', 'scope': 'all'}, function(err, data) {
                     assert.ok(!err);
                     assert.equal(data.total, 7);
                     assert.equal(data.results.length, 5);
 
-                    SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'includeExternal': true}, function(err, data) {
+                    SearchTestsUtil.searchRefreshed(anonymousCamRestContext, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'scope': 'all'}, function(err, data) {
                         assert.ok(!err);
                         assert.equal(data.total, 7);
                         assert.equal(data.results.length, 5);
@@ -422,7 +422,7 @@ describe('Related content', function() {
                     assert.ok(!err);
 
                     // Search for it in the cam tenant.
-                    SearchTestsUtil.searchRefreshed(loggedinCamRestContexts[1], 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'includeExternal': true}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(loggedinCamRestContexts[1], 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'scope': 'all'}, function(err, results) {
                         assert.ok(!err);
                         var docsFromPrivateTenant = _.filter(results.results, function(searchDoc) { return searchDoc.tenant.alias === privateTenant.alias; });
                         assert.equal(docsFromPrivateTenant.length, 0);
@@ -430,7 +430,7 @@ describe('Related content', function() {
                         assert.ok(docsFromCamTenant.length > 0);
 
                         // Searching in the private tenant shouldn't return any documents from the Cambridge tenant.
-                        RestAPI.Search.search(privateTenantAdminRestCtx, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'includeExternal': true}, function(err, results) {
+                        RestAPI.Search.search(privateTenantAdminRestCtx, 'relatedcontent', [contentItems.BY_TENANT.CAM.PUBLIC[0]], {'scope': 'all'}, function(err, results) {
                             assert.ok(!err);
                             var docsFromCamTenant = _.filter(results.results, function(searchDoc) { return searchDoc.tenant.alias === global.oaeTests.tenants.cam.alias; });
                             assert.equal(docsFromCamTenant.length, 0);

--- a/node_modules/oae-search/lib/rest.js
+++ b/node_modules/oae-search/lib/rest.js
@@ -37,7 +37,7 @@ OAE.globalAdminRouter.on('post', '/api/search/reindexAll', function(req, res) {
 /**
  * _GET_ `/api/search/[searchType][/pathParam0/pathParam1/pathParam2]?[opts]`
  *
- * Perform a search for resources in the database.
+ * Perform a search for resources in the database on the tenant router.
  *
  * @param  {String}        searchType      The type of search to execute
  * @param  {Object}        [opts]          The query string parameters of the search
@@ -45,6 +45,7 @@ OAE.globalAdminRouter.on('post', '/api/search/reindexAll', function(req, res) {
  * @param  {Number}        [opts.limit]    The maximum number of results to return (Default: 10)
  * @param  {Number}        [opts.start]    The document at which to start (Default: 0)
  * @param  {String}        [opts.sort]     Which direction to sort the results. Can be one of: `asc` or `desc`. If an invalid sort value is provided, it defaults to `asc`
+ * @param  {String}        [opts.scope]    Specifies if the search is cross-tenant. Can be <tenant alias> or `all`. (Default: null)
  * @return {SearchResult}                  The response, if successful, will be a search result object as defined by `SearchModel.SearchResult`
  */
 OAE.tenantRouter.on('get', /\/api\/search\/([^\/]+)(\/.*)?/, function(req, res) {
@@ -64,3 +65,33 @@ OAE.tenantRouter.on('get', /\/api\/search\/([^\/]+)(\/.*)?/, function(req, res) 
     });
 }, '/api/search');
 
+/**
+ * _GET_ `/api/search/[searchType][/pathParam0/pathParam1/pathParam2]?[opts]`
+ *
+ * Perform a search for resources in the database on the global admin router.
+ *
+ * @param  {String}        searchType      The type of search to execute
+ * @param  {Object}        [opts]          The query string parameters of the search
+ * @param  {String}        [opts.q]        A full-text search that can be input to filter documents by a text match (Default: * for all documents)
+ * @param  {Number}        [opts.limit]    The maximum number of results to return (Default: 10)
+ * @param  {Number}        [opts.start]    The document at which to start (Default: 0)
+ * @param  {String}        [opts.sort]     Which direction to sort the results. Can be one of: `asc` or `desc`. If an invalid sort value is provided, it defaults to `asc`
+ * @param  {String}        [opts.scope]    Specifies if the search is cross-tenant. Can be <tenant alias> or `all`. (Default: null)
+ * @return {SearchResult}                  The response, if successful, will be a search result object as defined by `SearchModel.SearchResult`
+ */
+OAE.globalAdminRouter.on('get', /\/api\/search\/([^\/]+)(\/.*)?/, function(req, res) {
+    var searchType = req.params[0];
+    if (searchType) {
+        req.telemetryUrl = '/api/search/' + searchType;
+    }
+    var pathParams = req.params[1] ? _.compact(req.params[1].split('/')) : [];
+    var opts = _.extend({}, req.query, SearchUtil.getSearchParams(req), {'pathParams': pathParams});
+
+    SearchAPI.search(req.ctx, searchType, opts, function(err, result) {
+        if (err) {
+            res.send(err.code, err);
+        } else {
+            res.send(200, result);
+        }
+    });
+}, '/api/search');

--- a/node_modules/oae-search/lib/searches/general.js
+++ b/node_modules/oae-search/lib/searches/general.js
@@ -35,8 +35,8 @@ var RESOURCE_TYPES_ACCESS_SCOPED = [SearchConstants.general.RESOURCE_TYPE_ALL,
  * @param  {Context}       ctx                     The context of the current request
  * @param  {Object}        [opts]                  General search options
  * @param  {String[]}      [opts.resourceTypes]    An array of resource types to search (e.g., content, user). If not specified, then the search will not filter on resource type at all. Possible resource types are those that have registered producers in SearchAPI#registerSearchDocumentProducer.
- * @param  {String}        [opts.includeExternal]  Whether or not to include content from other tenants ('true' or 'false') (Default: 'false')
  * @param  {String}        [opts.includeIndirect]  Whether or not to include private resources that the user has access to indirectly (Default: 'true');
+ * @param  {String}        [opts.scope]            Specifies if the search is cross-tenant. Can be `all`. (Default: null)
  * @param  {Function}      callback                Invoked when the process completes
  * @param  {Object}        callback.err            An error that occurred, if any
  * @param  {SearchResult}  callback.results        An object that represents the results of the query
@@ -45,9 +45,9 @@ module.exports = function(ctx, opts, callback) {
     // Sanitize custom search options
     opts = opts || {};
     opts.resourceTypes = opts.resourceTypes || [];
-    opts.includeExternal = (opts.includeExternal === 'true');
     opts.includeIndirect = (opts.includeIndirect !== 'false');
     opts.limit = OaeUtil.getNumberParam(opts.limit, 10, 1, 25);
+    opts.scope = opts.scope || null;
 
     // Sanitize the resourceTypes array
     if (!_.isArray(opts.resourceTypes)) {
@@ -124,26 +124,25 @@ var _search = function(ctx, opts, callback) {
     var interactingTenantAliases = TenantsUtil.getAllTenantsForInteraction(ctx.tenant().alias);
 
     if (ctx.user() && ctx.user().isGlobalAdmin()) {
-        // The user is a global admin
+        // As the user is a global admin, we get everything from the current tenant or everything from all tenants depending on the value of `scope`
         filter = SearchUtil.filterAnd(
             baseFilter,
-            (!opts.includeExternal) ? SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias) : null
+            (opts.scope !== 'all') ? SearchUtil.filterTerm('tenantAlias', (opts.scope) ? opts.scope : ctx.tenant().alias) : null
         );
 
     } else if (ctx.user()) {
         // The user is authenticated
-
         filter = SearchUtil.filterAnd(
             baseFilter,
             SearchUtil.filterOr(
 
-                // I can always see content that I have explicit access to, even if it belongs to another tenant and I haven't specified `includeExternal`
+                // I can always see content that I have explicit access to, even if it belongs to another tenant and I haven't specified `scope`
                 accessFilter,
 
                 SearchUtil.filterAnd(
 
-                    // I will only get resources from my own tenant if I have not specified to include external
-                    (!opts.includeExternal) ? SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias) : null,
+                    // I will only get resources from my own tenant if I have not specified `scope`
+                    (opts.scope !== 'all') ? SearchUtil.filterTerm('tenantAlias', opts.scope || ctx.tenant().alias) : null,
 
                     // This or statement applies visibility restrictions
                     SearchUtil.filterOr(
@@ -151,12 +150,10 @@ var _search = function(ctx, opts, callback) {
                         // Public resources from the current tenant should always be included. If external results should be included, resources from
                         // other permeable tenants should be included as well
                         SearchUtil.filterAnd(
-
-                            // Include private or public resources in results, depending whether the user is a global admin or not
                             SearchUtil.filterTerm('visibility', AuthzConstants.visibility.PUBLIC),
                             SearchUtil.filterOr(
                                 SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias),
-                                (opts.includeExternal && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
+                                (opts.scope && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
                             )
                         ),
 
@@ -165,7 +162,7 @@ var _search = function(ctx, opts, callback) {
                         SearchUtil.filterAnd(
                             SearchUtil.filterOr(
                                 SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias),
-                                (opts.includeExternal && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
+                                (opts.scope && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
                             ),
                             SearchUtil.filterTerm('resourceType', 'group'),
                             SearchUtil.filterTerms('joinable', [AuthzConstants.joinable.YES, AuthzConstants.joinable.REQUEST])
@@ -180,20 +177,21 @@ var _search = function(ctx, opts, callback) {
                 )
             )
         );
+
     } else {
         // For anonymous users, only show public resources
         filter = SearchUtil.filterAnd(
             baseFilter,
 
             // Limit to the current tenant unless specified otherwise
-            (!opts.includeExternal) ? SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias) : null,
+            (opts.scope !== 'all') ? SearchUtil.filterTerm('tenantAlias', opts.scope || ctx.tenant().alias) : null,
 
             // Public resources from the current tenant and other permeable tenants should be included
             SearchUtil.filterAnd(
                 SearchUtil.filterTerm('visibility', AuthzConstants.visibility.PUBLIC),
                 SearchUtil.filterOr(
                     SearchUtil.filterTerm('tenantAlias', ctx.tenant().alias),
-                    (opts.includeExternal && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
+                    (opts.scope && interactingTenantAliases.length > 0) ? SearchUtil.filterTerms('tenantAlias', interactingTenantAliases) : null
                 )
             )
         );

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -87,7 +87,7 @@ describe('General Search', function() {
      * @throws {Error}                                  If the resource is not in the results when you expected it to, or vice versa.
      */
     var searchForResource = function(restCtx, resource, expectInResults, callback) {
-        SearchTestsUtil.searchRefreshed(restCtx, 'general', null, {'includeExternal': true, 'resourceTypes': resource.resourceType, 'q': resource.displayName}, function(err, results) {
+        SearchTestsUtil.searchRefreshed(restCtx, 'general', null, {'scope': 'all', 'resourceTypes': resource.resourceType, 'q': resource.displayName}, function(err, results) {
             assert.ok(!err);
             var resourceDoc = _getDocById(results, resource.id);
             if (expectInResults) {
@@ -673,6 +673,155 @@ describe('General Search', function() {
         });
 
         /**
+         * Verifies cross-tenant searching when using the `scope` parameter
+         */
+        it('verify cross-tenant searching', function(callback) {
+            // Create a Cambridge user
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, camUsers, camUser) {
+                assert.ok(!err);
+                assert.ok(camUser);
+
+                // Create a new content item on the Cambridge tenant
+                RestAPI.Content.createLink(camUser.restContext, 'OAE Project', null, 'public', 'http://www.oaeproject.org', [], [], function(err, camContentObj) {
+                    assert.ok(!err);
+                    assert.ok(camContentObj);
+
+                    // Create a GT user
+                    TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, gtUsers, gtUser) {
+                        assert.ok(!err);
+                        assert.ok(gtUser);
+
+                        // Create a new content item on the GT tenant
+                        RestAPI.Content.createLink(gtUser.restContext, 'Google', null, 'public', 'http://www.google.com', [], [], function(err, gtContentObj) {
+                            assert.ok(!err);
+                            assert.ok(gtContentObj);
+
+                            // Search for the created Cambridge resource with the global admin when the scope is specified
+                            SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'oaeproject', 'scope': 'all'}, function(err, results) {
+                                assert.ok(!err);
+                                assert.ok(_getDocById(results, camContentObj.id));
+
+                                // Search for the created GT resource with the global admin when the scope is set to `all`
+                                SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'google', 'scope': 'all'}, function(err, results) {
+                                    assert.ok(!err);
+                                    assert.ok(_getDocById(results, gtContentObj.id));
+
+                                    // Search for the created Cambridge resource with the global admin when the scope is set to `camtest`
+                                    SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'oaeproject', 'scope': 'camtest'}, function(err, results) {
+                                        assert.ok(!err);
+                                        assert.ok(_getDocById(results, camContentObj.id));
+
+                                        // Search for the created Cambridge resource with the global admin when the scope is set to `camtest`
+                                        SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'oaeproject', 'scope': 'gttest'}, function(err, results) {
+                                            assert.ok(!err);
+                                            assert.ok(!_getDocById(results, camContentObj.id));
+
+                                            // Search for the created Cambridge resource with the global admin when the scope is NOT specified
+                                            SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'oaeproject'}, function(err, results) {
+                                                assert.ok(!err);
+                                                assert.ok(!_getDocById(results, camContentObj.id));
+
+                                                // Search for the created GT resource with the global admin when the scope is NOT specified
+                                                SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'google'}, function(err, results) {
+                                                    assert.ok(!err);
+                                                    assert.ok(!_getDocById(results, gtContentObj.id));
+
+                                                    // Make the tenant private
+                                                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, camContentObj.tenantAlias, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
+                                                        assert.ok(!err);
+
+                                                        // Search for the created Cambridge resource with the global admin when the scope is specified
+                                                        SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'oaeproject', 'scope': 'all'}, function(err, results) {
+                                                            assert.ok(!err);
+                                                            assert.ok(_getDocById(results, camContentObj.id));
+
+                                                            // Search for the created Cambridge resource with the global admin when the scope is NOT specified
+                                                            SearchTestsUtil.searchAll(globalAdminRestContext, 'general', null, {'q': 'oaeproject'}, function(err, results) {
+                                                                assert.ok(!err);
+                                                                assert.ok(!_getDocById(results, camContentObj.id));
+
+                                                                // Search for the created Cambridge resource with the Cambridge admin when the scope is specified
+                                                                SearchTestsUtil.searchAll(camAdminRestContext, 'general', null, {'q': 'oaeproject', 'scope': 'all'}, function(err, results) {
+                                                                    assert.ok(!err);
+                                                                    assert.ok(_getDocById(results, camContentObj.id));
+
+                                                                    // Search for the created Cambridge resource with the Cambridge admin when the scope is NOT specified
+                                                                    SearchTestsUtil.searchAll(camAdminRestContext, 'general', null, {'q': 'oaeproject'}, function(err, results) {
+                                                                        assert.ok(!err);
+                                                                        assert.ok(_getDocById(results, camContentObj.id));
+
+                                                                        // Search for the created GT resource with the Cambridge admin when the scope is specified
+                                                                        SearchTestsUtil.searchAll(camAdminRestContext, 'general', null, {'q': 'google', 'scope': 'all'}, function(err, results) {
+                                                                            assert.ok(!err);
+                                                                            assert.ok(!_getDocById(results, gtContentObj.id));
+
+                                                                            // Search for the created GT resource with the Cambridge admin when the scope is NOT specified
+                                                                            SearchTestsUtil.searchAll(camAdminRestContext, 'general', null, {'q': 'google'}, function(err, results) {
+                                                                                assert.ok(!err);
+                                                                                assert.ok(!_getDocById(results, gtContentObj.id));
+
+                                                                                // Search for the created Cambridge resource with the GT admin when the scope is specified
+                                                                                SearchTestsUtil.searchAll(gtAdminRestContext, 'general', null, {'q': 'oaeproject', 'scope': 'all'}, function(err, results) {
+                                                                                    assert.ok(!err);
+                                                                                    assert.ok(!_getDocById(results, camContentObj.id));
+
+                                                                                    // Search for the created Cambridge resource with the GT admin when the scope is specified
+                                                                                    SearchTestsUtil.searchAll(gtAdminRestContext, 'general', null, {'q': 'oaeproject'}, function(err, results) {
+                                                                                        assert.ok(!err);
+                                                                                        assert.ok(!_getDocById(results, camContentObj.id));
+
+                                                                                        // Search for the created Cambridge resource with the Cambridge user when the scope is specified
+                                                                                        SearchTestsUtil.searchAll(camUser.restContext, 'general', null, {'q': 'oaeproject', 'scope': 'all'}, function(err, results) {
+                                                                                            assert.ok(!err);
+                                                                                            assert.ok(_getDocById(results, camContentObj.id));
+
+                                                                                            // Search for the created Cambridge resource with the Cambridge user when the scope is NOT specified
+                                                                                            SearchTestsUtil.searchAll(camUser.restContext, 'general', null, {'q': 'oaeproject'}, function(err, results) {
+                                                                                                assert.ok(!err);
+                                                                                                assert.ok(_getDocById(results, camContentObj.id));
+
+                                                                                                // Search for the created Cambridge resource with the GT user when the scope is specified
+                                                                                                SearchTestsUtil.searchAll(gtUser.restContext, 'general', null, {'q': 'oaeproject', 'scope': 'all'}, function(err, results) {
+                                                                                                    assert.ok(!err);
+                                                                                                    assert.ok(!_getDocById(results, camContentObj.id));
+
+                                                                                                    // Search for the created Cambridge resource with the anonymous user when the scope is NOT specified
+                                                                                                    SearchTestsUtil.searchAll(anonymousRestContext, 'general', null, {'q': 'oaeproject'}, function(err, results) {
+                                                                                                        assert.ok(!err);
+                                                                                                        assert.ok(_getDocById(results, camContentObj.id));
+
+                                                                                                        // Search for the created GT resource with the anonymous user when the scope is NOT specified
+                                                                                                        SearchTestsUtil.searchAll(anonymousRestContext, 'general', null, {'q': 'google'}, function(err, results) {
+                                                                                                            assert.ok(!err);
+                                                                                                            assert.ok(!_getDocById(results, gtContentObj.id));
+                                                                                                            return callback();
+                                                                                                        });
+                                                                                                    });
+                                                                                                });
+                                                                                            });
+                                                                                        });
+                                                                                    });
+                                                                                });
+                                                                            });
+                                                                        });
+                                                                    });
+                                                                });
+                                                            });
+                                                        });
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies loggedin content items are only search by users authenticated to the content item's parent tenant.
          */
         it('verify loggedin content search not searchable by anonymous or cross-tenant', function(callback) {
@@ -718,7 +867,7 @@ describe('General Search', function() {
                                                 assert.ok(!_getDocById(results, contentObj.id));
 
                                                 // Verify cross-tenant user cannot see it
-                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.ok(!_getDocById(results, contentObj.id));
 
@@ -845,7 +994,7 @@ describe('General Search', function() {
                                                 assert.ok(!_getDocById(results, contentObj.id));
 
                                                 // Verify cross-tenant user cannot see it
-                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.ok(!_getDocById(results, contentObj.id));
 
@@ -895,7 +1044,7 @@ describe('General Search', function() {
                                                                 assert.equal(contentDoc.sort, undefined);
 
                                                                 // Verify global admin on a different tenant can see it
-                                                                SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                                                                SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                                                     assert.ok(!err);
 
                                                                     var contentDoc = _getDocById(results, contentObj.id);
@@ -915,7 +1064,7 @@ describe('General Search', function() {
                                                                     assert.equal(contentDoc.sort, undefined);
 
                                                                     // Verify global admin on a different tenant can't see it when external tenants are not included
-                                                                    SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString, 'includeExternal': false}, function(err, results) {
+                                                                    SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                                         assert.ok(!err);
                                                                         var contentDoc = _getDocById(results, contentObj.id);
                                                                         assert.ok(!contentDoc);
@@ -1021,7 +1170,7 @@ describe('General Search', function() {
                             assert.ok(!jackDoc);
 
                             // Verify visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                 assert.ok(!err);
                                 var jackDoc = _getDocById(results, jack.id);
                                 assert.ok(jackDoc);
@@ -1137,7 +1286,7 @@ describe('General Search', function() {
                             assert.ok(!jackDoc);
 
                             // Verify not visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                 assert.ok(!err);
                                 var jackDoc = _getDocById(results, jack.id);
                                 assert.ok(!jackDoc);
@@ -1229,7 +1378,7 @@ describe('General Search', function() {
                             assert.ok(!jackDoc);
 
                             // Verify not visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                 assert.ok(!err);
                                 var jackDoc = _getDocById(results, jack.id);
                                 assert.ok(!jackDoc);
@@ -1267,7 +1416,7 @@ describe('General Search', function() {
 
 
                                             // Verify not hidden for global admin authenticated to a different tenant
-                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                                 assert.ok(!err);
 
                                                 var jackDoc = _getDocById(results, jack.id);
@@ -1385,14 +1534,14 @@ describe('General Search', function() {
                                     assert.equal(groupDoc.q_low, undefined);
                                     assert.equal(groupDoc.sort, undefined);
 
-                                    // Verify cross-tenant user cannot query the group without includeExternal
+                                    // Verify cross-tenant user cannot query the group without scope
                                     SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                                         assert.ok(!err);
                                         var groupDoc = _getDocById(results, group.id);
                                         assert.ok(!groupDoc);
 
-                                        // Verify cross-tenant user can query the group with includeExternal
-                                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'includeExternal': true}, function(err, results) {
+                                        // Verify cross-tenant user can query the group with scope
+                                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': 'all'}, function(err, results) {
                                             assert.ok(!err);
                                             var groupDoc = _getDocById(results, group.id);
                                             assert.ok(groupDoc);
@@ -1408,7 +1557,7 @@ describe('General Search', function() {
                                             assert.equal(groupDoc.q_low, undefined);
                                             assert.equal(groupDoc.sort, undefined);
 
-                                            // Verify cross-tenant *member* can query the group *without* includeExternal
+                                            // Verify cross-tenant *member* can query the group *without* scope
                                             SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                                                 assert.ok(!err);
                                                 var groupDoc = _getDocById(results, group.id);
@@ -1544,13 +1693,13 @@ describe('General Search', function() {
                                                             assert.ok(!groupDoc);
 
                                                             // Verify cross-tenant user cannot query the unjoinable group
-                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA, 'includeExternal': true}, function(err, results) {
+                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA, 'scope': 'all'}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 var groupDoc = _getDocById(results, group.id);
                                                                 assert.ok(!groupDoc);
 
                                                                 // Verify cross-tenant user can query the joinable group
-                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'includeExternal': true}, function(err, results) {
+                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': 'all'}, function(err, results) {
                                                                     assert.ok(!err);
                                                                     var groupDoc = _getDocById(results, groupJoinable.id);
                                                                     assert.ok(groupDoc);
@@ -1567,7 +1716,7 @@ describe('General Search', function() {
                                                                     assert.equal(groupDoc.q_low, undefined);
                                                                     assert.equal(groupDoc.sort, undefined);
 
-                                                                    // Verify cross-tenant member can query the unjoinable group. They do not need includeExternal because they are a member
+                                                                    // Verify cross-tenant member can query the unjoinable group. They do not need scope because they are a member
                                                                     SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                                         assert.ok(!err);
                                                                         var groupDoc = _getDocById(results, group.id);
@@ -1636,13 +1785,13 @@ describe('General Search', function() {
                                                                                     assert.equal(groupDoc.sort, undefined);
 
                                                                                     // Verify a user from a *private tenant* cannot query an external loggedin joinable group
-                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'includeExternal': true}, function(err, results) {
+                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': 'all'}, function(err, results) {
                                                                                         assert.ok(!err);
                                                                                         var groupDoc = _getDocById(results, groupJoinable.id);
                                                                                         assert.ok(!groupDoc);
 
                                                                                         // Verify that user from a public tenant cannot query a loggedin joinable group that belongs to a *private* tenant (luke skywalker's tenant and group)
-                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC, 'includeExternal': true}, function(err, results) {
+                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC, 'scope': 'all'}, function(err, results) {
                                                                                             assert.ok(!err);
                                                                                             var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                                             assert.ok(!groupDoc);
@@ -1733,13 +1882,13 @@ describe('General Search', function() {
                                                             assert.ok(!groupDoc);
 
                                                             // Verify cross-tenant user cannot query the unjoinable group
-                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome', 'includeExternal': true}, function(err, results) {
+                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome', 'scope': 'all'}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 var groupDoc = _getDocById(results, group.id);
                                                                 assert.ok(!groupDoc);
 
                                                                 // Verify cross-tenant user can query the joinable group
-                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'includeExternal': true}, function(err, results) {
+                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': 'all'}, function(err, results) {
                                                                     assert.ok(!err);
 
                                                                     var groupDoc = _getDocById(results, groupJoinable.id);
@@ -1818,19 +1967,19 @@ describe('General Search', function() {
                                                                                     assert.equal(groupDoc.sort, undefined);
 
                                                                                     // Verify a user from a *private tenant* cannot query an external private joinable group
-                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'includeExternal': true}, function(err, results) {
+                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': 'all'}, function(err, results) {
                                                                                         assert.ok(!err);
                                                                                         var groupDoc = _getDocById(results, groupJoinable.id);
                                                                                         assert.ok(!groupDoc);
 
                                                                                         // Verify that user from a public tenant cannot query a private joinable group that belongs to a *private* tenant (luke skywalker's tenant and group)
-                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'includeExternal': true}, function(err, results) {
+                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'scope': 'all'}, function(err, results) {
                                                                                             assert.ok(!err);
                                                                                             var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                                             assert.ok(!groupDoc);
 
-                                                                                            // Verify global admin user authenticated to a different tenant can query the private unjoinable group if includeExternal is true
-                                                                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'includeExternal': true}, function(err, results) {
+                                                                                            // Verify global admin user authenticated to a different tenant can query the private unjoinable group if `scope` is set to `all`
+                                                                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'scope': 'all'}, function(err, results) {
                                                                                                 assert.ok(!err);
                                                                                                 var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                                                 assert.ok(groupDoc);
@@ -1843,8 +1992,8 @@ describe('General Search', function() {
                                                                                                 assert.equal(groupDoc.tenant.displayName, privateTenantGroup.tenant.displayName);
                                                                                                 assert.equal(groupDoc.profilePath, privateTenantGroup.profilePath);
 
-                                                                                                // Verify global admin user authenticated to a different tenant can't query the private unjoinable group is includeExternal is false
-                                                                                                SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'includeExternal': false}, function(err, results) {
+                                                                                                // Verify global admin user authenticated to a different tenant can't query the private unjoinable group if `scope` is not specified
+                                                                                                SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker'}, function(err, results) {
                                                                                                     assert.ok(!err);
                                                                                                     var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                                                     assert.ok(!groupDoc);


### PR DESCRIPTION
When doing searches we can specify an `includeExternal=true|false` flag which indicates whether or not resources from other tenants should be included in the response.

When a global admin performs a search we do not respect this parameter and simply query everything. We should apply the filter for global admins as well.
This will allow us to search through all the users of a tenant in case we need to make somebody a tenant admin.

A quick grep shows this needs to be changed in:
- general search
- related content

Assigning to @Coenego 
