### PR TITLE
(IntermittentFailure) Try not adding timeouts directly to a socket connection

### DIFF
--- a/node_modules/oae-activity/lib/internal/push.js
+++ b/node_modules/oae-activity/lib/internal/push.js
@@ -41,7 +41,7 @@ var ActivityUtil = require('oae-activity/lib/util');
 //////////////////////
 
 // A hash of sockets per stream
-var socketsPerStream = {};
+var connectionInfosPerStream = {};
 
 // The name of the queue we'll be using for this app server
 var queueName = null;
@@ -199,8 +199,14 @@ var init = module.exports.init = function(callback) {
  */
 var registerConnection = module.exports.registerConnection = function(socket) {
     log().trace({'sid': socket.id}, 'Got a new websocket connection');
-    socket.streams = [];
-    socket.ctx = null;
+
+    // Hold state about the registered websocket connection
+    var connectionInfo = {
+        'socket': socket,
+        'streams': [],
+        'ctx': null
+    };
+
     var connectionStart = Date.now();
     Telemetry.incr('connection.count');
 
@@ -209,10 +215,10 @@ var registerConnection = module.exports.registerConnection = function(socket) {
      * cleared and the close function will not get executed. If the client does not authenticate,
      * the connection is closed
      */
-    socket.authenticationTimeout = setTimeout(function() {
-        if (!socket.ctx) {
+    connectionInfo.authenticationTimeout = setTimeout(function() {
+        if (!connectionInfo.ctx) {
             log().warn({'sid': socket.id, 'durationInMs': AUTHENTICATION_TIMEOUT}, 'Socket was not authenticated within an acceptable duration');
-            _writeResponse(socket, 0, {'code': 400, 'msg': 'Authentication should happen within 5 seconds after opening the socket'});
+            _writeResponse(connectionInfo, 0, {'code': 400, 'msg': 'Authentication should happen within 5 seconds after opening the socket'});
             socket.close();
         } else {
             log().trace({'sid': socket.id, 'durationInMs': AUTHENTICATION_TIMEOUT}, 'Socket was authenticated within the acceptable duration');
@@ -231,7 +237,7 @@ var registerConnection = module.exports.registerConnection = function(socket) {
             message = JSON.parse(msg);
         } catch (err) {
             log().error({'msg': msg, 'err': err}, 'Ignoring malformed message');
-            _writeResponse(socket, 0, {'code': 400, 'msg': 'Malformed message'});
+            _writeResponse(connectionInfo, 0, {'code': 400, 'msg': 'Malformed message'});
             socket.close();
 
             // Do not attempt to do anything else with this frame and return
@@ -243,22 +249,22 @@ var registerConnection = module.exports.registerConnection = function(socket) {
         // We require an id for all incoming messages
         if (!message.id) {
             log().error({'msg': msg}, 'Missing id on the message');
-            _writeResponse(socket, 0, {'code': 400, 'msg': 'Missing id on the message'});
+            _writeResponse(connectionInfo, 0, {'code': 400, 'msg': 'Missing id on the message'});
             return socket.close();
         }
 
         // The first message coming from the UI has to be an authentication frame
         // If it's something else, we ignore it and immediately close the socket
-        if (!socket.ctx && message.name !== 'authentication') {
+        if (!connectionInfo.ctx && message.name !== 'authentication') {
             log().error('First frame is not authentication');
-            _writeResponse(socket, message.id, {'code': 401, 'msg': 'The first frame should be an authentication frame'});
+            _writeResponse(connectionInfo, message.id, {'code': 401, 'msg': 'The first frame should be an authentication frame'});
             return socket.close();
         }
 
         if (message.name === 'authentication') {
-            _authenticate(socket, message);
+            _authenticate(connectionInfo, message);
         } else if (message.name === 'subscribe') {
-            _subscribe(socket, message);
+            _subscribe(connectionInfo, message);
         }
     });
 
@@ -270,58 +276,58 @@ var registerConnection = module.exports.registerConnection = function(socket) {
      * 2/ Clear all local references to this socket, so we're not leaking memory.
      */
     socket.on('close', function() {
-        log().trace({'sid': socket.id, 'streams': socket.streams}, 'Closing socket');
+        log().trace({'sid': socket.id, 'streams': connectionInfo.streams}, 'Closing socket');
         // Measure how long the clients stay connected
         Telemetry.appendDuration('connected.time', connectionStart);
 
-        var todo = socket.streams.length;
+        var todo = connectionInfo.streams.length;
         if (todo === 0) {
             log().trace({'sid': socket.id}, 'Not registered for any streams, not doing anything');
             return;
         }
 
         var start = Date.now();
-        _.each(socket.streams, function(stream) {
-            if (!socketsPerStream[stream]) {
+        _.each(connectionInfo.streams, function(stream) {
+            if (!connectionInfosPerStream[stream]) {
                 // Seems unlikely, but it's better to be safe
-                log().warn({'stream': stream}, 'A stream was associated with a socket, but the socket could not be found in the socketsPerStream hash');
+                log().warn({'stream': stream}, 'A stream was associated with a socket, but the socket could not be found in the connectionInfosPerStream hash');
                 return;
-            } else if (socketsPerStream[stream].length === 1) {
+            } else if (connectionInfosPerStream[stream].length === 1) {
                 // We can also stop listening to messages from this stream as nobody is interested in it anymore
                 MQ.unbindQueueFromExchange(queueName, QueueConstants.exchange.NAME, stream, function() {
                     todo--;
 
                     // If nobody else is interested in this stream, we can remove it
-                    delete socketsPerStream[stream];
+                    delete connectionInfosPerStream[stream];
 
                     if (todo === 0) {
                         Telemetry.appendDuration('unbind.all.time', start);
                     }
                 });
 
-                // Otherwise we need to iterate through the list of sockets for this stream and splice this one out
+                return;
+
+            // Otherwise we need to iterate through the list of sockets for this stream and splice this one out
             } else {
                 todo--;
 
-                // Find the socket in the socketsPerStream[stream] array and remove it
+                // Find the socket in the connectionInfosPerStream[stream] array and remove it
                 // Unfortunately we can't use an underscore utility as all of the filter/find
                 // functions return a copy of the array or the socket we're searching for
-                var index = 0;
-                log().trace({'sid': socket.id, 'stream': stream, 'socketsInstream': socketsPerStream[stream].length}, 'Searching through sockets');
-                while (index < socketsPerStream[stream].length) {
-                    if (socketsPerStream[stream][index].id === socket.id) {
+                log().trace({'sid': socket.id, 'stream': stream, 'socketsInstream': connectionInfosPerStream[stream].length}, 'Searching through sockets');
+                for (var i = 0; i < connectionInfosPerStream[stream].length; i++) {
+                    if (connectionInfosPerStream[stream][i].socket.id === socket.id) {
                         // If we have found the socket we're looking for, we can splice it out
-                        socketsPerStream[stream].splice(index, 1);
+                        connectionInfosPerStream[stream].splice(i, 1);
                         break;
                     }
-
-                    // Otherwise we need to look at the next element
-                    index++;
                 }
 
                 if (todo === 0) {
                     Telemetry.appendDuration('unbind.all.time', start);
                 }
+
+                return;
             }
         });
     });
@@ -335,14 +341,15 @@ var registerConnection = module.exports.registerConnection = function(socket) {
  * Once the user is connected, a `Context` object will be made available on the socket
  * which can be used to pass into any of the standard API methods.
  *
- * @param  {Socket}     socket      The socket on which the client connected
- * @param  {Object}     message     The authentication frame
+ * @param  {Object}     connectionInfo  The state of the connection we wish to authenticate
+ * @param  {Object}     message         The authentication frame
  * @api private
  */
-var _authenticate = function(socket, message) {
+var _authenticate = function(connectionInfo, message) {
+    var socket = connectionInfo.socket;
     var data = message.payload;
     if (!data) {
-        _writeResponse(socket, message.id, {'code': 400, 'msg': 'Missing data payload containing the userId and signature'});
+        _writeResponse(connectionInfo, message.id, {'code': 400, 'msg': 'Missing data payload containing the userId and signature'});
         return socket.close();
     }
 
@@ -352,7 +359,7 @@ var _authenticate = function(socket, message) {
     validator.check(data.userId, {'code': 400, 'msg': 'A userId needs to be provided'}).isUserId();
     validator.check(null, {'code': 400, 'msg': 'A signature object needs to be provided'}).isObject(data.signature);
     if (validator.hasErrors()) {
-        _writeResponse(socket, message.id, validator.getFirstError());
+        _writeResponse(connectionInfo, message.id, validator.getFirstError());
         log().error({'err': validator.getFirstError()}, 'Invalid auth frame');
         return socket.close();
     }
@@ -361,7 +368,7 @@ var _authenticate = function(socket, message) {
     validator.check(data.signature.expires, {'code': 400, 'msg': 'Signature must contain an integer expires value'}).isInt();
     validator.check(data.signature.signature, {'code': 400, 'msg': 'Signature must contain a string signature value'}).notNull();
     if (validator.hasErrors()) {
-        _writeResponse(socket, message.id, validator.getFirstError());
+        _writeResponse(connectionInfo, message.id, validator.getFirstError());
         log().error({'err': validator.getFirstError()}, 'Invalid auth frame');
         return socket.close();
     }
@@ -369,28 +376,28 @@ var _authenticate = function(socket, message) {
     // Get the full user object so we can build a context with which to authenticate to the signing utility
     PrincipalsDAO.getPrincipal(data.userId, function (err, user) {
         if (err) {
-            _writeResponse(socket, message.id, err);
+            _writeResponse(connectionInfo, message.id, err);
             log().error({'err': err, 'userId': data.userId, 'sid': socket.id}, 'Error trying to get the principal object');
             return socket.close();
         }
 
         // Store a context with the tenant we're running on and the full user object
         var currentTenant = TenantsAPI.getTenant(data.tenantAlias);
-        socket.ctx = new Context(currentTenant, user);
+        connectionInfo.ctx = new Context(currentTenant, user);
 
-        if (!Signature.verifyExpiringResourceSignature(socket.ctx, data.userId, data.signature.expires, data.signature.signature)) {
-            _writeResponse(socket, message.id, {'code': 401, 'msg': 'Invalid signature'});
+        if (!Signature.verifyExpiringResourceSignature(connectionInfo.ctx, data.userId, data.signature.expires, data.signature.signature)) {
+            _writeResponse(connectionInfo, message.id, {'code': 401, 'msg': 'Invalid signature'});
             log().error({'userId': data.userId, 'sid': socket.id}, 'Incoming authentication signature was invalid');
             return socket.close();
         }
 
         // Clear the authentication timeout
-        clearTimeout(socket.authenticationTimeout);
+        clearTimeout(connectionInfo.authenticationTimeout);
 
-        log().trace({'sid': socket.id, 'userId': socket.ctx.user().id}, 'Successfully authenticated websocket connection');
+        log().trace({'sid': socket.id, 'userId': connectionInfo.ctx.user().id}, 'Successfully authenticated websocket connection');
 
         // Send an OK response to the client
-        return _writeResponse(socket, message.id);
+        return _writeResponse(connectionInfo, message.id);
     });
 };
 
@@ -398,31 +405,32 @@ var _authenticate = function(socket, message) {
  * A client wants to subscribe on a stream. We do some basic validation, pass the message
  * too the authorization handler for that stream and do the appropriate MQ binding
  *
- * @param  {Socket}     socket      The socket on which the client connected
- * @param  {Object}     message     The message containing the subscription request
+ * @param  {Object}     connectionInfo  The state of the connection we wish to authenticate
+ * @param  {Object}     message         The message containing the subscription request
  * @api private
  */
-var _subscribe = function (socket, message) {
+var _subscribe = function (connectionInfo, message) {
+    var socket = connectionInfo.socket;
     var data = message.payload;
     if (!data || !data.stream || !data.stream.resourceId || !data.stream.streamType) {
-        return _writeResponse(socket, message.id, {'code': 400, 'msg': 'Missing stream properties'});
+        return _writeResponse(connectionInfo, message.id, {'code': 400, 'msg': 'Missing stream properties'});
     }
 
     // If a format is specified, ensure that it is one that we support
     if (data.format && !_.chain(ActivityConstants.transformerTypes).values().contains(data.format).value()) {
-        return _writeResponse(socket, message.id, {'code': 400, 'msg': 'The specified stream format is unknown'});
+        return _writeResponse(connectionInfo, message.id, {'code': 400, 'msg': 'The specified stream format is unknown'});
     }
 
     // Check if the client is authorized for this stream (and if the stream even exists)
     var authzHandler = _getAuthorizationHandler(data.stream.streamType);
     if (!authzHandler) {
-        return _writeResponse(socket, message.id, {'code': 400, 'msg': 'Unknown stream'});
+        return _writeResponse(connectionInfo, message.id, {'code': 400, 'msg': 'Unknown stream'});
     }
 
     // Perform authorization
-    authzHandler(socket.ctx, data.stream.resourceId, data.token, function(err) {
+    authzHandler(connectionInfo.ctx, data.stream.resourceId, data.token, function(err) {
         if (err) {
-            return _writeResponse(socket, message.id, err);
+            return _writeResponse(connectionInfo, message.id, err);
         }
 
         var activityStreamId = ActivityUtil.createActivityStreamId(data.stream.resourceId, data.stream.streamType);
@@ -434,32 +442,32 @@ var _subscribe = function (socket, message) {
         var finish = function() {
             // Remember the desired transformer for this stream on this socket
             var transformerType = data.format || ActivityConstants.transformerTypes.INTERNAL;
-            socket.transformerTypes = socket.transformerTypes || {};
-            socket.transformerTypes[activityStreamId] = socket.transformerTypes[activityStreamId] || [];
-            socket.transformerTypes[activityStreamId].push(transformerType);
+            connectionInfo.transformerTypes = connectionInfo.transformerTypes || {};
+            connectionInfo.transformerTypes[activityStreamId] = connectionInfo.transformerTypes[activityStreamId] || [];
+            connectionInfo.transformerTypes[activityStreamId].push(transformerType);
 
             // Remember this socket on the app server so we can push to it asynchronously
-            socketsPerStream[activityStreamId] = socketsPerStream[activityStreamId] || [];
-            socketsPerStream[activityStreamId].push(socket);
+            connectionInfosPerStream[activityStreamId] = connectionInfosPerStream[activityStreamId] || [];
+            connectionInfosPerStream[activityStreamId].push(connectionInfo);
 
             // Acknowledge a succesful subscription
             log().trace({'sid': socket.id, 'activityStreamId': activityStreamId, 'format': transformerType}, 'Registered a client for a stream');
-            return _writeResponse(socket, message.id);
+            return _writeResponse(connectionInfo, message.id);
         };
 
         // We need to perform the following check as a socket can subscribe for the same activity stream twice, but with a different format
-        if (socket.streams.indexOf(activityStreamId) > -1) {
+        if (connectionInfo.streams.indexOf(activityStreamId) > -1) {
             // No need to bind, we're already bound
             return finish();
         } else {
             // Remember this stream on the socket
-            socket.streams.push(activityStreamId);
+            connectionInfo.streams.push(activityStreamId);
 
             // Bind our app queue to the exchange
             _bindQueue(activityStreamId, function(err) {
                 if (err) {
                     log().error({'sid': socket.id, 'err': err, 'activityStreamId': activityStreamId}, 'Could not bind our queue to the exchange');
-                    return _writeResponse(socket, message.id, err);
+                    return _writeResponse(connectionInfo, message.id, err);
                 }
 
                 return finish();
@@ -480,7 +488,7 @@ var _subscribe = function (socket, message) {
 var _bindQueue = function(activityStreamId, callback) {
     // If this is the first time we see this stream we'll need to bind this app server to receive
     // events from RabbitMQ
-    if (!socketsPerStream[activityStreamId]) {
+    if (!connectionInfosPerStream[activityStreamId]) {
         MQ.bindQueueToExchange(queueName, QueueConstants.exchange.NAME, activityStreamId, callback);
 
     // If we've seen this stream before, we're already listening for events for that stream
@@ -507,17 +515,17 @@ var _getAuthorizationHandler = function(activityStreamId) {
 };
 
 /**
- * Writes a message over the socket.
- * Only use this in response to an earlier request.
+ * Writes a message over the socket. Only use this in response to an earlier request
  *
- * @param  {Socket}     socket          The socket to write to
+ * @param  {Object}     connectionInfo  The connection info containing the socket to write to
  * @param  {Number}     id              The id of the message that was sent by the client. This will be used by the client to identify what request this response is for
  * @param  {Object}     [error]         An optional error object
  * @param  {Number}     [error.code]    An HTTP error code
  * @param  {String}     error.msg       A message explaining the error
  * @api private
  */
-var _writeResponse = function(socket, id, error) {
+var _writeResponse = function(connectionInfo, id, error) {
+    var socket = connectionInfo.socket;
     var msg = {};
     msg.replyTo = id;
     if (error) {
@@ -565,13 +573,14 @@ var _handlePushActivity = function(data, callback) {
 
     var todo = 0;
     // Iterate over the sockets that are interested in this stream, transform the activity and send it down the socket
-    _.each(socketsPerStream[activityStreamId], function(socket) {
+    _.each(connectionInfosPerStream[activityStreamId], function(connectionInfo) {
+        var socket = connectionInfo.socket;
 
-        _.each(socket.transformerTypes[activityStreamId], function(transformerType) {
+        _.each(connectionInfo.transformerTypes[activityStreamId], function(transformerType) {
             todo++;
             // Because we're sending this activity to possible multiple sockets/users we'll need to clone and transform it for each socket
             var activities = [clone(data.activity)];
-            ActivityTransformer.transformActivities(socket.ctx, activities, transformerType, function(err) {
+            ActivityTransformer.transformActivities(connectionInfo.ctx, activities, transformerType, function(err) {
                 if (err) {
                     return log().error({'err': err}, 'Could not transform event');
                 }


### PR DESCRIPTION
This one makes no sense to me. This is more-or-less a shot in the dark.

The `setTimeout` set for 5 seconds never gets invoked within the 60 second timeout. There are clear log entries that indicate that:

a) The setTimeout occurs
b) The callback function never gets invoked
c) The timeout never gets cleared

My best guess at this point is that there is something associated to a socket, either within sockjs or the Node.js streams / connections API that scrapes the object looking for "leaky" things that need to be trashed such as timeouts, event emitters, etc... and ours is becoming a casualty of that since we attach the timeout pointer directly to the socket object.

As a further improvement to find a solution, rather than attaching things directly to the `socket`, I wrap the socket in a `connectionInfo` object that contains all the state that we just attach to the socket.

Hopefully this will stop our timeout from being trashed.
