### PR TITLE
Event Listener leak in unit tests

### DIFF
--- a/node_modules/oae-preview-processor/lib/api.js
+++ b/node_modules/oae-preview-processor/lib/api.js
@@ -62,20 +62,20 @@ var PreviewProcessorAPI = module.exports = new events.EventEmitter();
 /**
  * Start listening for preview tasks.
  *
- * @param  {Function}    [callback]      Standard callback method.
- * @param  {Object}      [callback.err]  Standard error object (if any.)
+ * @param  {Function}    [callback]      Standard callback method
+ * @param  {Object}      [callback.err]  Standard error object (if any)
  */
 var enable = module.exports.enable = function(callback) {
     callback = callback || function(err) { /* error is logged within the implementation */ };
 
-    // Set up the message queue and start listenening for preview tasks.
+    // Set up the message queue and start listenening for preview tasks
     var options = {
         'subscribe': {
             'prefetchCount': 1
         }
     };
 
-    // Bind an error listener to the REST methods.
+    // Bind an error listener to the REST methods
     RestUtil.on('error', _restErrorLister);
 
     TaskQueue.bind(PreviewConstants.MQ.TASK_GENERATE_PREVIEWS, _handleGeneratePreviewsTask, options, function(err) {
@@ -101,8 +101,8 @@ var enable = module.exports.enable = function(callback) {
 /**
  * Remove the listener for preview tasks.
  *
- * @param  {Function}    [callback]      Standard callback method.
- * @param  {Object}      [callback.err]  Standard error object (if any.)
+ * @param  {Function}    [callback]      Standard callback method
+ * @param  {Object}      [callback.err]  Standard error object (if any)
  */
 var disable = module.exports.disable = function(callback) {
     callback = callback || function(err) { /* error is logged within the implementation */ };

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -260,7 +260,7 @@ describe('Preview processor', function() {
         /*!
          * Disable the Preview Processor in case we enabled it earlier
          */
-        after(function(callback) {
+        afterEach(function(callback) {
             // Ignore this test if the PP is disabled
             if (!defaultConfig.previews.enabled) {
                 return callback();


### PR DESCRIPTION
In `oae-preview-processor/tests/test-previews.js`, the `beforeEach` will run `PreviewProcessorAPI.enable` before each test, but `PreviewProcessorAPI.disable` will run only on the `after` which causes this console warning:

```
      ✓ verify default link processing works (10871ms)
      ✓ verify default link processing checks if a url is embeddable in an iframe (8867ms)
      ✓ verify default link processing checks if a url is available over HTTPS (11979ms)
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at EventEmitter.addListener (events.js:160:15)
    at EventEmitter.module.exports.enable (/Users/branden/Source/oaeproject/Hilary/node_modules/oae-preview-processor/lib/api.js:79:14)
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-preview-processor/tests/test-previews.js:249:32
    at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-preview-processor/lib/test/util.js:74:28
    at null.<anonymous> (/Users/branden/Source/oaeproject/Hilary/node_modules/oae-util/lib/mq.js:522:16)
    at EventEmitter.emit (events.js:117:20)
    at exports.Promise.emitSuccess (/Users/branden/Source/oaeproject/Hilary/node_modules/amqp/lib/promise.js:49:13)
    at Queue.Channel._handleTaskReply (/Users/branden/Source/oaeproject/Hilary/node_modules/amqp/lib/channel.js:69:20)
    at Queue._onMethod (/Users/branden/Source/oaeproject/Hilary/node_modules/amqp/lib/queue.js:355:29)
    at Queue.Channel._onChannelMethod (/Users/branden/Source/oaeproject/Hilary/node_modules/amqp/lib/channel.js:85:12)
      ✓ verify default link processing can handle HEAD failures (4063ms)
```
