### PR TITLE
Intermittent test failure "verify authentication timeout" in push notifications

### DIFF
--- a/node_modules/oae-activity/lib/internal/push.js
+++ b/node_modules/oae-activity/lib/internal/push.js
@@ -198,22 +198,24 @@ var init = module.exports.init = function(callback) {
  * @param  {Socket}     socket  A WebSocket connection
  */
 var registerConnection = module.exports.registerConnection = function(socket) {
-    log().trace({'sid': socket.id}, 'Got a new WS connection');
+    log().trace({'sid': socket.id}, 'Got a new websocket connection');
     socket.streams = [];
     socket.ctx = null;
     var connectionStart = Date.now();
     Telemetry.incr('connection.count');
 
-
     /*!
-     * The client has a 5 second window to authenticate himself, if the client has authenticated
-     * within that timeframe, this variable will be cleared and the function will not get executed.
-     * If he hasn't, the socket will be closed.
+     * The client has a 5 second window to authenticate itself, at which time this timeout will be
+     * cleared and the close function will not get executed. If the client does not authenticate,
+     * the connection is closed
      */
     socket.authenticationTimeout = setTimeout(function() {
         if (!socket.ctx) {
+            log().warn({'sid': socket.id, 'durationInMs': AUTHENTICATION_TIMEOUT}, 'Socket was not authenticated within an acceptable duration');
             _writeResponse(socket, 0, {'code': 400, 'msg': 'Authentication should happen within 5 seconds after opening the socket'});
             socket.close();
+        } else {
+            log().trace({'sid': socket.id, 'durationInMs': AUTHENTICATION_TIMEOUT}, 'Socket was authenticated within the acceptable duration');
         }
     }, AUTHENTICATION_TIMEOUT);
 
@@ -235,6 +237,8 @@ var registerConnection = module.exports.registerConnection = function(socket) {
             // Do not attempt to do anything else with this frame and return
             return;
         }
+
+        log().trace({'sid': socket.id, 'request': msg}, 'Received websocket request');
 
         // We require an id for all incoming messages
         if (!message.id) {
@@ -383,6 +387,8 @@ var _authenticate = function(socket, message) {
         // Clear the authentication timeout
         clearTimeout(socket.authenticationTimeout);
 
+        log().trace({'sid': socket.id, 'userId': socket.ctx.user().id}, 'Successfully authenticated websocket connection');
+
         // Send an OK response to the client
         return _writeResponse(socket, message.id);
     });
@@ -438,7 +444,7 @@ var _subscribe = function (socket, message) {
 
             // Acknowledge a succesful subscription
             log().trace({'sid': socket.id, 'activityStreamId': activityStreamId, 'format': transformerType}, 'Registered a client for a stream');
-            _writeResponse(socket, message.id);
+            return _writeResponse(socket, message.id);
         };
 
         // We need to perform the following check as a socket can subscribe for the same activity stream twice, but with a different format
@@ -517,6 +523,13 @@ var _writeResponse = function(socket, id, error) {
     if (error) {
         msg.error = error;
     }
+
+    log().trace({
+        'sid': socket.id,
+        'messageId': id,
+        'response': msg
+    }, 'Writing response to websocket connection');
+
     socket.write(JSON.stringify(msg));
 };
 


### PR DESCRIPTION
Fails after 60s timeout, the connection does not automatically close as it should sometimes.

This is not a fix, but some additional logging to help debug the next time it happens. At the moment it's difficult to tell from the logs if the issue is on the server side or the client side.
