### PR TITLE
Intermittent test failure: Email scheduling is not synchronized in tests

### DIFF
--- a/node_modules/oae-activity/lib/internal/email.js
+++ b/node_modules/oae-activity/lib/internal/email.js
@@ -18,6 +18,7 @@ var util = require('util');
 
 var AuthzUtil = require('oae-authz/lib/util');
 var Context = require('oae-context').Context;
+var Counter = require('oae-util/lib/counter');
 var EmailAPI = require('oae-email');
 var Locking = require('oae-util/lib/locking');
 var log = require('oae-logger').logger('oae-activity-email');
@@ -56,6 +57,10 @@ var TWO_DAYS_IN_MS = 2 * 24 * ONE_HOUR_IN_MS;
 // The amount of milliseconds that go in two weeks
 var TWO_WEEKS_IN_MS = 14 * 24 * ONE_HOUR_IN_MS;
 
+// Keeps track of users that are scheduled for email when delivered activities are fired. This is
+// helpful to synchronize things like tests so we know when email should be collected
+var scheduledEmailsCounter = new Counter();
+
 /*!
  * When activities get delivered to a stream, we check if any were delivered to users their
  * `email` stream and queue the user IDs for email delivery
@@ -74,9 +79,12 @@ ActivityEmitter.on(ActivityConstants.events.DELIVERED_ACTIVITIES, function(deliv
         return;
     }
 
+    scheduledEmailsCounter.incr();
+
     // We need to know the email preferences for each user so we know whether and when to send them an e-mail
     PrincipalsDAO.getPrincipals(usersToMail, ['principalId', 'tenantAlias', 'email', 'emailPreference'], function(err, users) {
         if (err) {
+            scheduledEmailsCounter.decr();
             return log().error({'err': err, 'usersToMail': usersToMail}, 'Failed to get the email preference field for all the users in this activity');
         }
 
@@ -94,11 +102,13 @@ ActivityEmitter.on(ActivityConstants.events.DELIVERED_ACTIVITIES, function(deliv
 
         ActivityDAO.saveQueuedUserIdsForEmail(emailBuckets, function(err) {
             if (err) {
+                scheduledEmailsCounter.decr();
                 return log().error({'err': err, 'deliveredActivities': deliveredActivities}, 'Unable to store the IDs of the users who need to receive mail');
             }
 
             log().trace({'usersToQueue': usersToQueue}, 'Queued mail for users');
             Telemetry.incr('queued.count', usersToQueue.length);
+            scheduledEmailsCounter.decr();
         });
     });
 });
@@ -552,6 +562,17 @@ var _aggregate = function(userId, activities) {
     return aggregatedActivities.sort(function(a, b) {
         return b.published - a.published;
     });
+};
+
+/**
+ * Invoke the handler the next time there are currently no activity delivery events being handled
+ * to schedule email delivery for users. If there are currently no activity delivery events being
+ * handled when this is invoked, the handler is invoked immediately
+ *
+ * @param  {Function}   handler     The handler to invoke when all activity delivery events have been processed
+ */
+var whenEmailsScheduled = module.exports.whenEmailsScheduled = function(handler) {
+    scheduledEmailsCounter.whenZero(handler);
 };
 
 /**

--- a/node_modules/oae-activity/lib/internal/notifications.js
+++ b/node_modules/oae-activity/lib/internal/notifications.js
@@ -19,6 +19,7 @@ var events = require('events');
 var util = require('util');
 
 var Context = require('oae-context').Context;
+var Counter = require('oae-util/lib/counter');
 var log = require('oae-logger').logger('oae-activity-notifications');
 var PrincipalsConstants = require('oae-principals/lib/constants').PrincipalsConstants;
 var PrincipalsDAO = require('oae-principals/lib/internal/dao');
@@ -33,9 +34,9 @@ var ActivityRegistry = require('./registry');
 var ActivityTransformer = require('./transformer');
 var ActivityUtil = require('oae-activity/lib/util');
 
-// Tracks the handling of notifications for synchronization to determine when there are no notifications being processed
-var notificationsCount = 0;
-var notificationsEmptyEmitter = new events.EventEmitter();
+// Tracks the handling of notifications for synchronization to determine when there are no
+// notifications being processed
+var notificationsCounter = new Counter();
 
 /*!
  * When a batch of activities are delivered, we check if there are any notifications in there and
@@ -53,10 +54,10 @@ ActivityEmitter.on(ActivityConstants.events.DELIVERED_ACTIVITIES, function(deliv
             var userId = deliveredActivities.resourceId;
             deliveredNotifications[userId] = deliveredActivities.activities;
 
-            // Increment the notifications count, when each one of these potential notifications is handled / complete,
-            // they should be decremented
+            // Increment the notifications count, when each one of these potential notifications is
+            // handled / complete, they should be decremented
             notificationsToDecrement++;
-            _incrementNotifications();
+            notificationsCounter.incr();
             userIdsIncrBy[userId] = deliveredActivities.activities.length;
         }
     });
@@ -67,7 +68,7 @@ ActivityEmitter.on(ActivityConstants.events.DELIVERED_ACTIVITIES, function(deliv
             log().error({'err': new Error(err.msg), 'userIdsIncrBy': userIdsIncrBy}, 'Could not mark notifications as unread');
         }
 
-        _decrementNotifications(notificationsToDecrement);
+        notificationsCounter.decr(notificationsToDecrement);
     });
 });
 
@@ -188,14 +189,10 @@ var incrementNotificationsUnread = module.exports.incrementNotificationsUnread =
  * are no longer processing, for purposes of gracefully stopping the server or synchronization of processing for
  * tests.
  *
- * @param  {Function}   callback    The function to invoke when there are 0 notifications being processed
+ * @param  {Function}   handler     The function to invoke when there are 0 notifications being processed
  */
-var whenNotificationsEmpty = module.exports.whenNotificationsEmpty = function(callback) {
-    if (notificationsCount === 0) {
-        return callback();
-    }
-
-    notificationsEmptyEmitter.once('empty', callback);
+var whenNotificationsEmpty = module.exports.whenNotificationsEmpty = function(handler) {
+    notificationsCounter.whenZero(handler);
 };
 
 /**
@@ -207,28 +204,4 @@ var whenNotificationsEmpty = module.exports.whenNotificationsEmpty = function(ca
 var _getRegisteredActivityOptions = function(activity) {
     var activityType = activity[ActivityConstants.properties.OAE_ACTIVITY_TYPE];
     return ActivityRegistry.getRegisteredActivityTypes()[activityType];
-};
-
-/**
- * Increment the notifications counter to indicate that we have received a new set of notifications for a user.
- * @api private
- */
-var _incrementNotifications = function() {
-    notificationsCount++;
-};
-
-/**
- * Decrement the notifications counter to indicate that we have completed handling a set of notifications for a user. If
- * the notifications are now empty, the "empty" event on the internal emitter is fired so `whenNotificationsEmpty` will
- * trigger any waiting listeners.
- *
- * @param  {Number}     deliveredNotificationsCount     The number of notifications that were delivered
- * @api private
- */
-var _decrementNotifications = function(deliveredNotificationsCount) {
-    notificationsCount -= deliveredNotificationsCount;
-    if (notificationsCount <= 0) {
-        notificationsCount = 0;
-        notificationsEmptyEmitter.emit('empty');
-    }
 };

--- a/node_modules/oae-email/lib/test/util.js
+++ b/node_modules/oae-email/lib/test/util.js
@@ -96,10 +96,14 @@ var collectAndFetchAllEmails = module.exports.collectAndFetchAllEmails = functio
             // Collect the activity buckets, which will aggregate any pending activities into the proper email activity streams
             ActivityAggregator.collectAllBuckets(function() {
 
-                // Collect and send the emails
-                ActivityEmail.collectAllBuckets(function() {
-                    EmailAPI.removeListener('debugSent', _handleDebugSent);
-                    return callback(messages);
+                // Ensure all scheduling of email delivery has been completed
+                ActivityEmail.whenEmailsScheduled(function() {
+
+                    // Collect and send the emails
+                    ActivityEmail.collectAllBuckets(function() {
+                        EmailAPI.removeListener('debugSent', _handleDebugSent);
+                        return callback(messages);
+                    });
                 });
             });
         });

--- a/node_modules/oae-util/lib/counter.js
+++ b/node_modules/oae-util/lib/counter.js
@@ -1,0 +1,79 @@
+/*!
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var events = require('events');
+
+/**
+ * A utility structure that allows one to increment and decrement a count, firing bound handlers
+ * when the count becomes `0`
+ */
+var Counter = module.exports = function() {
+    var _count = 0;
+    var _emitter = new events.EventEmitter();
+
+    var that = {};
+
+    /**
+     * Increment the current count by the provided amount
+     *
+     * @param  {Number}     [incrBy]    How much to increment the counter by. Default: 1
+     */
+    that.incr = function(incrBy) {
+        incrBy = incrBy || 1;
+        _count += incrBy;
+    };
+
+    /**
+     * Decrement the current count by the provided amount. If decrementing by this amount brings the
+     * count down to 0, then whatever handlers are waiting on it to become `0` will be fired. The
+     * value of the counter cannot be less than `0`, therefore decrementing an empty counter will
+     * result in no change, and no offset for future incrementing
+     *
+     * @param  {Number}     [decrBy]    How much to decrement the counter by. Default: 1
+     */
+    that.decr = function(decrBy) {
+        decrBy = decrBy || 1;
+
+        // If the count is already "empty", just ensure we're settled at 0 and don't fire any events
+        if (_count <= 0) {
+            _count = 0;
+            return;
+        }
+
+        // Decrement by the provided amount, and if we become empty, fire the empty event in case
+        // anyone is waiting
+        _count -= decrBy;
+        if (_count <= 0) {
+            _count = 0;
+            _emitter.emit('empty');
+        }
+    };
+
+    /**
+     * Fire the given handler when the count becomes `0`. If the count is currently `0`, the handler
+     * is fired immediately
+     *
+     * @param  {Function}   handler     Invoked when the count becomes `0`
+     */
+    that.whenZero = function(handler) {
+        if (_count <= 0) {
+            return handler();
+        }
+
+        return _emitter.once('empty', handler);
+    };
+
+    return that;
+};

--- a/node_modules/oae-util/lib/mq.js
+++ b/node_modules/oae-util/lib/mq.js
@@ -518,7 +518,7 @@ var unsubscribeQueue = module.exports.unsubscribeQueue = function(queueName, cal
             log().error({'queueName': queueName}, 'An unknown error occurred unsubscribing a queue');
             return callback({'code': 500, 'msg': 'An unknown error occurred unsubscribing a queue'});
         }
-        
+
         return callback();
     });
 };

--- a/node_modules/oae-util/lib/test/mq-util.js
+++ b/node_modules/oae-util/lib/test/mq-util.js
@@ -15,25 +15,25 @@
 
 var _ = require('underscore');
 var events = require('events');
+
+var Counter = require('oae-util/lib/counter');
 var MQ = require('oae-util/lib/mq');
 
 // Track when counts for a particular type of task return to 0
-var emitter = new events.EventEmitter();
-var submitCount = {};
+var queueCounters = {};
 
 MQ.on('preSubmit', function(routingKey) {
-    // Technically, the routing key is not the same as the queue, all the Task Queues in OAE however use the same routing key as their destination queue name
-    _incrementSubmitCount(routingKey);
+    // Technically, the routing key is not the same as the queue, all the Task Queues in OAE however
+    // use the same routing key as their destination queue name
+    _increment(routingKey);
 });
 
 MQ.on('postHandle', function(err, queueName) {
-    _decrementSubmitCount(queueName);
+    _decrement(queueName, 1);
 });
 
-MQ.on('postPurge', function(queueName, count) {
-    for (var i = 0; i < count; i++) {
-        _decrementSubmitCount(queueName);
-    }
+MQ.on('postPurge', function(name, count) {
+    _decrement(name, count);
 });
 
 /**
@@ -46,23 +46,24 @@ MQ.on('postPurge', function(queueName, count) {
  * @param  {Function}   handler     The handler to invoke when the task queue is empty
  */
 var whenTasksEmpty = module.exports.whenTasksEmpty = function(name, handler) {
-    if (!submitCount[name] || !_hasQueue(name)) {
-        handler();
-    } else {
-        emitter.once('tasksEmpty-' + name, handler);
+    if (!queueCounters[name] || !_hasQueue(name)) {
+        return handler();
     }
+
+    // Bind the handler to the counter for this queue
+    queueCounters[name].whenZero(handler);
 };
 
 /**
- * Increment the submitCount for a task of the given name.
+ * Increment the count for a task of the given name
  *
- * @param  {String}     name    The name of the task whose submitCount to increment
+ * @param  {String}     name    The name of the task whose count to increment
  * @api private
  */
-var _incrementSubmitCount = function(name) {
+var _increment = function(name) {
     if (_hasQueue(name)) {
-        submitCount[name] = submitCount[name] || 0;
-        submitCount[name]++;
+        queueCounters[name] = queueCounters[name] || new Counter();
+        queueCounters[name].incr();
     }
 };
 
@@ -70,25 +71,20 @@ var _incrementSubmitCount = function(name) {
  * Determines if MQ has a handler bound for a task by the given name.
  *
  * @return {Boolean}    Whether or not there is a task bound
+ * @api private
  */
 var _hasQueue = function(name) {
-    return (_.indexOf(MQ.getBoundQueueNames(), name) !== -1);
+    return (_.contains(MQ.getBoundQueueNames(), name));
 };
 
 /**
- * Decrement the submitCount for a task of the given name, and fire the `tasksEmpty` event for it if appropriate.
+ * Decrement the count for a task of the given name, firing any `whenTasksEmpty` handlers that are
+ * waiting for the count to reach 0, if appropriate
  *
- * @param  {String}     name    The name of the task whose submit count to decrement
+ * @param  {String}     name    The name of the task whose count to decrement
  * @api private
  */
-var _decrementSubmitCount = function(name) {
-    submitCount[name] = submitCount[name] || 0;
-    submitCount[name]--;
-
-    if (submitCount[name] === 0) {
-        emitter.emit('tasksEmpty-' + name);
-    } else if (submitCount[name] < 0) {
-        // This could happen if you have pending items in your task queue when the server starts for tests
-        submitCount[name] = 0;
-    }
+var _decrement = function(name, count) {
+    queueCounters[name] = queueCounters[name] || new Counter();
+    queueCounters[name].decr(count);
 };


### PR DESCRIPTION
Currently when activity is delivered, we listen to the delivery event which eventually schedules email to be sent. The process in `collectAndFetchAllEmails` is currently:
1. Collect activity -- this fires the ACTIVITIES_DELIVERED events
2. Collect all scheduled emails
3. Listen to the `debugSent` event for all emails that were sent

However in between step 1 and 2, there is no guarantee that there was sufficient time for the emails to be schedule for the email, therefore step 2 collects no scheduled emails, and you wind up with:

```
2) Notifications Mail deduplication verify mails for the same activity and the same user are only sent once:
     Uncaught AssertionError: 0 == 2
      at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-activity/tests/test-notifications.js:293:40
      at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-email/lib/test/util.js:102:28
      at allDone (/Users/branden/Source/oaeproject/Hilary/node_modules/oae-activity/lib/internal/email.js:182:20)
      at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-activity/lib/internal/buckets.js:119:16
      at _collectBuckets (/Users/branden/Source/oaeproject/Hilary/node_modules/oae-activity/lib/internal/buckets.js:138:16)
      at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-activity/lib/internal/buckets.js:149:16
      at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-activity/lib/internal/buckets.js:215:28
      at /Users/branden/Source/oaeproject/Hilary/node_modules/oae-util/lib/locking.js:94:20
      at b (domain.js:183:18)
      at try_callback (/Users/branden/Source/oaeproject/Hilary/node_modules/redis/index.js:573:9)
```

... intermittently. This is probably a fairly large source of intermittent test failures in email currently along with #956 
