### PR TITLE
Break long names better in email

### DIFF
--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -498,27 +498,27 @@
                                                     %>
                                                 </tbody>
                                             </table>
-                                            <% _.each(activity.allComments, function(comment) {
+                                            <% _.each(activity.allComments, function(item) {
                                                 %>
-                                                <div class="activity-comment-container comment-level-<%= comment['oae:level'] %>">
+                                                <div class="activity-comment-container comment-level-<%= item.level %>">
                                                     <div class="activity-comment-thumbnail-container">
-                                                        <% renderUserThumbnail(comment.author); %>
+                                                        <% renderUserThumbnail(item.comment.author); %>
                                                     </div>
                                                     <div class="activity-comment">
                                                         <%
-                                                            var authorLink = shared.ensureAbsoluteLink(comment.author['oae:profilePath'], baseUrl);
+                                                            var authorLink = shared.ensureAbsoluteLink(item.comment.author['oae:profilePath'], baseUrl);
                                                             if (authorLink) {
-                                                                print('<a href="' + authorLink + '" title="' +  util.html.encodeForHTMLAttribute(comment.author.displayName) + '" class="wrapped">');
+                                                                print('<a href="' + authorLink + '" title="' +  util.html.encodeForHTMLAttribute(item.comment.author.displayName) + '" class="wrapped">');
                                                             }
                                                         %>
-                                                            <%= util.html.encodeForHTML(comment.author.displayName) %>
+                                                            <%= util.html.encodeForHTML(item.comment.author.displayName) %>
                                                         <%
                                                             if (authorLink) {
                                                                 print('</a>');
                                                             }
                                                         %>
-                                                        <span class="activity-date muted"><%= util.i18n.formatDate(new Date(comment.published), 'f') %></span>
-                                                        <div class="activity-comment-message wrapped"><%= util.text.toHtml(comment.content) %></div>
+                                                        <span class="activity-date muted"><%= util.i18n.formatDate(new Date(item.comment.published), 'f') %></span>
+                                                        <div class="activity-comment-message wrapped"><%= util.text.toHtml(item.comment.content) %></div>
                                                     </div>
                                                 </div>
                                             <% }); %>


### PR DESCRIPTION
The name is displayed properly at the top but next to the comments they flow outside of the box before breaking.

![screen shot 2014-06-13 at 16 32 00](https://cloud.githubusercontent.com/assets/218391/3271733/21e13296-f310-11e3-82fb-eaad9ef4399f.png)
