### PR TITLE
add check-style back to the stuff travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ services:
   - redis-server
 
 script:
-  - grunt test-coverage-coveralls
+    - grunt check-style test-coverage-coveralls
 
 after_success:
   # Package and upload to Amazon S3


### PR DESCRIPTION
When we added coveralls we stopped running check-style on travis, this adds it back, we might need to fix up some style regressions to get it back to passing.
