### PR TITLE
(LockIntermittentFailure) Fix intermittent test failure in locking

### DIFF
--- a/node_modules/oae-activity/lib/internal/aggregator.js
+++ b/node_modules/oae-activity/lib/internal/aggregator.js
@@ -112,7 +112,7 @@ var collectBuckets = module.exports.collectBuckets = function(bucketNumbers, cal
     var bucketNumber = bucketNumbers.shift();
     _collectBucket(bucketNumber, function(err) {
         if (err) {
-            log().warn({'err': err, 'bucketNumber': bucketNumber}, 'Error collecting aggregate bucket.');
+            log().warn({'err': err, 'bucketNumber': bucketNumber}, 'Error collecting aggregate bucket');
             Telemetry.incr('collection.error.count');
             errs.push(err);
         }
@@ -132,7 +132,7 @@ var collectBuckets = module.exports.collectBuckets = function(bucketNumbers, cal
  */
 var _collectBucket = function(bucketNumber, callback) {
     if (shuttingDown) {
-        log().info('Aborting activity bucket collection of bucket %s as shutdown is in progress.', bucketNumber);
+        log().info('Aborting activity bucket collection of bucket %s as shutdown is in progress', bucketNumber);
         return callback();
     }
 
@@ -142,6 +142,8 @@ var _collectBucket = function(bucketNumber, callback) {
         if (err) {
             return callback(err);
         } else if (lockId) {
+            log().trace({'lockId': lockId}, 'Acquired a lock on bucket number %s', bucketNumber);
+
             // We acquired the lock, perform a collection iteration
             _collectBucketBatch(bucketNumber, ActivitySystemConfig.getConfig().collectionBatchSize, function(collectionErr, empty) {
                 // We want to ensure we release the bucket, whether we received an error or not
@@ -149,10 +151,14 @@ var _collectBucket = function(bucketNumber, callback) {
                     if (collectionErr) {
                         return callback(collectionErr);
                     } else if (releaseErr) {
+                        log().warn({'err': releaseErr}, 'An unexpected error occurred while releasing the lock from bucket number %s', bucketNumber);
+
                         // If there was an error releasing the lock, worst case scenario would be that the lock eventually expires
                         // and a cluster node picks it up soon after that and continues processing.
                         return callback(releaseErr);
                     }
+
+                    log().trace({'lockId': lockId}, 'Successfully released lock for bucket number %s', bucketNumber);
 
                     if (!hadLock) {
                         // This means that the lock expired before we finished collecting, which likely means the lock expiry

--- a/node_modules/oae-activity/lib/internal/dao.js
+++ b/node_modules/oae-activity/lib/internal/dao.js
@@ -62,7 +62,7 @@ var getActivities = module.exports.getActivities = function(activityStreamId, st
 
         /*
          * The following block of code is intended for migrating from 3.0.0 to 4.0.0 (Push)
-         * The `activityStreamId` for "activity" activity streams is/was of the form: 
+         * The `activityStreamId` for "activity" activity streams is/was of the form:
          *   -  4.0.0:   `u:cam:abc123#activity`   or    `g:cam:abc123#activity`
          *   -  3.0.0:   `u:cam:abc123`            or    `g:cam:abc123`
          *

--- a/node_modules/oae-config/lib/test/util.js
+++ b/node_modules/oae-config/lib/test/util.js
@@ -43,15 +43,11 @@ var updateConfigAndWait = module.exports.updateConfigAndWait = function(restCtx,
         if (calledBack) {
             // Already called back, do nothing
             return;
-        }
-
-        if (err) {
+        } else if (err) {
             // Received an error from either rest endpoint or internal refresh, throw the error
             calledBack = true;
             return callback(err);
-        }
-
-        if (requestReturned && configRefreshed) {
+        } else if (requestReturned && configRefreshed) {
             // Call the callback with the arguments from the web request
             calledBack = true;
             return callback.apply(this, responseArgs);

--- a/node_modules/oae-util/lib/locking.js
+++ b/node_modules/oae-util/lib/locking.js
@@ -81,7 +81,7 @@ var release = module.exports.release = function(lockKey, token, callback) {
         if (err) {
             return callback(err);
         } else if (lockedToken !== token) {
-            log().trace({'lockKey': lockKey}, 'Attempted to release a lock that we did not have.');
+            log().trace({'lockKey': lockKey}, 'Attempted to release a lock that we did not have');
             // There is either no lock with this key, or we no longer hold the lock
             return callback(null, false);
         }
@@ -91,7 +91,7 @@ var release = module.exports.release = function(lockKey, token, callback) {
                 return callback(err);
             }
 
-            log().trace({'lockKey': lockKey}, 'Released a lock.');
+            log().trace({'lockKey': lockKey}, 'Released a lock');
             return callback(null, true);
         });
     });
@@ -114,8 +114,8 @@ var _acquire = function(lockKey, expiresIn, callback) {
         if (err) {
             return callback(err);
         } else if (wasSet !== 1) {
-            log().trace({'key': lockKey}, 'Failed to acquire a lock');
             // We failed to acquire the lock
+            log().trace({'key': lockKey}, 'Tried to acquire a lock when it was already locked');
             return callback();
         }
 
@@ -137,12 +137,22 @@ var _acquire = function(lockKey, expiresIn, callback) {
  * @api private
  */
 var _ensureTtl = function(lockKey, val, expiresIn) {
-    // First check the ttl on the key
-    Redis.getClient().ttl(lockKey, function(err, ttl) {
+    // Since `ttl` returns -1 both when "the key does not exist" and "the key exists with no ttl", we need to
+    // check that it both exists and has a ttl. This is because the lock may have been released sometime
+    // before this _ensureTtl executed, which is completely valid, and we will set a temporary deadlock if we
+    // execute `setex` as a result of a -1 ttl
+    var multi = Redis.getClient().multi();
+    multi.exists(lockKey);
+    multi.ttl(lockKey);
+    multi.exec(function(err, results) {
         if (err) {
             return callback(err);
-        } else if (ttl === -1) {
-            // It's not set, so we set one
+        }
+
+        var exists = (results[0] === 1);
+        var ttl = results[1];
+        if (exists && ttl === -1) {
+            // The key exists but does not have a ttl, so we set one
             Redis.getClient().setex(lockKey, expiresIn, val, function(err) {
                 if (err) {
                     // This is the best we can do, we don't want to explode or anything


### PR DESCRIPTION
This fixes an issue with intermittent test failures. When a lock is attempted to be acquired, the following happens:
1. Get the lock by key, if it doesn't exist, acquire the lock and you are finished
2. If it did exist, check if it has a ttl
3. If it doesn't have a ttl (the result of `ttl` is `-1`), apply a `ttl` using `setex` which also sets a key. This is done in case a process created the lock and crashed before it was able to apply the `ttl` causing a deadlock

If a lock is released after step 1 but before step 2, the check for the `ttl` will result in a `-1`, which will cause the process to reset a lock that was already released. This results in the lock being set and never released until it expires.

This fix puts step 1 and 2 within the same Redis transaction which ensures that it will not be impacted by a race condition.
