### PR TITLE
Unit tests can generate invalid random column family names

### DIFF
--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -246,7 +246,7 @@ var generateGroupHierarchy = module.exports.generateGroupHierarchy = function(re
  */
 var generateTestCassandraName = module.exports.generateTestCassandraName = function(seed) {
     seed = seed || 'name';
-    return util.format('%s_%s', seed, ShortId.generate().replace('-', '_'));
+    return util.format('%s_%s', seed, ShortId.generate().replace(/-/g, '_'));
 };
 
 /**


### PR DESCRIPTION
I'm seeing one right now that is breaking the build that generates with a dash which is not allowed:

`"HelenusInvalidRequestException: \"name__ygQoYGO-\" is not a valid column family name (must be alphanumeric character only: [0-9A-Za-z]+)`

I don't think this is entirely correct because I'm pretty sure we've been generating with underscores for quite some time, unless there is an update in Cassandra that is starting to validate them differently.
