### PR TITLE
Change `dir` to `tmpDir`

### DIFF
--- a/config.js
+++ b/config.js
@@ -230,7 +230,7 @@ config.mq = {
  * Configuration namespace for the preview processor.
  *
  * @param  {Boolean}     enabled                        Whether or not the preview processor should be running
- * @param  {String}      dir                            A directory that can be used to store temporary files in
+ * @param  {String}      tmpDir                         A directory that can be used to store temporary files in
  * @param  {Object}      office                         Holds the configuration for anything Office related
  * @param  {String}      office.binary                  The path to the 'soffice.bin' binary that starts up Libre Office. ex: On OS X it is `/Applications/LibreOffice.app/Contents/MacOS/soffice.bin` with a default install
  * @param  {Number}      office.timeout                 Defines the timeout (in ms) when the Office process should be killed
@@ -250,7 +250,7 @@ config.mq = {
  */
 config.previews = {
     'enabled': false,
-    'dir': tmpDir + '/previews',
+    'tmpDir': tmpDir + '/previews',
     'office': {
         'binary': 'soffice.bin',
         'timeout': 120000

--- a/node_modules/oae-preview-processor/lib/init.js
+++ b/node_modules/oae-preview-processor/lib/init.js
@@ -29,14 +29,14 @@ module.exports = function(config, callback) {
     // Create the previews directory and periodically clean it.
     // mkdirp does not throw an error if the directory already exist
     // so there is no need to check that first.
-    mkdirp(config.previews.dir, function(err) {
+    mkdirp(config.previews.tmpDir, function(err) {
         if (err) {
             log().error({'err': err}, 'Could not create the previews directory');
             return callback({'code': 500, 'msg': 'Could not create the previews directory'});
         }
 
         // Periodically clean that directory.
-        Cleaner.start(config.previews.dir, config.files.cleaner.interval);
+        Cleaner.start(config.previews.tmpDir, config.files.cleaner.interval);
     });
 
     PreviewAPI.refreshPreviewConfiguration(config, callback);

--- a/node_modules/oae-preview-processor/lib/model.js
+++ b/node_modules/oae-preview-processor/lib/model.js
@@ -76,7 +76,7 @@ var PreviewContext = module.exports.PreviewContext = function(config, contentId,
     // The base directory for anything related to this piece of content.
     // When all the processing is done, this should contain a file called 'thumbnail.png' which can be used as
     // the piece of content's thumbnail image.
-    that.baseDir = Path.resolve(config.previews.dir + '/' + safeContentId);
+    that.baseDir = Path.resolve(config.previews.tmpDir + '/' + safeContentId);
 
     // Create the actual directory.
     shell.mkdir('-p', that.baseDir);


### PR DESCRIPTION
In the previews configuration, the `dir` variable should be changed to `tmpDir` to avoid confusion.
