### PR TITLE
Restored revisions no longer have working previews

### DIFF
--- a/node_modules/oae-preview-processor/lessTemplates/pdf2html.less.jst
+++ b/node_modules/oae-preview-processor/lessTemplates/pdf2html.less.jst
@@ -1,4 +1,4 @@
-.<%= contentId %>-<%= revisionId %>-pdf2html {
+.<%= cssScopeClass %> {
     @import (less) "base.min.css";
     @import (less) "fancy.min.css";
     @import (less) "lines.css";

--- a/node_modules/oae-preview-processor/lib/processors/file/pdf.js
+++ b/node_modules/oae-preview-processor/lib/processors/file/pdf.js
@@ -202,10 +202,12 @@ var _convertPDFToHTMLPages = function(ctx, path, pagesDir, callback) {
 
             // Process the CSS files using LESS. We have to replace any
             // colons in the parameters to ensure a valid LESS syntax
-            var lessSource = _pdf2htmlLessTemplate({
-                contentId: ctx.contentId.replace(/:/g, '-'),
-                revisionId: ctx.revisionId.replace(/:/g, '-')
-            });
+            var cssScopeClass = util.format('%s-%s-pdf2html', ctx.contentId.replace(/:/g, '-'),  ctx.revision.previewsId.replace(/:/g, '-'));
+            var lessSource = _pdf2htmlLessTemplate({'cssScopeClass': cssScopeClass});
+
+            // Add the CSS scope class in the preview metadata so the UI can apply it
+            // on the div that will embed the generated HTML
+            ctx.addPreviewMetadata('cssScopeClass', cssScopeClass);
 
             // Compile the LESS template with include paths set to the location
             // of the generated style sheets

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var assert = require('assert');
 var fs = require('fs');
 var gm = require('gm');
+var less = require('less');
 var request = require('request');
 var ShortId = require('shortid');
 var Path = require('path');
@@ -600,6 +601,60 @@ describe('Preview processor', function() {
                                     callback();
                                 });
                             });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that the CSS rules from PDF previews are scoped with the previews ID
+         */
+        it('verify the CSS rules for PDF previews are scoped with the previewsId', function(callback) {
+            // Ignore this test if the PP is disabled
+            if (!defaultConfig.previews.enabled) {
+                return callback();
+            }
+
+            // OpenOffice can sometimes be painfully slow to start up
+            this.timeout(50000);
+
+            _createContentAndWait('file', null, getMultiplePagesPDFStream, function(restCtx, content) {
+                assert.equal(content.previews.status, 'done');
+                assert.equal(content.previews.pageCount, 2);
+                RestAPI.Content.getRevision(restCtx, content.id, content.latestRevisionId, function(err, revision) {
+                    assert.ok(!err);
+
+                    // Assert we expose the scope selector class name
+                    var scopeSelectorClass = util.format('%s-%s-pdf2html', content.id.replace(/:/g, '-'),  revision.previewsId.replace(/:/g, '-'));
+                    assert.equal(content.previews.scopeSelectorClass, scopeSelectorClass);
+
+                    // Download the combined CSS file
+                    var params = {
+                        'signature': content.signature.signature,
+                        'expires': content.signature.expires,
+                        'lastmodified': content.signature.lastModified
+                    };
+                    var url = util.format('/api/content/%s/revisions/%s/previews/combined.css', content.id, content.latestRevisionId);
+                    RestUtil.RestRequest(restCtx, url, 'GET', params, function(err, body, response) {
+                        assert.ok(!err);
+                        assert.equal(response.statusCode, 200);
+                        assert.ok(body);
+
+                        // We parse the CSS file with less so we can assert that all CSS rules are properly scoped
+                        var parser = less.Parser({});
+                        parser.parse(body, function (err, tree) {
+                            assert.ok(!err);
+
+                            // Each CSS rule should be of the form:
+                            //    .contentId-previewsId-pdf2html <pdf2html rule>
+                            var expectedFirstElement = util.format('.%s', scopeSelectorClass);
+                            for (var i = 0; i < tree.rules.length; i++) {
+                                if (tree.rules[i].selectors && tree.rules[i].selectors[0].elements) {
+                                    assert.strictEqual(tree.rules[i].selectors[0].elements[0].value, expectedFirstElement, 'Unexpected first element for rule ' + i);
+                                }
+                            }
+                            return callback();
                         });
                     });
                 });


### PR DESCRIPTION
Regression from #741 . We currently just copy the preview from the restored revision. Unfortunately, the revision id is inside of the preview CSS file, and therefore previews for restored content items are no longer working.
