### PR TITLE
Check if a specified email address is already in use on user creation/update

### DIFF
--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -118,46 +118,77 @@ var createUser = module.exports.createUser = function(ctx, displayName, opts, ca
         return callback(validator.getFirstError());
     }
 
-    var id = AuthzUtil.toId('u', tenantAlias, ShortId.generate());
-
-    var values = {
-        'tenantAlias': tenantAlias,
-        'displayName': displayName,
-        'visibility': opts.visibility,
-        'email': opts.email,
-        'locale': opts.locale,
-        'timezone': opts.timezone,
-        'publicAlias': opts.publicAlias,
-        'smallPictureUri': opts.smallPictureUri,
-        'mediumPictureUri': opts.mediumPictureUri,
-        'largePictureUri': opts.lagePictureUri
-    };
-
-    // We store the timestamp at which the user accepted the Terms and Conditions
-    // This allows for allowing users to re-accept the Terms and Conditions after they have been updated
-    var tcEnabled = PrincipalsConfig.getValue(tenantAlias, 'termsAndConditions', 'enabled');
-    if (tcEnabled && opts.acceptedTC) {
-        values.acceptedTC = Date.now();
-
-        // Store the timestamp in the optional values as well, so that the user object we return to the UI contains the correct timestamp
-        opts.acceptedTC = values.acceptedTC;
-    }
-
-    var q = Cassandra.constructUpsertCQL('Principals', 'principalId', id, values);
-    if (!q) {
-        return callback({'code': 500, 'msg': 'Could not create a proper CQL query'});
-    }
-
-    // Create the user
-    Cassandra.runQuery(q.query, q.parameters, function (err) {
+    // Before registering the user, we check if the email address hasn't been associated with another user profile
+    PrincipalsDAO.checkIfEmailIsAlreadyRegistered(opts.email, function(err, userId) {
         if (err) {
+            log().error(err);
             return callback(err);
         }
 
-        var createdUser = new PrincipalsModel.User(tenantAlias, id, displayName, opts);
-        createdUser.needsToAcceptTC = false;
-        PrincipalsEmitter.emit(PrincipalsConstants.events.CREATED_USER, ctx, createdUser);
-        return callback(null, createdUser);
+        if (userId) {
+            log().error({'id': userId}, 'Email address already in use');
+            return callback({'code': 400, 'msg': 'Email address already in use'});
+        }
+
+        var id = AuthzUtil.toId('u', tenantAlias, ShortId.generate());
+
+        var values = {
+            'tenantAlias': tenantAlias,
+            'displayName': displayName,
+            'visibility': opts.visibility,
+            'email': opts.email,
+            'locale': opts.locale,
+            'timezone': opts.timezone,
+            'publicAlias': opts.publicAlias,
+            'smallPictureUri': opts.smallPictureUri,
+            'mediumPictureUri': opts.mediumPictureUri,
+            'largePictureUri': opts.lagePictureUri
+        };
+
+        // We store the timestamp at which the user accepted the Terms and Conditions
+        // This allows for allowing users to re-accept the Terms and Conditions after they have been updated
+        var tcEnabled = PrincipalsConfig.getValue(tenantAlias, 'termsAndConditions', 'enabled');
+        if (tcEnabled && opts.acceptedTC) {
+            values.acceptedTC = Date.now();
+
+            // Store the timestamp in the optional values as well, so that the user object we return to the UI contains the correct timestamp
+            opts.acceptedTC = values.acceptedTC;
+        }
+
+        var q = Cassandra.constructUpsertCQL('Principals', 'principalId', id, values);
+        if (!q) {
+            return callback({'code': 500, 'msg': 'Could not create a proper CQL query'});
+        }
+
+        // Create the user
+        Cassandra.runQuery(q.query, q.parameters, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            var createdUser = new PrincipalsModel.User(tenantAlias, id, displayName, opts);
+            createdUser.needsToAcceptTC = false;
+
+            if (!opts.email) {
+                PrincipalsEmitter.emit(PrincipalsConstants.events.CREATED_USER, ctx, createdUser);
+                return callback(null, createdUser);
+            }
+
+            // Add the user to the PrincipalsEmails table
+            var q = Cassandra.constructUpsertCQL('PrincipalsEmails', 'email', opts.email, {'principalId': id});
+            if (!q) {
+                return callback({'code': 500, 'msg': 'Could not create a proper CQL query'});
+            }
+
+            // Add the email address and the user id to
+            Cassandra.runQuery(q.query, q.parameters, function(err) {
+                if (err) {
+                    return callback(err);
+                }
+                PrincipalsEmitter.emit(PrincipalsConstants.events.CREATED_USER, ctx, createdUser);
+                return callback(null, createdUser);
+            });
+        });
     });
 };
 

--- a/node_modules/oae-principals/lib/init.js
+++ b/node_modules/oae-principals/lib/init.js
@@ -53,8 +53,10 @@ module.exports = function(config, callback) {
  * @api private
  */
 var ensureSchema = function(callback) {
-    // Both user and group information will be stored inside of the Principals CF
-    Cassandra.createColumnFamily('Principals', 'CREATE COLUMNFAMILY Principals (principalId text PRIMARY KEY, tenantAlias text, displayName text, visibility text);', callback);
+    Cassandra.createColumnFamilies({
+        'Principals': 'CREATE COLUMNFAMILY Principals (principalId text PRIMARY KEY, tenantAlias text, displayName text, visibility text);',
+        'PrincipalsEmails': 'CREATE COLUMNFAMILY PrincipalsEmails (email text PRIMARY KEY, principalId text);'
+    }, callback);
 };
 
 /**

--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -157,26 +157,53 @@ var updatePrincipal = module.exports.updatePrincipal = function(principalId, pro
         return callback(validator.getFirstError());
     }
 
-    var q = Cassandra.constructUpsertCQL('Principals', 'principalId', principalId, profileFields, 'QUORUM');
-    if (!q) {
-        return callback({'code': 500, 'msg': 'Unable to store profile fields'});
-    }
-
-    Cassandra.runQuery(q.query, q.parameters, function(err) {
+    // If the email needs to be updated, we will check if it's not already in use
+    var email = profileFields.email || null;
+    checkIfEmailIsAlreadyRegistered(email, function(err, userId) {
         if (err) {
+            log().error(err);
             return callback(err);
         }
 
-        if (isUser(principalId)) {
-            // Update the user in cache
-
-            // Ensure the `principalId` is not part of the hash to avoid revalidating a stale cache entry
-            profileFields = _.extend({}, profileFields);
-            delete profileFields.principalId;
-            return _updateCachedUser(principalId, profileFields, callback);
-        } else {
-            return callback();
+        if (userId) {
+            log().warn({'id': userId}, 'Email address already in use');
+            return callback({'code': 400, 'msg': 'Email address already in use'});
         }
+
+        var q = Cassandra.constructUpsertCQL('Principals', 'principalId', principalId, profileFields, 'QUORUM');
+        if (!q) {
+            return callback({'code': 500, 'msg': 'Unable to store profile fields'});
+        }
+
+        Cassandra.runQuery(q.query, q.parameters, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            if (isUser(principalId)) {
+
+                // Add the user to the PrincipalsEmails table
+                var q = Cassandra.constructUpsertCQL('PrincipalsEmails', 'email', email, {'principalId': principalId});
+                if (!q) {
+                    return callback({'code': 500, 'msg': 'Could not create a proper CQL query'});
+                }
+
+                // Add the email address and the user id to
+                Cassandra.runQuery(q.query, q.parameters, function(err) {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    // Ensure the `principalId` is not part of the hash to avoid revalidating a stale cache entry
+                    profileFields = _.extend({}, profileFields);
+                    delete profileFields.principalId;
+                    return _updateCachedUser(principalId, profileFields, callback);
+                });
+
+            } else {
+                return callback();
+            }
+        });
     });
 };
 
@@ -194,6 +221,35 @@ var acceptTermsAndConditions = module.exports.acceptTermsAndConditions = functio
         }
 
         invalidateCachedUsers([userId], callback);
+    });
+};
+
+/**
+ * Check if a user is already registered with a specific email address
+ *
+ * @param  {String}    email              The user's email address
+ * @param  {Function}  callback           Standard callback function.
+ * @param  {Object}    callback.err       Error object containing the error message
+ * @param  {String}    callback.userId    The user id
+ * @api private
+ */
+var checkIfEmailIsAlreadyRegistered = module.exports.checkIfEmailIsAlreadyRegistered = function(email, callback) {
+    if (!email) {
+        return callback();
+    }
+
+    Cassandra.runQuery('SELECT * FROM PrincipalsEmails USING CONSISTENCY QUORUM WHERE email = ?', [email], function(err, rows) {
+        if (err) {
+            return callback(err);
+        }
+
+        // No record found
+        if (!rows[0][1]) {
+            return callback();
+        }
+
+        // Return the userId if a record was found
+        return callback(null, rows[0][1]['value']);
     });
 };
 

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -216,6 +216,87 @@ describe('Users', function() {
         });
 
         /**
+         * Test that verifies that it should only be possible to register a user if a specified email address hasn't been used yet
+         */
+        it('verify email on user creation', function(callback) {
+            // Generate a user without an email address
+            var userId = TestsUtil.generateTestUserId();
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Mr. Visser', null, function(err, userObj) {
+                assert.ok(!err);
+                assert.ok(userObj);
+                assert.strictEqual(userObj.resourceType, 'user');
+                assert.strictEqual(userObj.displayName, 'Mr. Visser');
+
+                // Generate a user with an email address
+                var userId = TestsUtil.generateTestUserId();
+                RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Coenego', {'email': 'existing@mail.com'}, function(err, userObj) {
+                    assert.ok(!err);
+                    assert.ok(userObj);
+                    assert.strictEqual(userObj.resourceType, 'user');
+                    assert.strictEqual(userObj.displayName, 'Coenego');
+                    assert.strictEqual(userObj.email, 'existing@mail.com');
+
+                    // Try to register a user with an email address that is already in use
+                    var userId = TestsUtil.generateTestUserId();
+                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Simong', {'email': 'existing@mail.com'}, function(err, userObj) {
+                        assert.ok(err);
+                        assert.strictEqual(err.code, 400);
+                        assert.strictEqual(err.msg, 'Email address already in use');
+                        assert.ok(!userObj);
+                        return callback();
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that it should only be possible to update a user's email address if the specified email address hasn't been used yet
+         */
+        it('verify email on user update', function(callback) {
+            // Create a new Coenego user
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, coenego) {
+                assert.ok(!err);
+                assert.ok(coenego);
+                assert.ok(!coenego.user.email);
+
+                // Update the Coenego user's email address
+                var email = 'another.existing@mail.com';
+                RestAPI.User.updateUser(coenego.restContext, coenego.user.id, {'email': email}, function(err) {
+                    assert.ok(!err);
+
+                    // Ensure the Coenego user's email address has actually been changed
+                    RestAPI.User.getUser(camAdminRestContext, coenego.user.id, function(err, user) {
+                        assert.ok(!err);
+                        assert.ok(user);
+                        assert.strictEqual(user.email, email);
+
+                        // Create a new Simong user
+                        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                            assert.ok(!err);
+                            assert.ok(simong);
+                            assert.ok(!simong.user.email);
+
+                            // Update the Simong user's email address using the Coenego user's email address
+                            RestAPI.User.updateUser(simong.restContext, simong.user.id, {'email': email}, function(err) {
+                                assert.ok(err);
+                                assert.equal(err.code, 400);
+                                assert.equal(err.msg, 'Email address already in use');
+
+                                // Ensure the Simong user's email address has NOT been updated
+                                RestAPI.User.getUser(camAdminRestContext, simong.user.id, function(err, user) {
+                                    assert.ok(!err);
+                                    assert.ok(user);
+                                    assert.ok(!user.email);
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies that the default tenant user visibility is used when creating a user without a visibility
          */
         it('verify user visibility defaults to the tenant default when created', function(callback) {


### PR DESCRIPTION
Before creating/updating a user, we first check if the specified email address has not yet been saved in `PrincipalsEmails`
