### PR TITLE
Set grunt-contrib-jshint to 'latest' when 0.9.0 is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "grunt": "latest",
     "grunt-cli": "latest",
     "grunt-contrib-clean": "latest",
-    "grunt-contrib-jshint": "0.8.0",
+    "grunt-contrib-jshint": "latest",
     "grunt-mocha-hack": "latest",
     "grunt-text-replace": "latest",
     "istanbul": "latest",


### PR DESCRIPTION
We can set it back to latest after this is fixed: https://github.com/gruntjs/grunt-contrib-jshint/issues/148
