### PR TITLE
Search total count is sometimes 0

### DIFF
--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -76,9 +76,9 @@ var getSortParam = module.exports.getSortParam = function(val, defaultVal) {
  * @param  {SearchResult}  callback.results    The search results that can be sent to the client
  */
 var transformSearchResults = module.exports.transformSearchResults = function(ctx, transformers, results, callback) {
-    var hits = results.hits;
-    var total = (hits && hits.total) ? hits.total : 0;
-    if (!hits || !hits.hits || hits.hits.length === 0) {
+    var hits = results.hits || {};
+    var total = hits.total || 0;
+    if (!hits.hits || hits.hits.length === 0) {
         return callback(null, new SearchModel.SearchResult(total, []));
     } else {
         // Aggregate all the documents to be keyed by type

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -445,11 +445,11 @@ describe('General Search', function() {
         /**
          * Test that verifies that the total results count stays accurate regardless of paging parameters
          */
-        it('verify search count', function(callback) {
+        it('verify search total count', function(callback) {
             TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
 
-                // Make sure we have at least 2 content items to page with, their actual information is not important for this test
+                // Make sure we have at least 2 similar content items
                 RestAPI.Content.createLink(user.restContext, 'Apereo OAE', 'Link to OAE Project Website', 'public', 'http://www.oaeproject.org', [], [], function(err, link) {
                     assert.ok(!err);
 
@@ -460,18 +460,25 @@ describe('General Search', function() {
                         SearchTestsUtil.searchRefreshed(user.restContext, 'general', null, {'q': 'Apereo'}, function(err, results) {
                             assert.ok(!err);
 
-                            // When we only select a subset of the results, the count should still reflect the total matching items in the index
-                            RestAPI.Search.search(user.restContext, 'general', null, {'q': 'Apereo', 'start': 0, 'limit': 1}, function(err, emptyResults) {
+                            // When we only select a subset of the results, the count should reflect the total matching items in the index
+                            RestAPI.Search.search(user.restContext, 'general', null, {'q': 'Apereo', 'start': 0, 'limit': 1}, function(err, startResults) {
                                 assert.ok(!err);
-                                assert.strictEqual(results.total, emptyResults.total);
-                                assert.strictEqual(emptyResults.results.length, 1);
+                                assert.strictEqual(results.total, startResults.total);
+                                assert.strictEqual(startResults.results.length, 1);
 
-                                // When we do a search with a higher start number than the total number, we should still get an accurate total
-                                RestAPI.Search.search(user.restContext, 'general', null, {'q': 'Apereo', 'start': results.total}, function(err, emptyResults) {
+                                // When we search for all the results, the count should reflect the total matching items in the index
+                                SearchTestsUtil.searchAll(user.restContext, 'general', null, {'q': 'Apereo', 'start': 0, 'limit': results.total}, function(err, allResults) {
                                     assert.ok(!err);
-                                    assert.strictEqual(results.total, emptyResults.total);
-                                    assert.strictEqual(emptyResults.results.length, 0);
-                                    return callback();
+                                    assert.strictEqual(results.total, allResults.total);
+                                    assert.strictEqual(allResults.results.length, results.total);
+
+                                    // When we do a search with a higher start number than the total number, the count should reflect the total matching items in the index
+                                    RestAPI.Search.search(user.restContext, 'general', null, {'q': 'Apereo', 'start': results.total}, function(err, emptyResults) {
+                                        assert.ok(!err);
+                                        assert.strictEqual(results.total, emptyResults.total);
+                                        assert.strictEqual(emptyResults.results.length, 0);
+                                        return callback();
+                                    });
                                 });
                             });
                         });


### PR DESCRIPTION
See https://github.com/oaeproject/Hilary/issues/784

This seems to happen when the total number of results % page size (12) is 0. In other words, when the infinite scroll tries to load the set of results following the last page, it returns 0 as the total count.

![screen shot 2014-02-13 at 16 32 38](https://f.cloud.github.com/assets/109850/2161974/a1f58588-94cc-11e3-8492-67611bb02af5.png)
