### PR TITLE
Include isAdmin when getting user as global/tenant admin

### DIFF
--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -491,7 +491,6 @@ var getFullUserProfile = module.exports.getFullUserProfile = function(ctx, userI
         var _finishDecorator = function() {
             numDecorators--;
             if (numDecorators === 0) {
-
                 // Apply all the decorations to the user object
                 return callback(null, _.extend(user, decorations));
             }

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -188,7 +188,7 @@ OAE.tenantRouter.on('get', '/api/user/termsAndConditions', function(req, res) {
 });
 
 /*!
- * Get a user's basic profile information
+ * Get a user's basic profile information on the global admin router
  */
 OAE.globalAdminRouter.on('get', '/api/user/:id', function(req, res) {
     PrincipalsAPI.getFullUserProfile(req.ctx, req.params.id, function(err, user) {
@@ -199,6 +199,9 @@ OAE.globalAdminRouter.on('get', '/api/user/:id', function(req, res) {
     });
 });
 
+/*!
+ * Get a user's basic profile information on the tenant router
+ */
 OAE.tenantRouter.on('get', '/api/user/:id', function(req, res) {
     PrincipalsAPI.getFullUserProfile(req.ctx, req.params.id, function(err, user) {
         if (err) {

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -939,100 +939,112 @@ describe('Users', function() {
         it('verify visibility of isGlobalAdmin and isTenantAdmin properties', function(callback) {
 
             // Create a Cambridge user
-            var camUserId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, camUserId, 'password', 'John Doe', null, function(err, camUser) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, camUsers, camUser) {
                 assert.ok(!err);
                 assert.ok(camUser);
-                var camUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, camUserId, 'password');
 
                 // Create a GT user
-                var gtUserId = TestsUtil.generateTestUserId();
-                RestAPI.User.createUser(gtAdminRestContext, gtUserId, 'password', 'Jane Doe', null, function(err, gtUser) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, gtUsers, gtUser) {
                     assert.ok(!err);
                     assert.ok(gtUser);
-                    var gtUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, gtUserId, 'password');
 
                     // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the global admin
-                    RestAPI.User.getUser(globalAdminRestContext, camUser.id, function(err, user) {
+                    RestAPI.User.getUser(globalAdminRestContext, camUser.user.id, function(err, user) {
                         assert.ok(!err);
                         assert.ok(user);
-                        assert.equal(user.isGlobalAdmin, false);
-                        assert.equal(user.isTenantAdmin, false);
+                        assert.strictEqual(user.isGlobalAdmin, false);
+                        assert.strictEqual(user.isTenantAdmin, false);
 
                         // Verify the gtUsers's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the global admin
-                        RestAPI.User.getUser(globalAdminRestContext, gtUser.id, function(err, user) {
+                        RestAPI.User.getUser(globalAdminRestContext, gtUser.user.id, function(err, user) {
                             assert.ok(!err);
                             assert.ok(user);
-                            assert.equal(user.isGlobalAdmin, false);
-                            assert.equal(user.isTenantAdmin, false);
+                            assert.strictEqual(user.isGlobalAdmin, false);
+                            assert.strictEqual(user.isTenantAdmin, false);
 
                             // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the cam admin
-                            RestAPI.User.getUser(camAdminRestContext, camUser.id, function(err, user) {
+                            RestAPI.User.getUser(camAdminRestContext, camUser.user.id, function(err, user) {
                                 assert.ok(!err);
                                 assert.ok(user);
-                                assert.equal(user.isGlobalAdmin, false);
-                                assert.equal(user.isTenantAdmin, false);
+                                assert.strictEqual(user.isGlobalAdmin, false);
+                                assert.strictEqual(user.isTenantAdmin, false);
 
                                 // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the gt admin
-                                RestAPI.User.getUser(gtAdminRestContext, camUser.id, function(err, user) {
+                                RestAPI.User.getUser(gtAdminRestContext, camUser.user.id, function(err, user) {
                                     assert.ok(!err);
                                     assert.ok(user);
                                     assert.strictEqual(user.isGlobalAdmin, undefined);
                                     assert.strictEqual(user.isTenantAdmin, undefined);
 
                                     // Verify the gtUsers's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the cam admin
-                                    RestAPI.User.getUser(camAdminRestContext, gtUser.id, function(err, user) {
+                                    RestAPI.User.getUser(camAdminRestContext, gtUser.user.id, function(err, user) {
                                         assert.ok(!err);
                                         assert.ok(user);
                                         assert.strictEqual(user.isGlobalAdmin, undefined);
                                         assert.strictEqual(user.isTenantAdmin, undefined);
 
                                         // Verify the gtUsers's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the gt admin
-                                        RestAPI.User.getUser(gtAdminRestContext, gtUser.id, function(err, user) {
+                                        RestAPI.User.getUser(gtAdminRestContext, gtUser.user.id, function(err, user) {
                                             assert.ok(!err);
                                             assert.ok(user);
-                                            assert.equal(user.isGlobalAdmin, false);
-                                            assert.equal(user.isTenantAdmin, false);
+                                            assert.strictEqual(user.isGlobalAdmin, false);
+                                            assert.strictEqual(user.isTenantAdmin, false);
 
                                             // Verifty the camUsers's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the GT user
-                                            RestAPI.User.getUser(camUserRestContext, camUser.id, function(err, user) {
+                                            RestAPI.User.getUser(camUser.restContext, camUser.user.id, function(err, user) {
                                                 assert.ok(!err);
                                                 assert.ok(user);
                                                 assert.strictEqual(user.isGlobalAdmin, undefined);
                                                 assert.strictEqual(user.isTenantAdmin, undefined);
 
                                                 // Verifty the camUsers's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the anonymous user
-                                                RestAPI.User.getUser(anonymousRestContext, camUser.id, function(err, user) {
+                                                RestAPI.User.getUser(anonymousRestContext, camUser.user.id, function(err, user) {
                                                     assert.ok(!err);
                                                     assert.ok(user);
                                                     assert.strictEqual(user.isGlobalAdmin, undefined);
                                                     assert.strictEqual(user.isTenantAdmin, undefined);
 
-                                                    // Make camUser a tenant admin
-                                                    RestAPI.User.setTenantAdmin(globalAdminRestContext, camUser.id, true, function(err) {
+                                                    // Verifty the camUsers's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the global anonymous user
+                                                    RestAPI.User.getUser(anonymousGlobalRestContext, camUser.user.id, function(err, user) {
                                                         assert.ok(!err);
+                                                        assert.ok(user);
+                                                        assert.strictEqual(user.isGlobalAdmin, undefined);
+                                                        assert.strictEqual(user.isTenantAdmin, undefined);
 
-                                                        // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the global admin
-                                                        RestAPI.User.getUser(globalAdminRestContext, camUser.id, function(err, user) {
+                                                        // Make camUser a tenant admin
+                                                        RestAPI.User.setTenantAdmin(globalAdminRestContext, camUser.user.id, true, function(err) {
                                                             assert.ok(!err);
-                                                            assert.ok(user);
-                                                            assert.equal(user.isGlobalAdmin, false);
-                                                            assert.equal(user.isTenantAdmin, true);
 
-                                                            // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the cam admin
-                                                            RestAPI.User.getUser(camAdminRestContext, camUser.id, function(err, user) {
+                                                            // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the global admin
+                                                            RestAPI.User.getUser(globalAdminRestContext, camUser.user.id, function(err, user) {
                                                                 assert.ok(!err);
                                                                 assert.ok(user);
-                                                                assert.equal(user.isGlobalAdmin, false);
-                                                                assert.equal(user.isTenantAdmin, true);
+                                                                assert.strictEqual(user.isGlobalAdmin, false);
+                                                                assert.strictEqual(user.isTenantAdmin, true);
 
-                                                                // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the gt admin
-                                                                RestAPI.User.getUser(gtAdminRestContext, camUser.id, function(err, user) {
+                                                                // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are visible for the cam admin
+                                                                RestAPI.User.getUser(camAdminRestContext, camUser.user.id, function(err, user) {
                                                                     assert.ok(!err);
                                                                     assert.ok(user);
-                                                                    assert.strictEqual(user.isGlobalAdmin, undefined);
-                                                                    assert.strictEqual(user.isTenantAdmin, undefined);
-                                                                    return callback();
+                                                                    assert.strictEqual(user.isGlobalAdmin, false);
+                                                                    assert.strictEqual(user.isTenantAdmin, true);
+
+                                                                    // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the gt admin
+                                                                    RestAPI.User.getUser(gtAdminRestContext, camUser.user.id, function(err, user) {
+                                                                        assert.ok(!err);
+                                                                        assert.ok(user);
+                                                                        assert.strictEqual(user.isGlobalAdmin, undefined);
+                                                                        assert.strictEqual(user.isTenantAdmin, undefined);
+
+                                                                        // Verify the camUser's `isGlobalAdmin` and `isTenantAdmin` properties are NOT visible for the gt user
+                                                                        RestAPI.User.getUser(gtUser.restContext, camUser.user.id, function(err, user) {
+                                                                            assert.ok(!err);
+                                                                            assert.ok(user);
+                                                                            assert.strictEqual(user.isGlobalAdmin, undefined);
+                                                                            assert.strictEqual(user.isTenantAdmin, undefined);
+                                                                            return callback();
+                                                                        });
+                                                                    });
                                                                 });
                                                             });
                                                         });


### PR DESCRIPTION
The following properties are present on the `/api/me` feed:

```
"isGlobalAdmin": true/false,
"isTenantAdmin": true/false,
```

However, when getting a user, these properties are currently not present. We should add these properties when a user is requested by a global admin. We should also add them when a user from Tenant X is requested by a tenant admin from Tenant X (but not Tenant Y).

This will then be used in the Admin UI to show if a user is a tenant admin or not and to show the appropriate action button.
