### PR TITLE
Adding isManager/isViewer properties to content and discussion items

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -83,7 +83,7 @@ var getContent = module.exports.getContent = function(ctx, contentId, callback) 
         return callback(validator.getFirstError());
     }
 
-    ContentDAO.Content.getContent(contentId, function(err, contentObj) {
+    _getContent(ctx, contentId, function(err, contentObj) {
         if (err) {
             return callback(err);
         }
@@ -95,16 +95,37 @@ var getContent = module.exports.getContent = function(ctx, contentId, callback) 
                 return callback({'code': 401, 'msg': 'You don\'t have access to this piece of content'});
             }
 
-            ContentUtil.augmentContent(ctx, contentObj);
             return callback(null, contentObj);
         });
     });
 };
 
 /**
- * Get a full content item profile. Next to the basic content profile, this will include the created date, the profile of
- * the user who originally created the content, and a isManager property specifying whether or not the current user can
- * manage the content.
+ * Get a content item straight from the database.
+ * This method will *NOT* perform any access checks
+ *
+ * @param  {Context}        ctx                     Standard context object, representing the currently logged in user and its tenant
+ * @param  {String}         contentId               The id of the content object we want to retrieve
+ * @param  {Function}       callback                Standard callback function
+ * @param  {Object}         callback.err            Error object containing the error message
+ * @param  {Content}        callback.contentObj     Retrieved content object
+ * @api private
+ */
+var _getContent = function(ctx, contentId, callback) {
+    ContentDAO.Content.getContent(contentId, function(err, contentObj) {
+        if (err) {
+            return callback(err);
+        }
+
+        ContentUtil.augmentContent(ctx, contentObj);
+        return callback(null, contentObj);
+    });
+};
+
+/**
+ * Get a content item's full content profile. Next to the basic content profile, this will include the created date,
+ * the profile of the user who originally created the content, and a isManager property specifying whether or not
+ * the current user can manage the content.
  *
  * @param  {Context}        ctx                         Standard context object, representing the currently logged in user and its tenant
  * @param  {String}         contentId                   The id of the content item to get
@@ -120,36 +141,36 @@ var getFullContentProfile = module.exports.getFullContentProfile = function(ctx,
         return callback(validator.getFirstError());
     }
 
-    getContent(ctx, contentId, function(err, contentObj) {
+    // Get the basic content item
+    _getContent(ctx, contentId, function(err, contentObj) {
         if (err) {
             return callback(err);
         }
 
-        // Check whether the user is a manager.
-        _canManage(ctx, contentObj, function(err, isManager) {
-            if (err) {
-                return callback(err);
-            }
-
-            return _getFullContentProfile(ctx, contentObj, isManager, callback);
-        });
+        // Now get the full content profile which will take care of the access check
+        return _getFullContentProfile(ctx, contentObj, callback);
     });
 };
 
 /**
- * Add the `isManager` flag, `createdBy` user object, `canShare` flag and the `latestRevision` in case it's a collaborative document.
+ * Add the following properties to the content profile
+ *     `isManager`         -  `true` if the current user (or one of the groups he's a memebr of) is an explicit manager of the content item
+ *     `isViewer`          -  `true` if the current user (or one of the groups he's a memebr of) is an explicit viewer of the content item
+ *     `canManage`         -  `true` if the current user can manage this content item (either implicitly or explicitly)
+ *     `canShare`          -  `true` if the current user can share this content item with other users and/or groups
+ *     `createdBy`         -  The full user object of the user who created the content item
+ *     `latestRevision`    -  The full revision object in case the item is a collaborative document
+ *
+ * This method will perform an extra access check
  *
  * @param  {Context}    ctx                         Standard context object, representing the currently logged in user and its tenant
  * @param  {Content}    contentObj                  The content object to add the extra profile information on.
- * @param  {Boolean}    isManager                   Whether or not the current user is a manager of the piece of content.
  * @param  {Function}   callback                    Standard callback function
  * @param  {Object}     callback.err                An error that occurred, if any
  * @param  {Content}    callback.contentProfile     Full content profile
+ * @api private
  */
-var _getFullContentProfile = function(ctx, contentObj, isManager, callback) {
-    // Store the isManager property.
-    contentObj.isManager = isManager;
-
+var _getFullContentProfile = function(ctx, contentObj, callback) {
     // Get the user object for the createdBy property
     PrincipalsUtil.getPrincipal(ctx, contentObj.createdBy, function(err, createdBy) {
         if (err) {
@@ -157,31 +178,74 @@ var _getFullContentProfile = function(ctx, contentObj, isManager, callback) {
         }
         contentObj.createdBy = createdBy;
 
-        // Check if the user can share this content item
-        _canShareContent(ctx, contentObj, function(err, canShare) {
+        // Get the roles the user has on the content item
+        _getAllRoles(ctx, contentObj, function(err, roles) {
             if (err) {
                 return callback(err);
             }
 
-            // Specify on the return value if the current user can share the content item
-            contentObj.canShare = canShare;
-
-            // For any other than collabdoc, we simply return with the share information
-            if (contentObj.resourceSubType !== 'collabdoc') {
-                return callback(null, contentObj);
-            }
-
-            // If the content item is a collaborative document, add the latest revision data
-            _getRevision(ctx, contentObj, contentObj.latestRevisionId, function(err, revision) {
+            // Check if the user can access the content item by virtue of the visibility settings
+            AuthzAPI.resolveImplicitRole(ctx, contentObj.id, contentObj.tenant.alias, contentObj.visibility, ContentConstants.roles.ALL_PRIORITY, function(err, implicitRole, canInteract) {
                 if (err) {
                     return callback(err);
                 }
 
-                contentObj.latestRevision = revision;
-                return callback(null, contentObj);
+                // If the user does not have an implicit role nor an explicit role on the content item,
+                // he should not be allowed to view it
+                else if (!implicitRole && _.isEmpty(roles)) {
+                    return callback({'code': 401, 'msg': 'You don\'t have access to this piece of content'});
+                }
+
+                // Check if the user can share this content item
+                _canShareContent(ctx, contentObj, roles, function(err, canShare) {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    // Some properties that the UI can use to determine what components should be displayed
+                    var isViewer = _.contains(roles, ContentConstants.roles.VIEWER);
+                    var isManager = _.contains(roles, ContentConstants.roles.MANAGER);
+                    contentObj.isViewer = isViewer;
+                    contentObj.isManager = isManager;
+                    contentObj.canManage = isManager || (ctx.user() && ctx.user().isAdmin(contentObj.tenant.alias)) || false;
+                    contentObj.canShare = canShare;
+
+                    // For any other than collabdoc, we simply return here
+                    if (contentObj.resourceSubType !== 'collabdoc') {
+                        return callback(null, contentObj);
+                    }
+
+                    // If the content item is a collaborative document, add the latest revision data
+                    _getRevision(ctx, contentObj, contentObj.latestRevisionId, function(err, revision) {
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        contentObj.latestRevision = revision;
+                        return callback(null, contentObj);
+                    });
+                });
             });
         });
     });
+};
+
+/**
+ * Get all the roles the current user has on a piece of content
+ *
+ * @param  {Context}    ctx                 Standard context object containing the current user and the current tenant
+ * @param  {Content}    contentObj          The content object for which the roles of the current user should be retrieved
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        Standard error object
+ * @param  {String[]}   callback.roles      A set of roles the current user has on the piece of content
+ * @api private
+ */
+var _getAllRoles = function(ctx, contentObj, callback) {
+    if (!ctx.user()) {
+        return callback(null, []);
+    } else {
+        return AuthzAPI.getAllRoles(ctx.user().id, contentObj.id, callback);
+    }
 };
 
 /////////////////////////////////////
@@ -712,8 +776,8 @@ var deleteContent = module.exports.deleteContent = function(ctx, contentId, call
  * @param  {Context}   ctx               Standard context object containing the current user and the current tenant
  * @param  {String}    contentId         The id of the content item to share
  * @param  {String[]}  principalIds      Array of principal ids with whom the content will be shared. By default, they will all be made members.
- * @param  {Function}  callback          Standard callback function
- * @param  {Object}    callback.err      An error that occurred, if any
+ * @param  {Function}  callback          Standard callback function takes arguments `err` and `content`
+ * @param  {Object}    callback.err      Error object containing the error message
  */
 var shareContent = module.exports.shareContent = function(ctx, contentId, principalIds, callback) {
     callback = callback || function() {};
@@ -728,79 +792,46 @@ var shareContent = module.exports.shareContent = function(ctx, contentId, princi
     }
 
     // Check if the content item exists
-    ContentDAO.Content.getContent(contentId, function(err, contentObj) {
+    _getContent(ctx, contentId, function(err, contentObj) {
         if (err) {
             return callback(err);
         }
 
-        // Check if the user is allowed to share this content item
-        _canShareContent(ctx, contentObj, function(err, canShare) {
+        // Check if the user can share this content item
+        _canShareContent(ctx, contentObj, null, function(err, canShare, illegalPrincipalIds) {
             if (err) {
                 return callback(err);
+            } else if (illegalPrincipalIds) {
+                return callback({'code': 400, 'msg': 'One or more target members are not authorized to become viewers on this piece of content'});
             } else if (!canShare) {
                 return callback({'code': 401, 'msg': 'You are not allowed to share this content'});
             }
 
-            // Check the impact of making each user in the list a manager. We use this method to get a summary
-            // of which users will be newly added and to ensure we are not violating tenant boundary
-            // restrictions. We are testing with the "manager" role since we don't want this method to fail
-            // on the basis that we might be making the last manager of the content item a "viewer", leaving it
-            // without any managers
-            var testPermissionChanges = _makeAllPermissionChanges(principalIds, ContentConstants.roles.MANAGER);
-            _checkNewContentPermissions(ctx, contentObj, testPermissionChanges, function(err, membershipAfterChanges, newMemberIds, updatedMemberIds, removedMemberIds, newMembers) {
-                if (err) {
-                    return callback(err);
-                } else if (_.isEmpty(newMembers)) {
-                    // If there are no users being added, this means all users we are trying to
-                    // share with already have this in their library, so we just succeed with a
-                    // no-op
-                    return callback();
-                }
-
-                // Set the viewer permissions for only users who previously had no role on the item
-                var realPermissionChanges = _makeAllPermissionChanges(newMemberIds, ContentConstants.roles.VIEWER);
-                _setContentPermissions(ctx, contentObj, realPermissionChanges, function(err) {
-                    if (err) {
-                        return callback(err);
-                    }
-
-                    // Insert the new users into the content members library
-                    ContentMembersLibrary.insert(contentObj, newMembers, function(err) {
-                        if (err) {
-                            log().warn({
-                                'err': err,
-                                'contentId': contentObj.id,
-                                'principalIds': _.pluck(newMembers, 'id')
-                            }, 'An error occurred while inserting principals into content members library after share');
-                        }
-
-                        ContentAPI.emit(ContentConstants.events.UPDATED_CONTENT_MEMBERS, ctx, contentObj, realPermissionChanges, newMemberIds, [], []);
-                        return callback();
-                    });
-                });
-            });
+            return _shareContent(ctx, contentObj, principalIds, callback);
         });
     });
 };
 
 /**
- * Checks if a content item can be shared
+ * Checks if a piece of content can be shared.
  *
  * @param  {Context}    ctx                             The context of the current request
  * @param  {Content}    contentObj                      The content to test for access
- * @param  {Function}   callback                        Standard callback function
+ * @param  {String[]}   [roles]                         The roles the current user holds on the content object. If left `null`, the roles will be retrieved from the database
+ * @param  {Function}   callback                        Invoked when the process completes
  * @param  {Object}     callback.err                    An error that occurred, if any
- * @param  {Boolean}    callback.canShare               `true` if the user in context is allowed to share the content item. `false` otherwise
+ * @param  {Boolean}    callback.canShare               `true` if the user in context is allowed to perform this share operation. `false` otherwise
  * @api private
  */
-var _canShareContent = function(ctx, contentObj, callback) {
-    // Anonymous users can never share
+var _canShareContent = function(ctx, contentObj, roles, callback) {
     var user = ctx.user();
+
+    // Anonymous users can never share
     if (!user) {
         return callback(null, false);
     }
 
-    // Check if we have access on the content item
+    // Check if we have access on the content file
     AuthzAPI.resolveImplicitRole(ctx, contentObj.id, contentObj.tenant.alias, contentObj.visibility, ContentConstants.roles.ALL_PRIORITY, function(err, implicitRole, canInteract) {
         if (implicitRole === ContentConstants.roles.MANAGER) {
             // Managers can always share
@@ -808,14 +839,78 @@ var _canShareContent = function(ctx, contentObj, callback) {
         } else if (canInteract) {
             // If we can interact with the item, we can always share it
             return callback(null, true);
-        } else if (contentObj.visibility === AuthzConstants.visibility.PRIVATE) {
-            // If the content is private, we need to be a manager to share it
-            return AuthzAPI.hasRole(user.id, contentObj.id, ContentConstants.roles.MANAGER, callback);
         }
 
-        // There is no implicit access and the content item is not private, so if we have any
-        // explicit role on the content item we can share it
-        return AuthzAPI.hasAnyRole(user.id, contentObj.id, callback);
+        // If the content is private, only managers can share it
+        if (contentObj.visibility === AuthzConstants.visibility.PRIVATE) {
+            if (roles) {
+                var isManager = (_.contains(roles, ContentConstants.roles.MANAGER));
+                return callback(null, isManager);
+            } else {
+                return AuthzAPI.hasRole(user.id, contentObj.id, ContentConstants.roles.MANAGER, callback);
+            }
+        }
+
+        // At this point, we have to see if the user has any explicit role on the resource to see if they can share it
+        if (roles) {
+            var hasRole = (!_.isEmpty(roles));
+            return callback(null, hasRole);
+        } else {
+            AuthzAPI.hasAnyRole(user.id, contentObj.id, callback);
+        }
+    });
+};
+
+/**
+ * Internal function used to share a piece of content with a set of principals. This function assume that the current user is allowed
+ * to see and share the content. If some of the principals passed into this function are already content members, no updates to the
+ * existing role of those principals will be made.
+ *
+ * @param  {Context}   ctx               The current execution context.
+ * @param  {Content}   contentObj        Content object representing the content that is being shared
+ * @param  {String[]}  principalIds      Array of principal ids with whom the content will be shared. By default, they will all be made members
+ * @param  {Function}  callback          Standard callback function takes arguments `err` and `content`
+ * @param  {Object}    callback.err      Error object containing the error message
+ * @api private
+ */
+var _shareContent = function(ctx, contentObj, principalIds, callback) {
+    // Check the impact of making each user in the list a manager. We use this method to get a summary
+    // of which users will be newly added and to ensure we are not violating tenant boundary
+    // restrictions. We are testing with the "manager" role since we don't want this method to fail
+    // on the basis that we might be making the last manager of the content item a "viewer", leaving it
+    // without any managers
+    var testPermissionChanges = _makeAllPermissionChanges(principalIds, ContentConstants.roles.MANAGER);
+    _checkNewContentPermissions(ctx, contentObj, testPermissionChanges, function(err, membershipAfterChanges, newMemberIds, updatedMemberIds, removedMemberIds, newMembers) {
+        if (err) {
+            return callback(err);
+        } else if (_.isEmpty(newMembers)) {
+            // If there are no users being added, this means all users we are trying to
+            // share with already have this in their library, so we just succeed with a
+            // no-op
+            return callback();
+        }
+
+        // Set the viewer permissions for only users who previously had no role on the item
+        var realPermissionChanges = _makeAllPermissionChanges(newMemberIds, ContentConstants.roles.VIEWER);
+        _setContentPermissions(ctx, contentObj, realPermissionChanges, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            // Insert the new users into the content members library
+            ContentMembersLibrary.insert(contentObj, newMembers, function(err) {
+                if (err) {
+                    log().warn({
+                        'err': err,
+                        'contentId': contentObj.id,
+                        'principalIds': _.pluck(newMembers, 'id')
+                    }, 'An error occurred while inserting principals into content members library after share');
+                }
+
+                ContentAPI.emit(ContentConstants.events.UPDATED_CONTENT_MEMBERS, ctx, contentObj, realPermissionChanges, newMemberIds, [], []);
+                return callback();
+            });
+        });
     });
 };
 
@@ -838,13 +933,9 @@ var canManage = module.exports.canManage = function(ctx, contentId, callback) {
         return callback(validator.getFirstError());
     }
 
-    getContent(ctx, contentId, function(err, contentObj) {
+    _getContent(ctx, contentId, function(err, contentObj) {
         if (err) {
-            if (err.code === 401) {
-                return callback(null, false);
-            } else {
-                return callback(err);
-            }
+            return callback(err);
         }
 
         _canManage(ctx, contentObj, function(err, canManage) {
@@ -913,12 +1004,16 @@ var _canManageAll = function(ctx, contentItems, callback, _cannotManageContentIt
  * @api private
  */
 var _canManage = function(ctx, contentObj, callback) {
+    // Anonymous users can't manage anything
     if (!ctx.user()) {
         return callback(null, false);
+
+    // Tenant admins of the content item can manage it
     } else if (ctx.user().isAdmin(contentObj.tenant.alias)) {
         return callback(null, true);
     }
 
+    // Users with an explicit `manager` role can manage the content item
     return AuthzAPI.hasRole(ctx.user().id, contentObj.id, ContentConstants.roles.MANAGER, callback);
 };
 
@@ -954,24 +1049,24 @@ var hasAccess = module.exports.hasAccess = function(ctx, contentId, callback) {
  * @param  {Content}        contentObj          The content object representing the content item we're checking access for
  * @param  {Function}       callback            Standard callback function
  * @param  {Object}         callback.err        An error that occurred, if any
- * @param  {Boolean}        callback.canManage  Whether or not the user has access to the content
+ * @param  {Boolean}        callback.hasAccess  Whether or not the user has access to the content
  * @api private
  */
 var _hasAccess = function(ctx, contentObj, callback) {
-    if (contentObj.visibility === AuthzConstants.visibility.PUBLIC) {
-        return callback(null, contentObj);
-    // If the content is visible to logged in users, I get access if I'm logged in
-    } else if (contentObj.visibility === AuthzConstants.visibility.LOGGEDIN && TenantsUtil.isLoggedIn(ctx, contentObj.tenant.alias)) {
-        return callback(null, contentObj);
-    // If the user is admin of the content's tenant, they have access
-    } else if (ctx.user() && ctx.user().isAdmin(contentObj.tenant.alias)) {
-        return callback(null, contentObj);
-    // If the content is private
-    } else if (ctx.user()) {
-        return AuthzAPI.hasAnyRole(ctx.user().id, contentObj.id, callback);
-    }
+    AuthzAPI.resolveImplicitRole(ctx, contentObj.id, contentObj.tenant.alias, contentObj.visibility, ContentConstants.roles.ALL_PRIORITY, function(err, implicitRole, canInteract) {
+        if (err) {
+            return callback(err);
+        } else if (implicitRole) {
+            // We have an implicit access, no reason to try and find an explicit access because we can atleast view
+            return callback(null, true);
+        } else if (!ctx.user()) {
+            // Anonymous user with no implicit access cannot view
+            return callback(null, false);
+        }
 
-    return callback({'code': 401, 'msg': 'You don\'t have access to this piece of content'});
+        // By this point, we only have access to view if we have a role on the item
+        AuthzAPI.hasAnyRole(ctx.user().id, contentObj.id, callback);
+    });
 };
 
 /**
@@ -1001,7 +1096,7 @@ var setContentPermissions = module.exports.setContentPermissions = function(ctx,
     }
 
     // Check if the content exists
-    getContent(ctx, contentId, function(err, contentObj) {
+    _getContent(ctx, contentId, function(err, contentObj) {
         if (err) {
             return callback(err);
         }
@@ -1182,7 +1277,7 @@ var removeContentFromLibrary = module.exports.removeContentFromLibrary = functio
     }
 
     // Make sure the content exists
-    ContentDAO.Content.getContent(contentId, function(err, content) {
+    _getContent(ctx, contentId, function(err, content) {
         if (err) {
             return callback(err);
         }
@@ -1418,7 +1513,7 @@ var _updateFileBody = function(ctx, contentId, file, callback) {
                     ContentAPI.emit(ContentConstants.events.UPDATED_CONTENT_BODY, ctx, updatedContentObj, contentObj, revision);
 
                     // Output a full content profile
-                    return _getFullContentProfile(ctx, updatedContentObj, true, callback);
+                    return _getFullContentProfile(ctx, updatedContentObj, callback);
                 });
             });
         });
@@ -1458,7 +1553,7 @@ var setPreviewItems = module.exports.setPreviewItems = function(ctx, contentId, 
         return cleanUpCallback(validator.getFirstError());
     }
 
-    ContentDAO.Content.getContent(contentId, function(err, contentObj) {
+    _getContent(ctx, contentId, function(err, contentObj) {
         if (err) {
             return cleanUpCallback(err);
         }
@@ -1708,8 +1803,8 @@ var updateContentMetadata = module.exports.updateContentMetadata = function(ctx,
 
             ContentAPI.emit(ContentConstants.events.UPDATED_CONTENT, ctx, newContentObj, oldContentObj);
 
-            // Add the isManager, createdBy, .. properties.
-            _getFullContentProfile(ctx, newContentObj, true, callback);
+            // Add the isManager, createdBy, .. properties
+            _getFullContentProfile(ctx, newContentObj, callback);
         });
     });
 };

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -168,12 +168,14 @@ describe('Content', function() {
      * @param  {String}             creator             The user id for which we want to check the library
      * @param  {Content}            contentObj          The content object we'll be running checks for
      * @param  {Boolean}            expectAccess        Whether or not we expect the current user to have access to the piece of content
-     * @param  {Boolean}            expectManager       Whether or not we expect the current user to be able to manage the piece of content
+     * @param  {Boolean}            expectCanManage     Whether or not we expect the current user to be able to manage the piece of content
+     * @param  {Boolean}            expectIsManager     Whether or not we expect the current user is an explicit manager of the content item
+     * @param  {Boolean}            expectIsViewer      Whether or not we expect the current user is an explicit viewer of the content item
      * @param  {Boolean}            expectInLibrary     Whether or not we expect the current user to see the item in the creator's library
      * @param  {Boolean}            expectCanShare      Whether or not we expect the current user to be allowed to share the content
      * @param  {Function}           callback            Standard callback function executed when all checks have finished
      */
-    var checkPieceOfContent = function(restCtx, libraryToCheck, contentObj, expectAccess, expectManager, expectInLibrary, expectCanShare, callback) {
+    var checkPieceOfContent = function(restCtx, libraryToCheck, contentObj, expectAccess, expectCanManage, expectIsManager, expectIsViewer, expectInLibrary, expectCanShare, callback) {
         // Check whether the content can be retrieved
         RestAPI.Content.getContent(restCtx, contentObj.id, function(err, retrievedContent) {
             if (expectAccess) {
@@ -192,8 +194,9 @@ describe('Content', function() {
                 assert.ok(retrievedContent.lastModified);
                 assert.equal(retrievedContent.resourceType, 'content');
                 assert.equal(retrievedContent.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                // Check if the canManage check is appropriate
-                assert.equal(retrievedContent.isManager, expectManager);
+                assert.equal(retrievedContent.canManage, expectCanManage);
+                assert.equal(retrievedContent.isManager, expectIsManager);
+                assert.equal(retrievedContent.isViewer, expectIsViewer);
                 assert.equal(retrievedContent.canShare, expectCanShare);
             } else {
                 assert.ok(err);
@@ -1693,11 +1696,11 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                         // Get the piece of content as a different logged in user
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, false, true, true, function() {
                             // Get the piece of content as an anonymous user
-                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, true, false, callback);
+                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, false, false, true, false, callback);
                         });
                     });
                 });
@@ -1716,11 +1719,11 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                         // Get the piece of content as a different logged in user
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, false, true, true, function() {
                             // Get the piece of content as an anonymous user
-                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
+                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, callback);
                         });
                     });
                 });
@@ -1739,11 +1742,11 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                         // Get the piece of content as a different logged in user
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, function() {
                             // Get the piece of content as an anonymous user
-                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
+                            checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, callback);
                         });
                     });
                 });
@@ -1763,15 +1766,15 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                         // Get the piece of content as another manager
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, false, true, true, function() {
                             // Get the piece of content as a viewer
-                            checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, false, function() {
+                            checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, true, false, function() {
                                 // Get the piece of content as a non-member
-                                checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, false, false, false, false, function() {
+                                checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, false, false, false, false, false, false, function() {
                                     // Get the piece of content as an anonymous user
-                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
+                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, callback);
                                 });
                             });
                         });
@@ -1793,15 +1796,15 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                         // Get the piece of content as another manager
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, false, true, true, function() {
                             // Get the piece of content as a viewer
-                            checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, false, function() {
+                            checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, true, false, function() {
                                 // Get the piece of content as a non-member
-                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, function() {
+                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, false, false, function() {
                                     // Get the piece of content as an anonymous user
-                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
+                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, callback);
                                 });
                             });
                         });
@@ -1823,15 +1826,15 @@ describe('Content', function() {
                     assert.ok(contentObj.id);
 
                     // Get the piece of content as the person who created the content
-                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                         // Get the piece of content as another manager
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, false, true, true, function() {
                             // Get the piece of content as a viewer
-                            checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, false, function() {
+                            checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, true, false, function() {
                                 // Get the piece of content as a non-member
-                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, function() {
+                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, false, false, function() {
                                     // Get the piece of content as an anonymous user
-                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
+                                    checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, callback);
                                 });
                             });
                         });
@@ -2611,42 +2614,42 @@ describe('Content', function() {
                 assert.ok(!err);
                 assert.ok(contentObj.id);
                 // Get the piece of content as the creator
-                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                     // Make a user a manager and make a user a member
                     var permissions = {};
                     permissions[contexts['simon'].user.id] = 'manager';
                     permissions[contexts['ian'].user.id] = 'viewer';
                     RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                         assert.ok(!err);
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
-                            checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, true, false, true, (privacy !== 'private'), function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, false, true, true, function() {
+                            checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, true, false, false, true, true, (privacy !== 'private'), function() {
                                 // Share the content with another user
                                 RestAPI.Content.shareContent(contexts['simon'].restContext, contentObj.id, [contexts['stuart'].user.id], function(err) {
                                     assert.ok(!err);
-                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, (privacy !== 'private'), function() {
+                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, true, (privacy !== 'private'), function() {
                                         // Try to delete the content as an anonymous user
                                         RestAPI.Content.deleteContent(anonymousRestContext, contentObj.id, function(err) {
                                             assert.ok(err);
                                             // Check that it is still around
-                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                                                 // Try to delete the content as a logged in user
                                                 RestAPI.Content.deleteContent(contexts['anthony'].restContext, contentObj.id, function(err) {
-                                                    assert.ok(err);
+                                                    assert.equal(err.code, 401);
                                                     // Check that it is still around
-                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                                                         // Try to delete the content as a content member
                                                         RestAPI.Content.deleteContent(contexts['stuart'].restContext, contentObj.id, function(err) {
-                                                            assert.ok(err);
+                                                            assert.equal(err.code, 401);
                                                             // Check that it is still around
-                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
                                                                 // Try to delete the content as a content manager
                                                                 RestAPI.Content.deleteContent(contexts['nicolaas'].restContext, contentObj.id, function(err) {
                                                                     assert.ok(!err);
                                                                     // Check to see if the manager, a member, a logged in user and the anonymous user still have access
-                                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, function() {
-                                                                        checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, false, false, false, false, function() {
-                                                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, function() {
-                                                                                checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, function() {
+                                                                    checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, function() {
+                                                                        checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, false, false, false, false, false, false, function() {
+                                                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, false, false, function() {
+                                                                                checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, function() {
                                                                                     // Check roles api for the role on the content for a manager, a member and a logged in user
                                                                                     AuthzAPI.getAllRoles(contexts['nicolaas'].user.id, contentObj.id, function(err, roles) {
                                                                                         assert.strictEqual(roles.length, 0);
@@ -2755,13 +2758,120 @@ describe('Content', function() {
                 assert.ok(contentObj.id);
 
                 // Get the piece of content as the person who created the content
-                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
+                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
+                    // Check the list of content members
+                    RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
+                        assert.ok(!err);
+                        assert.equal(members.results.length, 1);
+                        // Morph results to hash for easy access.
+                        var hash = _.groupBy(members.results, function(member) {
+                            return member.profile.id;
+                        });
+                        assert.equal(hash[contexts['nicolaas'].user.id][0].role, 'manager');
 
-                    // Make another user viewer of the content
-                    var permissions = {};
-                    permissions[contexts['stuart'].user.id] = 'viewer';
-                    return ContentTestUtil.assertUpdateContentMembersSucceeds(contexts['nicolaas'].restContext, contexts['nicolaas'].restContext, contentObj.id, permissions, function() {
-                        return callback(contentObj);
+                        // Try an invalid set permissions with no principals passed in
+                        RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, {}, function(err) {
+                            assert.ok(err);
+
+                            // Make another user manager of the content
+                            var permissions = {};
+                            permissions[contexts['simon'].user.id] = 'manager';
+                            RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                assert.ok(!err);
+                                // Get the piece of content as the newly added manager
+                                checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, false, true, true, function() {
+                                    RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
+                                        assert.ok(!err);
+                                        assert.equal(members.results.length, 2);
+                                        // Morph results to hash for easy access.
+                                        var hash = _.groupBy(members.results, function(member) {
+                                            return member.profile.id;
+                                        });
+                                        assert.equal(hash[contexts['nicolaas'].user.id][0].role, 'manager');
+                                        assert.equal(hash[contexts['simon'].user.id][0].role, 'manager');
+
+                                        // Make another user member of the content
+                                        permissions = {};
+                                        permissions[contexts['stuart'].user.id] = 'viewer';
+                                        RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                            assert.ok(!err);
+                                            // Get the piece of content as the added member
+                                            checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, true, (privacy !== 'private'), function() {
+                                                RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
+                                                    assert.ok(!err);
+                                                    assert.equal(members.results.length, 3);
+                                                    // Morph results to hash for easy access.
+                                                    var hash = _.groupBy(members.results, function(member) {
+                                                        return member.profile.id;
+                                                    });
+                                                    assert.equal(hash[contexts['nicolaas'].user.id][0].role, 'manager');
+                                                    assert.equal(hash[contexts['simon'].user.id][0].role, 'manager');
+                                                    assert.equal(hash[contexts['stuart'].user.id][0].role, 'viewer');
+
+                                                    // Try to add an existing and non-existing user
+                                                    permissions = {};
+                                                    permissions[contexts['anthony'].user.id] = 'viewer';
+                                                    permissions['u:cam:nonExistingUser'] = 'viewer';
+                                                    RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                                        assert.ok(err);
+                                                        // Get the piece of content as the member that was part of the invalid setPermissions
+                                                        checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, (privacy !== 'private'), false, false, false, false, (privacy !== 'private'), function() {
+                                                            RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
+                                                                assert.ok(!err);
+                                                                assert.equal(members.results.length, 3);
+                                                                // Morph results to hash for easy access.
+                                                                var hash = _.groupBy(members.results, function(member) {
+                                                                    return member.profile.id;
+                                                                });
+                                                                assert.equal(hash[contexts['nicolaas'].user.id][0].role, 'manager');
+                                                                assert.equal(hash[contexts['simon'].user.id][0].role, 'manager');
+                                                                assert.equal(hash[contexts['stuart'].user.id][0].role, 'viewer');
+
+                                                                // Remove a manager from the content
+                                                                permissions = {};
+                                                                permissions[contexts['simon'].user.id] = false;
+                                                                RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                                                    assert.ok(!err);
+                                                                    // Get the piece of content as the removed manager
+                                                                    checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, (privacy !== 'private'), false, false, false, false, (privacy !== 'private'), function() {
+                                                                        RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
+                                                                            assert.ok(!err);
+                                                                            assert.equal(members.results.length, 2);
+                                                                            // Morph results to hash for easy access.
+                                                                            var hash = _.groupBy(members.results, function(member) {
+                                                                                return member.profile.id;
+                                                                            });
+                                                                            assert.equal(hash[contexts['nicolaas'].user.id][0].role, 'manager');
+                                                                            assert.equal(hash[contexts['simon'].user.id], undefined);
+                                                                            assert.equal(hash[contexts['stuart'].user.id][0].role, 'viewer');
+
+                                                                            // Try setting the permissions with an undefined role
+                                                                            permissions = {};
+                                                                            permissions[contexts['branden'].user.id] = undefined;
+                                                                            RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
+                                                                                assert.ok(err);
+
+                                                                                // Try to set the permissions on the content as a non-manager of the content
+                                                                                permissions = {};
+                                                                                permissions[contexts['nicolaas'].user.id] = 'viewer';
+                                                                                RestAPI.Content.updateMembers(contexts['simon'].restContext, contentObj.id, permissions, function(err) {
+                                                                                    assert.ok(err);
+                                                                                    callback(contentObj);
+                                                                                });
+                                                                            });
+                                                                        });
+                                                                    });
+                                                                });
+                                                            });
+                                                        });
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
                     });
                 });
             });
@@ -2774,9 +2884,9 @@ describe('Content', function() {
             setUpUsers(function(contexts) {
                 setUpContentPermissions(contexts, 'public', function(contentObj) {
                     // Get the piece of content as a non-associated user
-                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, true, function() {
+                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, false, false, true, function() {
                         // Get the piece of content as an anonymous user
-                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, true, false, callback);
+                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, true, false, false, false, true, false, callback);
                     });
                 });
             });
@@ -2789,9 +2899,9 @@ describe('Content', function() {
             setUpUsers(function(contexts) {
                 setUpContentPermissions(contexts, 'loggedin', function(contentObj) {
                     // Get the piece of content as a non-associated user
-                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, true, function() {
+                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, false, false, true, function() {
                         // Get the piece of content as an anonymous user
-                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
+                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, callback);
                     });
                 });
             });
@@ -2804,9 +2914,9 @@ describe('Content', function() {
             setUpUsers(function(contexts) {
                 setUpContentPermissions(contexts, 'private', function(contentObj) {
                     // Get the piece of content as a non-associated user
-                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, function() {
+                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, false, false, false, false, false, false, function() {
                         // Get the piece of content as an anonymous user
-                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, callback);
+                        checkPieceOfContent(anonymousRestContext, contexts['nicolaas'].user.id, contentObj, false, false, false, false, false, false, callback);
                     });
                 });
             });
@@ -3171,8 +3281,17 @@ describe('Content', function() {
                 assert.ok(!err);
                 assert.ok(contentObj.id);
                 // Get the piece of content as the creator
-                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, true, function() {
-                    return callback(contentObj);
+                checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, true, true, false, true, true, function() {
+                    RestAPI.Content.getMembers(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, members) {
+                        assert.ok(!err);
+                        assert.equal(members.results.length, 1);
+                        // Morph results to hash for easy access.
+                        var hash = _.groupBy(members.results, function(member) {
+                            return member.profile.id;
+                        });
+                        assert.equal(hash[contexts['nicolaas'].user.id][0].role, 'manager');
+                        callback(contentObj);
+                    });
                 });
             });
         };
@@ -3181,25 +3300,28 @@ describe('Content', function() {
          * Utility function for the sharing tests that will try to share content, will then check for access to the content by the person
          * the content was shared with. Then the test will check whether that person can see the content's membership list and sees the
          * correct list of members in there
+         *
          * @param  {Content}        contentObj          Content object that will be shared
          * @param  {Object}         sharer              Object representing the user that will share the content. The object will have a user key containing the user's basic profile and a restContext key containing the user's Rest Context
          * @param  {Object}         shareWith           Object representing the user that the content will be shared with. The object will have a user key containing the user's basic profile and a restContext key containing the user's Rest Context. Content access, library presence and membership checks will be run on this user
          * @param  {Boolean}        expectShare         Whether or not we expect that user 1 will be able to share the content with user 2
          * @param  {Boolean}        expectAccess        Whether or not we expect that user 2 will have access to the content after it's been shared with him
+         * @param  {Boolean}        expectCanManage     Whether or not we expect that user 2 can manage the content item
          * @param  {Boolean}        expectManager       Whether or not we expect that user 2 will be able to manage the content after it's been shared with him
+         * @param  {Boolean}        expectViewer        Whether or not we expect that user 2 will be a viewer of the content after it's been shared with him
          * @param  {Boolean}        expectInLibrary     Whether or not we expect user 2 to be able to see the content in his library after it's been shared with him
          * @param  {Object}         expectedMembers     JSON object representing the members that are expected to be on the content item after sharing. The keys represent the member ids and the values represent the role they should have.
-         * @param  {Boolean}         expectCanShare      Whether or not we expect user 2 to be able to share the content with further users
+         * @param  {Boolean}        expectCanShare      Whether or not we expect user 2 to be able to share the content with further users
          * @param  {Function}       callback            Standard callback function
          */
-        var testSharing = function(contentObj, sharer, shareWith, expectShare, expectAccess, expectManager, expectInLibrary, expectedMembers, expectCanShare, callback) {
+        var testSharing = function(contentObj, sharer, shareWith, expectShare, expectAccess, expectCanManage, expectManager, expectViewer, expectInLibrary, expectedMembers, expectCanShare, callback) {
             RestAPI.Content.shareContent(sharer.restContext, contentObj.id, [shareWith.user.id], function(err) {
                 if (expectShare) {
                     assert.ok(!err);
                 } else {
                     assert.ok(err);
                 }
-                checkPieceOfContent(shareWith.restContext, shareWith.user ? shareWith.user.id : null, contentObj, expectAccess, expectManager, expectInLibrary, expectCanShare , function() {
+                checkPieceOfContent(shareWith.restContext, shareWith.user ? shareWith.user.id : null, contentObj, expectAccess, expectCanManage, expectManager, expectViewer, expectInLibrary, expectCanShare , function() {
                     RestAPI.Content.getMembers(shareWith.restContext, contentObj.id, null, null, function(err, members) {
                         if (expectedMembers) {
                             assert.ok(!err);
@@ -3229,21 +3351,21 @@ describe('Content', function() {
                     var expectedMembers = {};
                     expectedMembers[contexts['nicolaas'].user.id] = 'manager';
                     expectedMembers[contexts['simon'].user.id] = 'viewer';
-                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, true, function() {
+                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, false, true, true, expectedMembers, true, function() {
 
                         // Share as content member
                         expectedMembers[contexts['anthony'].user.id] = 'viewer';
-                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, true, expectedMembers, true, function() {
+                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, false, true, true, expectedMembers, true, function() {
 
                             // Share as other user, add to own library
                             expectedMembers[contexts['stuart'].user.id] = 'viewer';
-                            testSharing(contentObj, contexts['anthony'], contexts['stuart'], true, true, false, true, expectedMembers, true, function() {
+                            testSharing(contentObj, contexts['anthony'], contexts['stuart'], true, true, false, false, true, true, expectedMembers, true, function() {
 
                                 // Share with the content manager, making sure that he's still the content manager after sharing
-                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], true, true, true, true, expectedMembers, true, function() {
+                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], true, true, true, true, false, true, expectedMembers, true, function() {
 
                                     // Share as anonymous
-                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, expectedMembers, true, callback);
+                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, false, false, expectedMembers, true, callback);
                                 });
                             });
                         });
@@ -3265,21 +3387,21 @@ describe('Content', function() {
                     var expectedMembers = {};
                     expectedMembers[contexts['nicolaas'].user.id] = 'manager';
                     expectedMembers[contexts['simon'].user.id] = 'viewer';
-                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, true, function() {
+                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, false, true, true, expectedMembers, true, function() {
 
                         // Share as content member
                         expectedMembers[contexts['anthony'].user.id] = 'viewer';
-                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, true, expectedMembers, true, function() {
+                        testSharing(contentObj, contexts['simon'], contexts['anthony'], true, true, false, false, true, true, expectedMembers, true, function() {
 
                             // Share as other user, add to own library
                             expectedMembers[contexts['stuart'].user.id] = 'viewer';
-                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], true, true, false, true, expectedMembers, true, function() {
+                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], true, true, false, false, true, true, expectedMembers, true, function() {
 
                                 // Share with the content manager, making sure that he's still the content manager after sharing
-                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], true, true, true, true, expectedMembers, true, function() {
+                                testSharing(contentObj, contexts['stuart'], contexts['nicolaas'], true, true, true, true, false, true, expectedMembers, true, function() {
 
                                     // Share as anonymous
-                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, expectedMembers, true, callback);
+                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, true, false, false, false, false, expectedMembers, true, callback);
                                 });
                             });
                         });
@@ -3303,19 +3425,19 @@ describe('Content', function() {
                     var expectedMembers = {};
                     expectedMembers[contexts['nicolaas'].user.id] = 'manager';
                     expectedMembers[contexts['simon'].user.id] = 'viewer';
-                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, true, expectedMembers, false, function() {
+                    testSharing(contentObj, contexts['nicolaas'], contexts['simon'], true, true, false, false, true, true, expectedMembers, false, function() {
 
                         // Share as content member
-                        testSharing(contentObj, contexts['simon'], contexts['anthony'], false, false, false, false, null, false, function() {
+                        testSharing(contentObj, contexts['simon'], contexts['anthony'], false, false, false, false, true, false, null, false, function() {
 
                             // Share as other user, add to own library
-                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], false, false, false, false, null, false, function() {
+                            testSharing(contentObj, contexts['stuart'], contexts['stuart'], false, false, false, false, true, false, null, false, function() {
 
                                 // Share with the content manager, making sure that he's still the content manager after sharing
-                                testSharing(contentObj, contexts['simon'], contexts['nicolaas'], false, true, true, true, expectedMembers, true, function() {
+                                testSharing(contentObj, contexts['simon'], contexts['nicolaas'], false, true, true, true, false, true, expectedMembers, true, function() {
 
                                     // Share as anonymous
-                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, false, false, false, null, false, callback);
+                                    testSharing(contentObj, {'restContext' : anonymousRestContext}, contexts['ian'], false, false, false, false, false, false, null, false, callback);
                                 });
                             });
                         });
@@ -3338,16 +3460,16 @@ describe('Content', function() {
                         assert.ok(!err);
 
                         // Check that these people have access
-                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, true, false, function() {
-                            checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, true, false, true, false, function() {
-                                checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, true, false, function() {
-                                    checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, function() {
+                        checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, false, true, true, false, function() {
+                            checkPieceOfContent(contexts['ian'].restContext, contexts['ian'].user.id, contentObj, true, false, false, true, true, false, function() {
+                                checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, true, false, function() {
+                                    checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, false, false, function() {
 
                                         // Share with multiple people, of which some are invalid users
                                         toShare = [contexts['anthony'].user.id, 'u:cam:nonExistingUser'];
                                         RestAPI.Content.shareContent(contexts['nicolaas'].restContext, contentObj.id, toShare, function(err) {
                                             assert.ok(err);
-                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, callback);
+                                            checkPieceOfContent(contexts['anthony'].restContext, contexts['anthony'].user.id, contentObj, false, false, false, false, false, false, callback);
                                         });
                                     });
                                 });
@@ -3429,9 +3551,9 @@ describe('Content', function() {
                 RestAPI.Content.updateMembers(contexts['anthony'].restContext, contentObj.id, permissions, function(err) {
                     assert.ok(!err);
                     // Check that UI Dev Team, Bert, Nico and Simon have member access
-                    checkPieceOfContent(contexts['bert'].restContext, groups['ui-team'].id, contentObj, true, false, true, (privacy !== 'private'), function() {
-                        checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
-                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
+                    checkPieceOfContent(contexts['bert'].restContext, groups['ui-team'].id, contentObj, true, false, false, true, true, (privacy !== 'private'), function() {
+                        checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, true, false, (privacy !== 'private'), function() {
+                            checkPieceOfContent(contexts['bert'].restContext, contexts['bert'].user.id, contentObj, true, false, false, true, false, (privacy !== 'private'), function() {
                                 // Check that it shows in UI Dev Team's library
                                 RestAPI.Content.getLibrary(contexts['nicolaas'].restContext, groups['ui-team'].id, null, 10, function(err, contentItems) {
                                     assert.ok(!err);
@@ -3458,16 +3580,16 @@ describe('Content', function() {
                                                         assert.ok(!err);
                                                         assert.equal(contentItems.results.length, 0);
                                                         // Check that Stuart doesn't have access
-                                                        checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), function() {
+                                                        checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, (privacy !== 'private'), false, false, false, false, (privacy !== 'private'), function() {
                                                             // Check that Branden doesn't have access
-                                                            checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), function() {
+                                                            checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, (privacy !== 'private'), false, false, false, false, (privacy !== 'private'), function() {
 
                                                                 // Share with the OAE Team group
                                                                 RestAPI.Content.shareContent(contexts['anthony'].restContext, contentObj.id, [groups['oae-team'].id], function(err) {
                                                                     // Check that Stuart has access
-                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
+                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, false, (privacy !== 'private'), function() {
                                                                         // Check that Branden has access
-                                                                        checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
+                                                                        checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, false, false, true, false, (privacy !== 'private'), function() {
                                                                             // Check that it shows in OAE Team and UI Dev team's library and not in the Back-End Team's library
                                                                             RestAPI.Content.getLibrary(contexts['anthony'].restContext, groups['oae-team'].id, null, 10, function(err, contentItems) {
                                                                                 assert.ok(!err);
@@ -3487,9 +3609,9 @@ describe('Content', function() {
                                                                                         RestAPI.Content.updateMembers(contexts['anthony'].restContext, contentObj.id, permissions, function(err) {
                                                                                             assert.ok(!err);
                                                                                             // Check that Simon and Branden are manager, check that Stuart is not a manager
-                                                                                            checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, function() {
-                                                                                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, true, false, true, function() {
-                                                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
+                                                                                            checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, true, true, true, true, true, function() {
+                                                                                                checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, true, true, true, true, false, true, function() {
+                                                                                                    checkPieceOfContent(contexts['stuart'].restContext, contexts['stuart'].user.id, contentObj, true, false, false, true, false, (privacy !== 'private'), function() {
 
                                                                                                         // Remove permission for Back-end team manager and OAE Team
                                                                                                         permissions = {};
@@ -3498,9 +3620,9 @@ describe('Content', function() {
                                                                                                         RestAPI.Content.updateMembers(contexts['anthony'].restContext, contentObj.id, permissions, function(err) {
                                                                                                             assert.ok(!err);
                                                                                                             // Check that Branden no longer has access, but Simon and Nico still do
-                                                                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, (privacy !== 'private'), function() {
-                                                                                                                checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, true, (privacy !== 'private'), function() {
-                                                                                                                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, privacy === 'private' ? false : true, false, false, (privacy !== 'private'), callback);
+                                                                                                            checkPieceOfContent(contexts['nicolaas'].restContext, contexts['nicolaas'].user.id, contentObj, true, false, false, true, false, (privacy !== 'private'), function() {
+                                                                                                                checkPieceOfContent(contexts['simon'].restContext, contexts['simon'].user.id, contentObj, true, false, false, true, true, (privacy !== 'private'), function() {
+                                                                                                                    checkPieceOfContent(contexts['branden'].restContext, contexts['branden'].user.id, contentObj, (privacy !== 'private'), false, false, false, false, (privacy !== 'private'), callback);
                                                                                                                 });
                                                                                                             });
                                                                                                         });

--- a/node_modules/oae-discussions/lib/api.authz.js
+++ b/node_modules/oae-discussions/lib/api.authz.js
@@ -270,25 +270,49 @@ var canDeleteDiscussionMessage = module.exports.canDeleteDiscussionMessage = fun
  * @param  {Boolean}    callback.canManage  `true` if the user in context can manage the discussion. `false` otherwise.
  * @param  {Boolean}    callback.canShare   `true` if the user in context can share the discussion. `false` otherwise.
  * @param  {Boolean}    callback.canPost    `true` if the user in context can post a message in the discussion. `false` otherwise.
+ * @param  {Boolean}    callback.isManager  `true` if the user in context is an explicit manager of the discussion. `false` otherwise.
+ * @param  {Boolean}    callback.isMember   `true` if the user in context is an explicit viewer of the discussion. `false` otherwise.
  */
 var resolveEffectiveDiscussionAccess = module.exports.resolveEffectiveDiscussionAccess = function(ctx, discussion, callback) {
-    AuthzAPI.resolveEffectiveRole(ctx, discussion.id, discussion.tenant.alias, discussion.visibility, DiscussionsConstants.roles.ALL_PRIORITY, function(err, effectiveRole, canInteract) {
+    if (!ctx.user()) {
+        return callback(null, (discussion.visibility === AuthzConstants.visibility.PUBLIC), false, false, false, false, false);
+    }
+
+    // Resolve the implicit role this user has on the discussion
+    AuthzAPI.resolveImplicitRole(ctx, discussion.id, discussion.tenant.alias, discussion.visibility, DiscussionsConstants.roles.ALL_PRIORITY, function(err, implicitRole, implicitInteract) {
         if (err) {
             return callback(err);
         }
 
-        var canView = _.isString(effectiveRole);
-        var canManage = (effectiveRole === DiscussionsConstants.roles.MANAGER);
+        // Get the explicit roles the user holds on the discussion
+        AuthzAPI.getAllRoles(ctx.user().id, discussion.id, function(err, roles) {
+            if (err) {
+                return callback(err);
+            }
 
-        // Anyone who can "interact" with the discussion can post to it
-        var canPost = canInteract;
+            var hasRole = (roles.length > 0);
+            var isMember = _.contains(roles, DiscussionsConstants.roles.MEMBER);
+            var isManager = _.contains(roles, DiscussionsConstants.roles.MANAGER);
 
-        // Anyone who can interact can share, unless the discussion is private. In that case, only managers can share
-        var canShare = canInteract;
-        if (discussion.visibility !== AuthzConstants.visibility.PUBLIC && discussion.visibility !== AuthzConstants.visibility.LOGGEDIN) {
-            canShare = canManage;
-        }
+            // Explicit managers or tenant/global admins can manage the discussion
+            var canManage = isManager || ctx.user().isAdmin(discussion.tenant.alias);
 
-        return callback(null, canView, canManage, canShare, canPost);
+            // You can view the discussion if the visibility settings allow it or when you have an explicit role on it or when you can manage it
+            var canView = implicitInteract || _.isString(implicitRole) || isMember || canManage;
+
+            // You can interact with the discussion either via the implicit visibility settings or when you have a role on it
+            var canInteract = implicitInteract || hasRole;
+
+            // Anybody who can "interact" with the discussion can post to it
+            var canPost = canInteract;
+
+            // Anyone who can "interact" can share, unless the discussion is private. In that case, only managers can share
+            var canShare = canInteract;
+            if (discussion.visibility === AuthzConstants.visibility.PRIVATE) {
+                canShare = canManage;
+            }
+
+            return callback(null, canView, canManage, canShare, canPost, isManager, isMember);
+        });
     });
 };

--- a/node_modules/oae-discussions/lib/api.discussions.js
+++ b/node_modules/oae-discussions/lib/api.discussions.js
@@ -165,7 +165,7 @@ var updateDiscussion = module.exports.updateDiscussion = function(ctx, discussio
             return callback(err);
         }
 
-        DiscussionsAPI.Authz.canManageDiscussion(ctx, discussion, function(err, canManage) {
+        DiscussionsAPI.Authz.resolveEffectiveDiscussionAccess(ctx, discussion, function(err, canView, canManage, canShare, canPost, isManager, isMember) {
             if (err) {
                 return callback(err);
             } else if (!canManage) {
@@ -190,9 +190,11 @@ var updateDiscussion = module.exports.updateDiscussion = function(ctx, discussio
                     _updateLibrary(memberIds, updatedDiscussion, oldLastModified);
 
                     // Fill in the full profile, the user has to have been a manager, so these are all true
-                    updatedDiscussion.isManager = true;
-                    updatedDiscussion.canPost = true;
-                    updatedDiscussion.canShare = true;
+                    updatedDiscussion.canManage = canManage;
+                    updatedDiscussion.canPost = canShare;
+                    updatedDiscussion.canShare = canPost;
+                    updatedDiscussion.isManager = isManager;
+                    updatedDiscussion.isMember = isMember;
 
                     DiscussionsAPI.emit(DiscussionsConstants.events.UPDATED_DISCUSSION, ctx, discussion, updatedDiscussion);
                     return callback(null, updatedDiscussion);
@@ -369,6 +371,7 @@ var getDiscussion = module.exports.getDiscussion = function(ctx, discussionId, c
  * @param  {Discussion} callback.discussion             The discussion object requested
  * @param  {User}       callback.discussion.createdBy   The basic profile of the user who created the discussion
  * @param  {Boolean}    callback.discussion.isManager   Specifies if the current user in context is a manager of the discussion
+ * @param  {Boolean}    callback.discussion.isMember    Specifies if the current user in context is a viewer of the discussion
  * @param  {Boolean}    callback.discussion.canShare    Specifies if the current user in context is allowed to share the discussion
  * @param  {Boolean}    callback.discussion.canPost     Specifies if the current user in context is allowed to post messages to the discussion
  */
@@ -386,7 +389,7 @@ var getFullDiscussionProfile = module.exports.getFullDiscussionProfile = functio
         }
 
         // Resolve the full discussion access information for the current user
-        DiscussionsAPI.Authz.resolveEffectiveDiscussionAccess(ctx, discussion, function(err, canView, canManage, canShare, canPost) {
+        DiscussionsAPI.Authz.resolveEffectiveDiscussionAccess(ctx, discussion, function(err, canView, canManage, canShare, canPost, isManager, isMember) {
             if (err) {
                 return callback(err);
             } else if (!canView) {
@@ -395,7 +398,9 @@ var getFullDiscussionProfile = module.exports.getFullDiscussionProfile = functio
                 return callback({'code': 401, 'msg': 'You are not authorized to view this discussion'});
             }
 
-            discussion.isManager = canManage;
+            discussion.isManager = isManager;
+            discussion.isMember = isMember;
+            discussion.canManage = canManage;
             discussion.canShare = canShare;
             discussion.canPost = canPost;
 

--- a/node_modules/oae-discussions/lib/test/util.js
+++ b/node_modules/oae-discussions/lib/test/util.js
@@ -74,11 +74,13 @@ var setupMultiTenantPrivacyEntities = module.exports.setupMultiTenantPrivacyEnti
  * @api private
  */
 var _setupTenant = function(tenant, callback) {
-    _createMultiPrivacyDiscussions(tenant.adminRestContext, function(publicDiscussion, loggedinDiscussion, privateDiscussion) {
-        tenant.publicDiscussion = publicDiscussion;
-        tenant.loggedinDiscussion = loggedinDiscussion;
-        tenant.privateDiscussion = privateDiscussion;
-        callback();
+    TestsUtil.generateTestUsers(tenant.adminRestContext, 1, function(err, users, simon) {
+        _createMultiPrivacyDiscussions(simon.restContext, function(publicDiscussion, loggedinDiscussion, privateDiscussion) {
+            tenant.publicDiscussion = publicDiscussion;
+            tenant.loggedinDiscussion = loggedinDiscussion;
+            tenant.privateDiscussion = privateDiscussion;
+            callback();
+        });
     });
 };
 

--- a/node_modules/oae-discussions/tests/test-discussions.js
+++ b/node_modules/oae-discussions/tests/test-discussions.js
@@ -660,6 +660,8 @@ describe('Discussions', function() {
 
                                 // Access info
                                 assert.ok(!discussion.isManager);
+                                assert.ok(!discussion.isMember);
+                                assert.ok(!discussion.canManage);
                                 assert.ok(!discussion.canPost);
                                 assert.ok(!discussion.canShare);
 
@@ -691,6 +693,8 @@ describe('Discussions', function() {
 
                                         // Access info
                                         assert.ok(!discussion.isManager);
+                                        assert.ok(!discussion.isMember);
+                                        assert.ok(!discussion.canManage);
                                         assert.ok(discussion.canPost);
                                         assert.ok(discussion.canShare);
 
@@ -711,6 +715,8 @@ describe('Discussions', function() {
 
                                             // Access info
                                             assert.ok(!discussion.isManager);
+                                            assert.ok(!discussion.isMember);
+                                            assert.ok(!discussion.canManage);
                                             assert.ok(discussion.canPost);
                                             assert.ok(discussion.canShare);
 
@@ -740,6 +746,8 @@ describe('Discussions', function() {
 
                                                     // Access info
                                                     assert.ok(!discussion.isManager);
+                                                    assert.ok(discussion.isMember);
+                                                    assert.ok(!discussion.canManage);
                                                     assert.ok(discussion.canPost);
                                                     assert.ok(!discussion.canShare);
 
@@ -771,6 +779,8 @@ describe('Discussions', function() {
 
                                                             // Access info
                                                             assert.ok(discussion.isManager);
+                                                            assert.ok(!discussion.isMember);
+                                                            assert.ok(discussion.canManage);
                                                             assert.ok(discussion.canPost);
                                                             assert.ok(discussion.canShare);
 
@@ -805,6 +815,8 @@ describe('Discussions', function() {
 
                                                                         // Access info
                                                                         assert.ok(!discussion.isManager);
+                                                                        assert.ok(!discussion.isMember);
+                                                                        assert.ok(!discussion.canManage);
                                                                         assert.ok(discussion.canPost);
                                                                         assert.ok(discussion.canShare);
 
@@ -839,10 +851,39 @@ describe('Discussions', function() {
 
                                                                                     // Access info
                                                                                     assert.ok(!discussion.isManager);
+                                                                                    assert.ok(!discussion.isMember);
+                                                                                    assert.ok(!discussion.canManage);
                                                                                     assert.ok(!discussion.canPost);
                                                                                     assert.ok(!discussion.canShare);
 
-                                                                                    return callback();
+                                                                                    /////////////////////////////////
+                                                                                    // ADMIN USER FROM SAME TENANT //
+                                                                                    /////////////////////////////////
+
+                                                                                    // Verify they can manage the discussion but do not have the manager role
+                                                                                    RestAPI.Discussions.getDiscussion(publicTenant.adminRestContext, publicTenant.publicDiscussion.id, function(err, discussion) {
+                                                                                        assert.ok(!err);
+
+                                                                                        // Basic info
+                                                                                        assert.equal(discussion.id, discussion.id);
+                                                                                        assert.equal(discussion.displayName, discussion.displayName);
+                                                                                        assert.equal(discussion.description, discussion.description);
+                                                                                        assert.equal(discussion.visibility, discussion.visibility);
+                                                                                        assert.equal(discussion.created, discussion.lastModified);
+                                                                                        assert.equal(discussion.created, discussion.created);
+                                                                                        assert.ok(discussion.tenant);
+                                                                                        assert.equal(discussion.tenant.alias, publicTenant.tenant.alias);
+                                                                                        assert.equal(discussion.tenant.displayName, publicTenant.tenant.displayName);
+
+                                                                                        // Access info
+                                                                                        assert.ok(!discussion.isManager);
+                                                                                        assert.ok(!discussion.isMember);
+                                                                                        assert.ok(discussion.canManage);
+                                                                                        assert.ok(discussion.canPost);
+                                                                                        assert.ok(discussion.canShare);
+
+                                                                                        return callback();
+                                                                                    });
                                                                                 });
                                                                             });
                                                                         });


### PR DESCRIPTION
Added the following properties to content and discussion profiles:
- isManager   - for when the user has explicit access to the object
- isViewer (= isMember for discussions)
- canManage
- canShare

Discussions also have:
- canView
- canPost

Includes the follow-up for https://github.com/oaeproject/Hilary/pull/856
