### PR TITLE
Remove Uris from REST API

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -129,7 +129,21 @@ var getFullContentProfile = module.exports.getFullContentProfile = function(ctx,
                 return callback(err);
             }
 
-            _getFullContentProfile(ctx, contentObj, isManager, callback);
+            _getFullContentProfile(ctx, contentObj, isManager, function(err, contentProfile) {
+                if (err) {
+                    return callback(err);
+                }
+
+                // Remove the preview uri's from the content profile
+                if (contentProfile.previews) {
+                    delete contentProfile.previews.smallUri;
+                    delete contentProfile.previews.mediumUri;
+                    delete contentProfile.previews.largeUri;
+                    delete contentProfile.previews.thumbnailUri;
+                }
+
+                return callback(null, contentProfile);
+            });
         });
     });
 };

--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -101,6 +101,13 @@ var getFullGroupProfile = module.exports.getFullGroupProfile = function(ctx, gro
             group.isManager = (_.contains(roles, Constants.roles.MANAGER) || isAdmin);
             group.canJoin = _canJoin(ctx, group, hasRole);
 
+            // Remove the picture uri's
+            if (group.picture) {
+                delete group.picture.smallUri;
+                delete group.picture.mediumUri;
+                delete group.picture.largeUri;
+            }
+
             if (group.isMember) {
                 // Generate a signature that can be used for push notifications
                 var tenantAlias = AuthzUtil.getResourceFromId(groupId).tenantAlias;
@@ -555,7 +562,7 @@ var joinGroup = module.exports.joinGroup = function(ctx, groupId, callback) {
                         PrincipalsEmitter.emit(PrincipalsConstants.events.JOINED_GROUP, ctx, group, Constants.roles.MEMBER);
                         return callback();
                     };
- 
+
                     // Update the libraries to indicate there has been group activity
                     var oldLastModified = group.lastModified;
                     var newLastModified = Date.now();
@@ -805,7 +812,7 @@ var updateGroup = module.exports.updateGroup = function(ctx, groupId, profileFie
                                 'memberIds': memberIds
                             }, 'An error occurred while updating the library index for group members after group update');
                         }
-                        
+
                         return _callback();
                     });
                 });
@@ -957,7 +964,7 @@ var _updateMembershipsLibraries = function(memberIds, group, oldLastModified, ca
     if (!_.isArray(memberIds) || memberIds.length === 0) {
         return callback();
     }
-    
+
     var libraryVisibilities = LibraryAPI.Authz.resolveEffectiveLibraryVisibilities(memberIds, group);
     LibraryAPI.Index.update(PrincipalsConstants.library.MEMBERSHIPS_INDEX_NAME, libraryVisibilities, group.id, group.lastModified, oldLastModified, callback);
 };
@@ -975,7 +982,7 @@ var _removeMembershipsLibraries = function(memberIds, groupId, oldLastModified, 
     if (!_.isArray(memberIds) || memberIds.length === 0) {
         return callback();
     }
-    
+
     LibraryAPI.Index.remove(PrincipalsConstants.library.MEMBERSHIPS_INDEX_NAME, memberIds, groupId, oldLastModified, callback);
 };
 

--- a/node_modules/oae-principals/lib/util.js
+++ b/node_modules/oae-principals/lib/util.js
@@ -53,6 +53,14 @@ var getPrincipal = module.exports.getPrincipal = function(ctx, principalId, call
         if (isUser(principalId)) {
             hideUserData(ctx, principal);
         }
+
+        // Remove the picture uri's from the user profile
+        if (principal.picture) {
+            delete principal.picture.smallUri;
+            delete principal.picture.mediumUri;
+            delete principal.picture.largeUri;
+        }
+
         return callback(null, principal);
     });
 };


### PR DESCRIPTION
Currently, REST API endpoints for users, groups and content will return a number of `Uri`s (e.g. `largeUri`, `mediumUri`, `smallUri`, `thumbnailUri`, etc.) when the entity has a profile picture. These should not be part of the response, as they can be confusing for people using the REST API directly.

e.g.

```
{
    "tenant": {
        "alias": "cam",
        "displayName": "University of Cambridge"
    },
    "id": "c:cam:xJWYxPdRI",
    "visibility": "private",
    "displayName": "Island-picture.jpg",
    "description": "",
    "resourceSubType": "file",
    "createdBy": {
        "tenant": {
            "alias": "cam",
            "displayName": "University of Cambridge"
        },
        "id": "u:cam:xkz4o2gvIX",
        "displayName": "Bert Pareyn",
        "visibility": "public",
        "picture": {
            "smallUri": "local:u/cam/xk/z4/o2/gv/xkz4o2gvIX/profilepictures/small.jpg",
            "mediumUri": "local:u/cam/xk/z4/o2/gv/xkz4o2gvIX/profilepictures/medium.jpg",
            "largeUri": "local:u/cam/xk/z4/o2/gv/xkz4o2gvIX/profilepictures/large.jpg",
            "small": "/api/download/signed?uri=local:u/cam/xk/z4/o2/gv/xkz4o2gvIX/profilepictures/small.jpg&signature=fda46a8323a3fa283af377d6a3e0bede57172ef9&expires=1387729800000",
            "medium": "/api/download/signed?uri=local:u/cam/xk/z4/o2/gv/xkz4o2gvIX/profilepictures/medium.jpg&signature=3aa6c274d16497d089b4848fb3085cb1109f0bb9&expires=1387729800000",
            "large": "/api/download/signed?uri=local:u/cam/xk/z4/o2/gv/xkz4o2gvIX/profilepictures/large.jpg&signature=5a416d6062572e4322e1cad8343c0d41e2f10d04&expires=1387729800000"
        },
        "profilePath": "/user/cam/xkz4o2gvIX",
        "resourceType": "user",
        "acceptedTC": 1386694519756,
        "lastModified": "1387727690664"
    },
    "created": "1387728538742",
    "lastModified": "1387728538744",
    "downloadPath": "/api/content/c:cam:xJWYxPdRI/download/rev:cam:eJlZKevO0I",
    "profilePath": "/content/cam/xJWYxPdRI",
    "resourceType": "content",
    "latestRevisionId": "rev:cam:eJlZKevO0I",
    "filename": "Island-picture.jpg",
    "size": 128319,
    "mime": "image/jpeg",
    "previews": {
        "largeUri": "local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/large.jpg",
        "mediumUri": "local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/medium.jpg",
        "smallUri": "local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/small.jpg",
        "status": "done",
        "total": 4,
        "thumbnailUri": "local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/thumbnail.jpg",
        "thumbnailUrl": "/api/download/signed?uri=local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/thumbnail.jpg&signature=49b9032e0771a7f9bed283683646a95ab65d2c88&expires=1387729800000",
        "smallUrl": "/api/download/signed?uri=local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/small.jpg&signature=20e42afe2d1753314e70342f227c31d659b3becd&expires=1387729800000",
        "mediumUrl": "/api/download/signed?uri=local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/medium.jpg&signature=69ac05d9a98124f6222a840e5c3177a878e41db0&expires=1387729800000",
        "largeUrl": "/api/download/signed?uri=local:c/cam/xJ/WY/xP/dR/xJWYxPdRI/previews/rev-cam-eJlZKevO0I/large.jpg&signature=479fb5911f8e011d1dacca287581e8ac81fa56aa&expires=1387729800000"
    },
    "signature": {
        "signature": "acd391e7c5cde8ccf887237b65b00c2d6f931f79",
        "expires": 1387729800000,
        "lastModified": "1387728538744"
    },
    "isManager": false,
    "canShare": false
}
```
