### PR TITLE
Intermittent Test Failure: verify reprocessing previews with a revision filter

### DIFF
--- a/bin/upload_logs
+++ b/bin/upload_logs
@@ -57,7 +57,7 @@ fs.stat(logPath, function(err, stat) {
     var buildNumber = process.env.TRAVIS_BUILD_NUMBER || 'no-build-number';
     var commitHash = process.env.TRAVIS_COMMIT || 'no-commit-hash';
     var now = new Date();
-    var objectName = util.format('travisci/logs/hilary/build-%s-%s.log.gz', buildNumber, commitHash);
+    var objectName = util.format('travisci/logs/hilary/build-%s-%s-%s.log.gz', buildNumber, commitHash, now);
 
     // Upload the log file to S3
     var s3 = new amazons3.S3({
@@ -68,7 +68,7 @@ fs.stat(logPath, function(err, stat) {
     s3.PutObject({
         'BucketName': bucketName,
         'ObjectName': objectName,
-        'ContentLength': stat.size, 
+        'ContentLength': stat.size,
         'Body': fs.createReadStream(logPath)
     }, function(err) {
         if (err) {

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -1639,33 +1639,42 @@ describe('Preview processor', function() {
                         var secondRevisionCreated = updatedContent.created;
                         var secondRevisionId = updatedContent.latestRevisionId;
 
-                        // Assert nothing has been previewed yet
-                        RestAPI.Content.getRevisions(user.restContext, content.id, null, null, function(err, data) {
+                        // Avoid processing the new revision just yet as we want the reprocessPreviews to handle that
+                        PreviewTestUtil.purgePreviewsQueue(function(err) {
                             assert.ok(!err);
-                            assert.ok(!data.results[0].previews);
-                            assert.ok(!data.results[1].previews);
 
-
-                            // Re-enable the preview processor
+                            // Re-enable the preview processor with an empty preview queue
                             PreviewAPI.enable(function(err) {
                                 assert.ok(!err);
 
-                                // Reprocess all content items that have a revision that was created after our first revision
-                                RestAPI.Previews.reprocessPreviews(globalAdminRestContext, {'revision_createdAfter': (secondRevisionCreated - 1)}, function(err) {
-                                    MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_REGENERATE_PREVIEWS, function() {
-                                        MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_GENERATE_PREVIEWS, function() {
+                                // Wait for any potential previews to finish as a sanity-check. There shouldn't be, though
+                                MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_GENERATE_PREVIEWS, function() {
 
-                                            // Assert that we only reprocessed the last revision
-                                            RestAPI.Content.getRevisions(user.restContext, content.id, null, null, function(err, data) {
-                                                assert.ok(!err);
+                                    // Ensure that no previews have been processed yet
+                                    RestAPI.Content.getRevisions(user.restContext, content.id, null, null, function(err, data) {
+                                        assert.ok(!data.results[0].previews);
+                                        assert.ok(!data.results[1].previews);
 
-                                                // The latest revision (first in the list) should have previews associated to it
-                                                assert.ok(data.results[0].previews);
-                                                assert.equal(data.results[0].previews.status, 'done');
+                                        // Reprocess only the second revision by filtering by revision date
+                                        RestAPI.Previews.reprocessPreviews(globalAdminRestContext, {'revision_createdAfter': (secondRevisionCreated - 1)}, function(err) {
 
-                                                // The initial revision (second in the list) should not have any previews
-                                                assert.ok(!data.results[1].previews);
-                                                return callback();
+                                            // Give all preview tasks a chance to complete
+                                            MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_REGENERATE_PREVIEWS, function() {
+                                                MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_GENERATE_PREVIEWS, function() {
+
+                                                    // Assert that we only reprocessed the last revision
+                                                    RestAPI.Content.getRevisions(user.restContext, content.id, null, null, function(err, data) {
+                                                        assert.ok(!err);
+
+                                                        // The latest revision (first in the list) should have previews associated to it
+                                                        assert.ok(data.results[0].previews);
+                                                        assert.equal(data.results[0].previews.status, 'done');
+
+                                                        // The initial revision (second in the list) should not have any previews
+                                                        assert.ok(!data.results[1].previews);
+                                                        return callback();
+                                                    });
+                                                });
                                             });
                                         });
                                     });


### PR DESCRIPTION
This test has a flaw, and is timing out intermittently due to a large variance in how long the preview generating time can take for the gif image that is being used (I've had tests that complete in 4 seconds, and some that would complete in 40 seconds). The test log from the instance that happened recently showed that PP time took 30s.

The flaw in the test is that the preview is processed twice for the second revision. The `PreviewsAPI.enable` method only purges the queue the first time it is invoked (rightfully so), therefore the second revision was processed immediately upon `PreviewsAPI.enable`, and then once again when the reprocessAll task is invoked.

Purging the queue once more before we enable the PP should cut the test time in half, and probably eliminate the timeout.
