### PR TITLE
Profile pic in email for private user is a link when it should just be an image

### DIFF
--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -70,10 +70,15 @@
             profilePath = shared.ensureAbsoluteLink(userProfile['oae:profilePath'], baseUrl);
         }
 
-        var str = '';
-        str += '<a class="thumbnail-user" href="' + profilePath +  '" title="' + util.html.encodeForHTMLAttribute(userProfile.displayName) + '">';
-        str += '    <img src="' + thumbnailUrl + '" alt="' + util.html.encodeForHTMLAttribute(userProfile.displayName) + '" />';
-        str += '</a>';
+        var str = '<img src="' + thumbnailUrl + '" alt="' + util.html.encodeForHTMLAttribute(userProfile.displayName) + '" />';
+
+        // If the profile path is defined, we will make the thumbnail a link to it
+        if (profilePath) {
+            str =
+                '<a class="thumbnail-user" href="' + profilePath +  '" title="' + util.html.encodeForHTMLAttribute(userProfile.displayName) + '">' +
+                    str +
+                '</a>';
+        }
 
         print(str);
     };

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -14,6 +14,7 @@
  */
 
 var _ = require('underscore');
+var $ = require('cheerio');
 var assert = require('assert');
 var fs = require('fs');
 var util = require('util');
@@ -1275,6 +1276,46 @@ describe('Activity Email', function() {
                         // not have an email addres. However that should not stop `secondUser` from
                         // getting an email
                         assert.strictEqual(messages.length, 1);
+                        return callback();
+                    });
+                });
+            });
+        });
+    });
+
+    /**
+     * Test that verifies a private user does not appear in a link in an activity email
+     */
+    it('verify private users are not displayed with links', function(callback) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
+            assert.ok(!err);
+
+            RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, {'visibility': 'private'}, function(err, updatedMrvisser) {
+                assert.ok(!err);
+                assert.strictEqual(updatedMrvisser.visibility, 'private');
+
+                // Mrvisser follows simong now that he is private
+                RestAPI.Following.follow(mrvisser.restContext, simong.user.id, function(err) {
+                    assert.ok(!err);
+
+                    // Collect the emails
+                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                        // Ensure we get one email, it is the following email, and that there are no
+                        // links to mrvisser's profile
+                        assert.strictEqual(messages.length, 1);
+
+                        var $html = $(messages[0]._message.html);
+
+                        // Iterate all links in the HTML, make sure none of them represent the user
+                        $html.find('a').each(function() {
+                            assert.notEqual($(this).html(), mrvisser.user.publicAlias);
+                        });
+
+                        // Get the thumbnail and ensure it does not have a link as a parent
+                        var $thumbnail = $html.find(util.format('img[alt="%s"]', mrvisser.user.publicAlias));
+                        assert.strictEqual($thumbnail.length, 1);
+                        assert.strictEqual($thumbnail.closest('a').length, 0);
+
                         return callback();
                     });
                 });


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/102265/3302861/e5ac3ae2-f638-11e3-92ca-a44f4def11dd.png)

The placeholder image for `Branden Visser` is a link that goes to nowhere.
