### PR TITLE
Webshot fails to render links or etherpad docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_install:
   - sudo service memcached stop
   - sudo service postgresql stop
 
+  # We must ensure phantomjs is not available so the travis build will include it in node_modules when deploying
+  - sudo rm -rf /usr/local/phantomjs
+
   # Install Hilary deps
   - sudo apt-get install -qq graphicsmagick libreoffice pdftk chrpath pdf2htmlex
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "grunt": "latest",
     "grunt-cli": "latest",
     "grunt-contrib-clean": "latest",
-    "grunt-contrib-jshint": "latest",
+    "grunt-contrib-jshint": "0.8.0",
     "grunt-mocha-hack": "latest",
     "grunt-text-replace": "latest",
     "istanbul": "latest",


### PR DESCRIPTION
Saw this in the BugBash today:

```
[2014-03-12T15:25:48.114Z] ERROR: oae/19598 on release0: An uncaught exception was raised to the application.
    Error: spawn ENOENT
        at errnoException (child_process.js:980:11)
        at Process.ChildProcess._handle.onexit (child_process.js:771:34)
[2014-03-12T15:26:18.110Z] ERROR: oae-preview-processor/19598 on release0: Could not generate a screenshot.
    Error: PhantomJS did not respond within the given timeout setting.
        at null._onTimeout (/opt/oae/node_modules/webshot/lib/webshot.js:185:12)
        at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
[2014-03-12T15:26:18.112Z] ERROR: oae-preview-processor/19598 on release0: Could not generate an image (contentId=c:oae:lJOrjoUgs)
    err: {
      "code": 500,
      "msg": "PhantomJS did not respond within the given timeout setting."
    }
```

There was an update in webshot recently, so fixing the version may be an expedient temporary solution to not block further releases.
