### PR TITLE
Intermittent Failure: GraphicsMagic

### DIFF
--- a/node_modules/oae-util/lib/image.js
+++ b/node_modules/oae-util/lib/image.js
@@ -421,7 +421,7 @@ var convertToJPG = module.exports.convertToJPG = function(inputPath, callback) {
 
         var now = Date.now();
         log().trace({'cmd': cmd}, 'Begin converting image into a JPG');
-        exec(cmd, {'timeout': 2000}, function (err, stdout, stderr) {
+        exec(cmd, {'timeout': 4000}, function (err, stdout, stderr) {
             var durationMs = Date.now() - now;
             if (err) {
                 log().error({'err': err}, 'Unable to convert input image to JPG (Took %sms)', durationMs);


### PR DESCRIPTION
Looks like it may have just timed out (2 seconds?). Maybe for tests this should increase.

I've uploaded the failure log masked as a JPG file (worth a try?). It's filtered down to just the failing test. Change the file extension to *.log and you can crunch it using `bunyan`.

![failure](https://cloud.githubusercontent.com/assets/102265/3071004/14a6fa26-e2b1-11e3-975c-9faaf793a3b4.jpg)

Assigning to @simong to have a look
