### PR TITLE
Connect 3.0.0. error

### DIFF
--- a/node_modules/oae-util/lib/middleware/multipart.js
+++ b/node_modules/oae-util/lib/middleware/multipart.js
@@ -14,7 +14,6 @@
  */
 
 var _ = require('underscore');
-var ConnectUtils = require('connect/lib/utils');
 var multiparty = require('multiparty');
 var util = require('util');
 
@@ -60,7 +59,7 @@ module.exports = function(formOptions) {
         if (_.contains(['GET', 'HEAD'], req.method)) {
             // Ignore GET and HEAD requests
             return next();
-        } else if (ConnectUtils.mime(req) !== 'multipart/form-data') {
+        } else if (!req.is('multipart/form-data')) {
             // Only handle multipart/form-data requests
             return next();
         }

--- a/node_modules/oae-util/lib/server.js
+++ b/node_modules/oae-util/lib/server.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var bodyParser = require('body-parser');
 var connect = require('connect');
 var cookieParser = require('cookie-parser');
+var cookieSession = require('cookie-session');
 var express = require('express');
 var http = require('http');
 
@@ -80,7 +81,7 @@ var setupServer = module.exports.setupServer = function(port, _config) {
     app.use(multipart(config.files));
 
     // This needs to come BEFORE passport and AFTER cookieParser. The secret will be used to sign the cookie
-    app.use(connect.cookieSession({'secret': config.cookie.secret}));
+    app.use(cookieSession({'secret': config.cookie.secret}));
 
     // Add telemetry before we do anything else
     app.use(function(req, res, next) {


### PR DESCRIPTION
When installing the latest version of `npm connect`, the following error is thrown: 
**`Error: Cannot find module 'connect/lib/utils'`**.

I currently downgraded to the last stable build (2.18.0) which fixed the problem.
