### PR TITLE
Using `delete` rather than `del` for DELETE rest endpoint

### DIFF
--- a/node_modules/oae-authentication/lib/strategies/oauth/rest.js
+++ b/node_modules/oae-authentication/lib/strategies/oauth/rest.js
@@ -197,7 +197,7 @@ OAE.tenantRouter.on('post', '/api/auth/oauth/clients/:userId/:clientId', functio
 /*!
  * Delete a client for a user
  */
-OAE.tenantRouter.on('del', '/api/auth/oauth/clients/:userId/:clientId', function(req, res) {
+OAE.tenantRouter.on('delete', '/api/auth/oauth/clients/:userId/:clientId', function(req, res) {
     OAuthAPI.Clients.deleteClient(req.ctx, req.params.clientId, function(err) {
         if (err) {
             return res.send(err.code, err.msg);

--- a/node_modules/oae-content/lib/rest.js
+++ b/node_modules/oae-content/lib/rest.js
@@ -87,7 +87,7 @@ OAE.tenantRouter.on('post', '/api/content/create', function(req, res) {
 /*!
  * Delete a piece of content
  */
-OAE.tenantRouter.on('del', '/api/content/:contentId', function(req, res) {
+OAE.tenantRouter.on('delete', '/api/content/:contentId', function(req, res) {
     ContentAPI.deleteContent(req.ctx, req.params.contentId, function(err) {
         if (err) {
             return res.send(err.code, err.msg);
@@ -375,7 +375,7 @@ OAE.tenantRouter.on('get', '/api/content/:contentId/messages', function(req, res
 /*!
  * Delete a comment on a piece of content
  */
-OAE.tenantRouter.on('del', '/api/content/:contentId/messages/:created', function(req, res) {
+OAE.tenantRouter.on('delete', '/api/content/:contentId/messages/:created', function(req, res) {
     ContentAPI.deleteComment(req.ctx, req.params.contentId, req.params.created, function(err, deleted) {
         if (err) {
             return res.send(err.code, err.msg);
@@ -400,7 +400,7 @@ OAE.tenantRouter.on('get', '/api/content/library/:principalId', function(req, re
 /*!
  * Delete a piece of content from a library.
  */
-OAE.tenantRouter.on('del', '/api/content/library/:principalId/:contentId', function(req, res) {
+OAE.tenantRouter.on('delete', '/api/content/library/:principalId/:contentId', function(req, res) {
     ContentAPI.removeContentFromLibrary(req.ctx, req.params.principalId, req.params.contentId, function(err) {
         if (err) {
             return res.send(err.code, err.msg);

--- a/node_modules/oae-discussions/lib/rest.js
+++ b/node_modules/oae-discussions/lib/rest.js
@@ -74,7 +74,7 @@ OAE.tenantRouter.on('post', '/api/discussion/:discussionId', function(req, res) 
 /*!
  * Delete a discussion
  */
-OAE.tenantRouter.on('del', '/api/discussion/:discussionId', function(req, res) {
+OAE.tenantRouter.on('delete', '/api/discussion/:discussionId', function(req, res) {
     DiscussionsAPI.Discussions.deleteDiscussion(req.ctx, req.params.discussionId, function(err, message) {
         if (err) {
             return res.send(err.code, err.msg);
@@ -101,7 +101,7 @@ OAE.tenantRouter.on('get', '/api/discussion/library/:principalId', function(req,
 /*!
  * Delete a discussion from a user or group library
  */
-OAE.tenantRouter.on('del', '/api/discussion/library/:principalId/:discussionId', function(req, res) {
+OAE.tenantRouter.on('delete', '/api/discussion/library/:principalId/:discussionId', function(req, res) {
     DiscussionsAPI.Discussions.removeDiscussionFromLibrary(req.ctx, req.params.principalId, req.params.discussionId, function(err) {
         if (err) {
             return res.send(err.code, err.msg);
@@ -213,7 +213,7 @@ OAE.tenantRouter.on('post', '/api/discussion/:discussionId/messages', function(r
 /*!
  * Delete a message in a discussion
  */
-OAE.tenantRouter.on('del', '/api/discussion/:discussionId/messages/:created', function(req, res) {
+OAE.tenantRouter.on('delete', '/api/discussion/:discussionId/messages/:created', function(req, res) {
     DiscussionsAPI.Discussions.deleteMessage(req.ctx, req.params.discussionId, req.params.created, function(err, message) {
         if (err) {
             return res.send(err.code, err.msg);

--- a/node_modules/oae-tenants/lib/rest.js
+++ b/node_modules/oae-tenants/lib/rest.js
@@ -65,7 +65,7 @@ OAE.globalAdminRouter.on('post', '/api/tenantNetwork/:id', function(req, res) {
 /*!
  * Delete a tenant network
  */
-OAE.globalAdminRouter.on('del', '/api/tenantNetwork/:id', function(req, res) {
+OAE.globalAdminRouter.on('delete', '/api/tenantNetwork/:id', function(req, res) {
     TenantNetworksAPI.deleteTenantNetwork(req.ctx, req.params.id, function(err) {
         if (err) {
             return res.send(err.code, err.msg);


### PR DESCRIPTION
Express has deprecated the usage of `del`. All instances of using the old
method have been replaced.
