### PR TITLE
Limit size of institutional logo in emails

### DIFF
--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -266,8 +266,12 @@
             }
 
             #header #logo img {
-                height: 50px;
                 margin: 0 0 20px;
+
+                /* GMail always converts `height` to `min-height` on atleast images, so use
+                   `min-height` with `max-height` for some client consistency */
+                min-height: 50px;
+                max-height: 100px;
             }
 
             #header #greeting h1 {


### PR DESCRIPTION
We auto-resize on the UI, so I'm guessing institutions will put some rather large ones there and expect the email to have it resized as well:

![image](https://cloud.githubusercontent.com/assets/102265/3272141/081433c2-f315-11e3-8868-10e2b2dbfa9b.png)
