### PR TITLE
A private user cannot share with themself

### DIFF
--- a/node_modules/oae-search/lib/searches/general.js
+++ b/node_modules/oae-search/lib/searches/general.js
@@ -71,7 +71,7 @@ var _search = function(ctx, opts, callback) {
     // The query and filter objects for the Query DSL
     var query = _createQuery(ctx, opts);
     var filterResources = SearchUtil.filterResources(opts.resourceTypes);
-    
+
     SearchUtil.filterScopeAndAccess(ctx, opts.scope, _needsFilterByExplicitAccess(ctx, opts), opts.includeIndirect, function(err, filterScopeAndAccess) {
         if (err) {
             return callback(err);

--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -457,10 +457,15 @@ var filterScopeAndAccess = module.exports.filterScopeAndAccess = function(ctx, s
                     implicitAccessFilter,
                     interactingTenantAliasesFilter,
 
-                    // We cannot implicitly interact with any private resource. So we exclude them
-                    // from the implicit scope, but private resources that I have explicit access to
-                    // will still be included by virtue of the wrapped `or` filter
-                    (!user.isAdmin(user.tenant.alias)) ? filterNot(filterTerm('visibility', 'private')) : null
+                    // While a user can have implicit access to private resources such as joinable
+                    // groups, they can never interact with them. The only private resource a
+                    // regular user can interact with is themself
+                    (!user.isAdmin(user.tenant.alias)) ?
+                        filterOr(
+                            filterNot(filterTerm('visibility', AuthzConstants.visibility.PRIVATE)),
+                            filterTerm('_id', user.id)
+                        ) : null
+
                 ),
                 explicitAccessFilter
             );
@@ -516,6 +521,7 @@ var filterImplicitAccess = module.exports.filterImplicitAccess = function(ctx) {
 
     // The user is authenticated, determine the implicit access for non-public items in the system
     var filterLoggedIn = null;
+    var filterPrivate = null;
     if (user.isTenantAdmin(user.tenant.alias)) {
         // Tenant admin can implicitly access all resources in the tenant, but not outside of it
         filterLoggedIn = filterTerm('tenantAlias', user.tenant.alias);
@@ -532,9 +538,17 @@ var filterImplicitAccess = module.exports.filterImplicitAccess = function(ctx) {
                 )
             )
         );
+
+        // The only private resource a user implicitly has access to is potentially themself
+        if (user.visibility === AuthzConstants.visibility.PRIVATE) {
+            filterPrivate = filterAnd(
+                filterTerm('visibility', AuthzConstants.visibility.PRIVATE),
+                filterTerm('_id', user.id)
+            );
+        }
     }
 
-    return filterOr(filterPublic, filterLoggedIn);
+    return filterOr(filterPublic, filterLoggedIn, filterPrivate);
 };
 
 /**

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -873,40 +873,44 @@ describe('General Search', function() {
                         searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant0.loggedinUser.user, true, function() {
                             searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant0.privateUser.user, false, function() {
 
-                                // Private joinable groups from the current tenant should be searched when searched with the tenant admin
-                                searchForResource(publicTenant0.adminRestContext, '_interact', publicTenant0.privateGroup, true, function() {
+                                // A private user can search themself
+                                searchForResource(publicTenant0.privateUser.restContext, '_interact', publicTenant0.privateUser.user, true, function() {
 
-                                    // Private joinable groups from the current tenant should not be searched when searched as a regular user
-                                    searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant0.privateGroup, false, function() {
+                                    // Private joinable groups from the current tenant should be searched when searched with the tenant admin
+                                    searchForResource(publicTenant0.adminRestContext, '_interact', publicTenant0.privateGroup, true, function() {
 
-                                        // Sanity check that under _network search, the private joinable group does get searched when searching as a regular user
-                                        searchForResource(publicTenant0.publicUser.restContext, '_network', publicTenant0.privateGroup, true, function() {
+                                        // Private joinable groups from the current tenant should not be searched when searched as a regular user
+                                        searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant0.privateGroup, false, function() {
 
-                                            // Only public items from another public tenant should be searched
-                                            searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant1.publicUser.user, true, function() {
-                                                searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant1.loggedinUser.user, false, function() {
-                                                    searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant1.privateUser.user, false, function() {
+                                            // Sanity check that under _network search, the private joinable group does get searched when searching as a regular user
+                                            searchForResource(publicTenant0.publicUser.restContext, '_network', publicTenant0.privateGroup, true, function() {
 
-                                                        // Nothing from an external private tenant should be searched
-                                                        searchForResource(publicTenant0.publicUser.restContext, '_interact', privateTenant0.publicUser.user, false, function() {
-                                                            searchForResource(publicTenant0.publicUser.restContext, '_interact', privateTenant0.loggedinUser.user, false, function() {
-                                                                searchForResource(publicTenant0.publicUser.restContext, '_interact', privateTenant0.privateUser.user, false, function() {
+                                                // Only public items from another public tenant should be searched
+                                                searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant1.publicUser.user, true, function() {
+                                                    searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant1.loggedinUser.user, false, function() {
+                                                        searchForResource(publicTenant0.publicUser.restContext, '_interact', publicTenant1.privateUser.user, false, function() {
 
-                                                                    // Public and logged items from the current private tenant should be searched
-                                                                    searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant0.publicUser.user, true, function() {
-                                                                        searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant0.loggedinUser.user, true, function() {
-                                                                            searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant0.privateUser.user, false, function() {
+                                                            // Nothing from an external private tenant should be searched
+                                                            searchForResource(publicTenant0.publicUser.restContext, '_interact', privateTenant0.publicUser.user, false, function() {
+                                                                searchForResource(publicTenant0.publicUser.restContext, '_interact', privateTenant0.loggedinUser.user, false, function() {
+                                                                    searchForResource(publicTenant0.publicUser.restContext, '_interact', privateTenant0.privateUser.user, false, function() {
 
-                                                                                // Nothing from an external public tenant should be searched when searching from a private tenant
-                                                                                searchForResource(privateTenant0.publicUser.restContext, '_interact', publicTenant0.publicUser.user, false, function() {
-                                                                                    searchForResource(privateTenant0.publicUser.restContext, '_interact', publicTenant0.loggedinUser.user, false, function() {
-                                                                                        searchForResource(privateTenant0.publicUser.restContext, '_interact', publicTenant0.privateUser.user, false, function() {
+                                                                        // Public and logged items from the current private tenant should be searched
+                                                                        searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant0.publicUser.user, true, function() {
+                                                                            searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant0.loggedinUser.user, true, function() {
+                                                                                searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant0.privateUser.user, false, function() {
 
-                                                                                            // Nothing from an external private tenant should be searched when searching from a private tenant
-                                                                                            searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant1.publicUser.user, false, function() {
-                                                                                                searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant1.loggedinUser.user, false, function() {
-                                                                                                    searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant1.privateUser.user, false, function() {
-                                                                                                        return callback();
+                                                                                    // Nothing from an external public tenant should be searched when searching from a private tenant
+                                                                                    searchForResource(privateTenant0.publicUser.restContext, '_interact', publicTenant0.publicUser.user, false, function() {
+                                                                                        searchForResource(privateTenant0.publicUser.restContext, '_interact', publicTenant0.loggedinUser.user, false, function() {
+                                                                                            searchForResource(privateTenant0.publicUser.restContext, '_interact', publicTenant0.privateUser.user, false, function() {
+
+                                                                                                // Nothing from an external private tenant should be searched when searching from a private tenant
+                                                                                                searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant1.publicUser.user, false, function() {
+                                                                                                    searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant1.loggedinUser.user, false, function() {
+                                                                                                        searchForResource(privateTenant0.publicUser.restContext, '_interact', privateTenant1.privateUser.user, false, function() {
+                                                                                                            return callback();
+                                                                                                        });
                                                                                                     });
                                                                                                 });
                                                                                             });


### PR DESCRIPTION
I think this is at the moment the only way a user can add something to their own library. This is likely an issue with the "implicit access scope" search filter in search util.js.
