### PR TITLE
Deleting discussion does not delete authz associations

### DIFF
--- a/node_modules/oae-discussions/lib/api.discussions.js
+++ b/node_modules/oae-discussions/lib/api.discussions.js
@@ -230,25 +230,39 @@ var deleteDiscussion = module.exports.deleteDiscussion = function(ctx, discussio
                 return callback({'code': 401, 'msg': 'You are not authorized to delete this discussion'});
             }
 
-            // Get all the member ids, we'll need them to remove the discussion from the principal libraries
+            // Get all the member ids, we'll need them to remove the discussion from the authz lists
+            // and the principal libraries
             _getAllMemberIds(discussion.id, function(err, memberIds) {
                 if (err) {
                     return callback(err);
                 }
 
-                // Remove it from the libraries.
-                _removeLibrary(memberIds, discussion, function(err) {
+                var roleChanges = {};
+                _.each(memberIds, function(memberId) {
+                    roleChanges[memberId] = false;
+                });
+
+                // Update the authz associations
+                AuthzAPI.updateRoles(discussion.id, roleChanges, function(err) {
                     if (err) {
                         return callback(err);
                     }
 
-                    // Remove the actual discussion profile.
-                    DiscussionsDAO.deleteDiscussion(discussion.id, function(err) {
+                    // Remove it from the libraries
+                    _removeLibrary(memberIds, discussion, function(err) {
                         if (err) {
                             return callback(err);
                         }
-                        DiscussionsAPI.emit(DiscussionsConstants.events.DELETED_DISCUSSION, ctx, discussionId);
-                        callback();
+
+                        // Remove the actual discussion profile
+                        DiscussionsDAO.deleteDiscussion(discussion.id, function(err) {
+                            if (err) {
+                                return callback(err);
+                            }
+
+                            DiscussionsAPI.emit(DiscussionsConstants.events.DELETED_DISCUSSION, ctx, discussionId);
+                            return callback();
+                        });
                     });
                 });
             });

--- a/node_modules/oae-discussions/tests/test-discussions.js
+++ b/node_modules/oae-discussions/tests/test-discussions.js
@@ -19,6 +19,7 @@ var fs = require('fs');
 
 var AuthzAPI = require('oae-authz');
 var ConfigTestsUtil = require('oae-config/lib/test/util');
+var LibraryAPI = require('oae-library');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var RestUtil = require('oae-rest/lib/util');
@@ -478,51 +479,108 @@ describe('Discussions', function() {
     });
 
     describe('Deleting Discussions', function() {
+
         /**
-         * Test that verifies that only managers can delete a discussion.
+         * Test that verifies deleting a discussion properly cleans up library and authz
+         * associations
+         */
+        it('verify deleting a discussion properly cleans up associations', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestCtx, 1, function(err, users, branden) {
+                assert.ok(!err);
+
+                // Add two discussions. One is to delete and the other is to sanity check the library can still be rebuilt and contain the undeleted discussion
+                RestAPI.Discussions.createDiscussion(branden.restContext, 'name', 'descr', 'public', null, null, function(err, discussion) {
+                    assert.ok(!err);
+                    RestAPI.Discussions.createDiscussion(branden.restContext, 'name2', 'descr2', 'public', null, null, function(err, discussion2) {
+
+                        // First, do a sanity check that the discussion is in Branden's library
+                        RestAPI.Discussions.getDiscussionsLibrary(branden.restContext, branden.user.id, null, null, function(err, items) {
+                            assert.ok(!err);
+                            assert.equal(items.results.length, 2);
+
+                            var itemIds = _.pluck(items.results, 'id');
+                            assert.ok(_.contains(itemIds, discussion.id));
+                            assert.ok(_.contains(itemIds, discussion2.id));
+
+                            // Purge Branden's library and ensure they're both still there
+                            LibraryAPI.Index.purge('discussions:discussions', branden.user.id, function(err) {
+                                assert.ok(!err);
+                                RestAPI.Discussions.getDiscussionsLibrary(branden.restContext, branden.user.id, null, null, function(err, items) {
+                                    assert.ok(!err);
+                                    assert.equal(items.results.length, 2);
+
+                                    // Delete one of the discussions
+                                    RestAPI.Discussions.deleteDiscussion(branden.restContext, discussion.id, function(err) {
+                                        assert.ok(!err);
+
+                                        // Ensure the discussion is removed from Branden's library
+                                        RestAPI.Discussions.getDiscussionsLibrary(branden.restContext, branden.user.id, null, null, function(err, items) {
+                                            assert.ok(!err);
+                                            assert.equal(items.results.length, 1);
+                                            assert.equal(items.results[0].id, discussion2.id);
+
+                                            // Purge Branden's library and ensure the deleted one is not there. This ensures
+                                            // the authz association does not have inconsistent association data
+                                            LibraryAPI.Index.purge('discussions:discussions', branden.user.id, function(err) {
+                                                assert.ok(!err);
+                                                RestAPI.Discussions.getDiscussionsLibrary(branden.restContext, branden.user.id, null, null, function(err, items) {
+                                                    assert.ok(!err);
+                                                    assert.equal(items.results.length, 1);
+
+                                                    // Sanity check the discussion is actually deleted
+                                                    RestAPI.Discussions.getDiscussion(branden.restContext, discussion.id, function(err, discussion) {
+                                                        assert.equal(err.code, 404);
+                                                        assert.ok(!discussion);
+                                                        return callback();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that only managers can delete a discussion
          */
         it('verify deleting a discussion', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestCtx, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestCtx, 2, function(err, users, branden, simon) {
                 assert.ok(!err);
-                var branden = _.values(users)[0];
-                var simon = _.values(users)[1];
 
+                // Add a discussion to try and delete
                 RestAPI.Discussions.createDiscussion(branden.restContext, 'name', 'descr', 'public', null, [simon.user.id], function(err, discussion) {
                     assert.ok(!err);
 
-                    // First, do a sanity check that the discusion is in Branden and Simon's library.
-                    RestAPI.Discussions.getDiscussionsLibrary(branden.restContext, branden.user.id, null, null, function(err, items) {
+                    // Ensure the discussion can be fetched
+                    RestAPI.Discussions.getDiscussion(branden.restContext, discussion.id, function(err, fetchedDiscussion) {
                         assert.ok(!err);
-                        assert.equal(items.results.length, 1);
-                        assert.equal(items.results[0].id, discussion.id);
-                        RestAPI.Discussions.getDiscussionsLibrary(simon.restContext, simon.user.id, null, null, function(err, items) {
-                            assert.ok(!err);
-                            assert.equal(items.results.length, 1);
-                            assert.equal(items.results[0].id, discussion.id);
+                        assert.ok(discussion);
+                        assert.equal(fetchedDiscussion.id, discussion.id);
 
-                            // Verify Simon cannot delete the discussion (as he's not the manager.)
-                            RestAPI.Discussions.deleteDiscussion(simon.restContext, discussion.id, function(err) {
-                                assert.equal(err.code, 401);
+                        // Verify Simon cannot delete the discussion (as he's not the manager)
+                        RestAPI.Discussions.deleteDiscussion(simon.restContext, discussion.id, function(err) {
+                            assert.equal(err.code, 401);
 
-                                // Branden can delete it.
+                            // Ensure the discussion can still be fetched
+                            RestAPI.Discussions.getDiscussion(branden.restContext, discussion.id, function(err, fetchedDiscussion) {
+                                assert.ok(!err);
+                                assert.ok(discussion);
+                                assert.equal(fetchedDiscussion.id, discussion.id);
+
+                                // Ensure Branden can delete it
                                 RestAPI.Discussions.deleteDiscussion(branden.restContext, discussion.id, function(err) {
                                     assert.ok(!err);
 
-                                    // The discussion should be removed from all the libraries.
-                                    RestAPI.Discussions.getDiscussionsLibrary(branden.restContext, branden.user.id, null, null, function(err, items) {
-                                        assert.ok(!err);
-                                        assert.equal(items.results.length, 0);
-                                        RestAPI.Discussions.getDiscussionsLibrary(simon.restContext, simon.user.id, null, null, function(err, items) {
-                                            assert.ok(!err);
-                                            assert.equal(items.results.length, 0);
-
-                                            // Getting the discussion profile should result in a 404
-                                            RestAPI.Discussions.getDiscussion(branden.restContext, discussion.id, function(err, discussion) {
-                                                assert.equal(err.code, 404);
-                                                assert.ok(!discussion);
-                                                callback();
-                                            });
-                                        });
+                                    // Ensure the discussion can no longer be fetched
+                                    RestAPI.Discussions.getDiscussion(branden.restContext, discussion.id, function(err, discussion) {
+                                        assert.equal(err.code, 404);
+                                        assert.ok(!discussion);
+                                        return callback();
                                     });
                                 });
                             });


### PR DESCRIPTION
This isn't a security issue, but it breaks libraries when a discussion is deleted. The library when it tries to rebuild does not account for `null` resources and throws a NPE.
