### PR TITLE
Config "getLastUpdate" reports time of last config reload, not update time

### DIFF
--- a/node_modules/oae-config/lib/api.js
+++ b/node_modules/oae-config/lib/api.js
@@ -355,7 +355,7 @@ var cacheTenantConfig = function(tenantAlias, callback) {
         }
     };
 
-    Cassandra.runQuery('SELECT * FROM "Config" WHERE "tenantAlias" = ?', [tenantAlias], function(err, rows) {
+    Cassandra.runQuery('SELECT "configKey", "value", WRITETIME("value") FROM "Config" WHERE "tenantAlias" = ?', [tenantAlias], function(err, rows) {
         if (err) {
             return callback(err);
         }
@@ -364,7 +364,7 @@ var cacheTenantConfig = function(tenantAlias, callback) {
         _.each(rows, function(row) {
             persistentConfig[row.get('configKey').value] = {
                 'value': row.get('value').value,
-                'timestamp': row.get('value').timestamp
+                'timestamp': new Date(Math.floor(row.get('writetime(value)').value/1000))
             };
         });
 

--- a/node_modules/oae-config/tests/test-config.js
+++ b/node_modules/oae-config/tests/test-config.js
@@ -170,7 +170,7 @@ describe('Configuration', function() {
         /**
          * Test that verifies the last updated timestamp is reflected when a value gets updated
          */
-        it('verify the last updated timestamp', function(callback) {
+        it('verify the last updated timestamp increases when updated', function(callback) {
             var PrincipalsConfig = ConfigAPI.config('oae-principals');
 
             // Not passing in any of the `tenantAlias`, `feature` or `element` parameters should result in the epoch date being returned
@@ -183,13 +183,47 @@ describe('Configuration', function() {
 
             // The createTenantWithAdmin test utility will set the recaptcha value to disabled when the tenant has been created. This should be reflected in the last updated timestamp
             var tenantAlias = TestsUtil.generateRandomText(1);
-            TestsUtil.createTenantWithAdmin(tenantAlias, tenantAlias, function(tenant, tenantAdminRestContext) {
-                assert.ok(PrincipalsConfig.getLastUpdated(tenantAlias, 'recaptcha', 'enabled').getTime() > 0);
+            TestsUtil.createTenantWithAdmin(tenantAlias, tenantAlias, function(err, tenant, tenantAdminRestContext) {
+                assert.ok(!err);
 
-                return callback();
+                // Record the current value of the recaptcha config update timestamp
+                var recaptchaUpdateTime = PrincipalsConfig.getLastUpdated(tenantAlias, 'recaptcha', 'enabled').getTime();
+                assert.ok(recaptchaUpdateTime > 0);
+
+                // Enable recaptcha on the tenant
+                ConfigTestUtil.updateConfigAndWait(tenantAdminRestContext, null, {'oae-principals/recaptcha/enabled': true}, function(err) {
+                    assert.ok(!err);
+
+                    // Ensure the config value update time is larger than it was before
+                    assert.ok(PrincipalsConfig.getLastUpdated(tenantAlias, 'recaptcha', 'enabled').getTime() > recaptchaUpdateTime);
+                    return callback();
+                });
             });
         });
 
+        /**
+         * Test that verifies the last updated timestamp does not get updated when the value does not change
+         */
+        it('verify the last updated timestamp does not change when the config value did not change', function(callback) {
+            var PrincipalsConfig = ConfigAPI.config('oae-principals');
+            var tenantAlias = TestsUtil.generateRandomText(1);
+            TestsUtil.createTenantWithAdmin(tenantAlias, tenantAlias, function(err, tenant, tenantAdminRestContext) {
+                assert.ok(!err);
+
+                // Record the current value of the recaptcha config update timestamp
+                var recaptchaUpdateTime = PrincipalsConfig.getLastUpdated(tenantAlias, 'recaptcha', 'enabled').getTime();
+                assert.ok(recaptchaUpdateTime > 0);
+
+                // Update a different configuration field. Let's enable the twitter!
+                ConfigTestUtil.updateConfigAndWait(tenantAdminRestContext, null, {'oae-authentication/twitter/enabled': true}, function(err) {
+                    assert.ok(!err);
+
+                    // Ensure the recaptcha config update timestamp has not updated
+                    assert.strictEqual(PrincipalsConfig.getLastUpdated(tenantAlias, 'recaptcha', 'enabled').getTime(), recaptchaUpdateTime);
+                    return callback();
+                });
+            });
+        });
     });
 
 


### PR DESCRIPTION
This was introduced by CQL3. CQL3  introduces a WRITETIME function that should be used instead:

e.g., 

``` sql
select writetime(value) from "Config" where "tenantAlias"='cam'
```
