### PR TITLE
CSV import fields need trimming

### DIFF
--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -246,7 +246,7 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
     var input = fs.createReadStream(userCSV.path);
 
     // Pipe the stream to a CSV parser and keep track of the user records
-    var parser = csv.parse();
+    var parser = csv.parse({'trim': true});
     input.pipe(parser);
     parser.on('readable', function() {
         var user = parser.read();

--- a/node_modules/oae-principals/tests/data/users-with-password.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password.csv
@@ -1,5 +1,5 @@
-user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@test.com
-user-plOPperDe,password2,Pareyn,Bert,bert@test.com
+user-zfdHliPLa, password1, Matthijs, Nicolaas, nicolaas@test.com
+user-plOPperDe, password2, Pareyn, Bert, bert@test.com
 user-mIAUwkeNS,password3,Visser,Branden,branden@test.com
 user-HlKKreaDP,password4,Gaeremynck,,simon@test.com
 user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@test.com


### PR DESCRIPTION
CSV import fields need trimming. When I do an import with the following file:

```
Batman, password, Wayne, Bruce, Batman@example.com
Superman, password, Kent, Clark, BigBlue@example.com
Lantern, password, Jordan, Hal, GreenLight@Example.com
```

The displayNames are as following: `Bruce[ ][ ]Wayne`
