### PR TITLE
YouTube shortened links not processed

### DIFF
--- a/node_modules/oae-preview-processor/lib/processors/link/youtube.js
+++ b/node_modules/oae-preview-processor/lib/processors/link/youtube.js
@@ -23,7 +23,7 @@ var LinkProcessorUtil = require('oae-preview-processor/lib/processors/link/util'
 var PreviewUtil = require('oae-preview-processor/lib/util');
 
 var YOUTUBE_FULL_REGEX = /^http(s)?:\/\/(www\.)?youtube\.com\/watch/;
-var YOUTUBE_SHORT_REGEX = /^http(s)?:\/\/youtu.be/;
+var YOUTUBE_SHORT_REGEX = /^http(s)?:\/\/youtu.be\/(.+)/;
 
 /**
  * @borrows Interface.test as YoutubeProcessor.test

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -836,14 +836,15 @@ describe('Preview processor', function() {
          * Verifies the youtube processor and assures that metadata is retrieved/set.
          */
         it('verify youtube link processing works', function(callback) {
-            // Ignore this test if the PP is disabled.
+            // Ignore this test if the PP is disabled
             if (!defaultConfig.previews.enabled) {
                 return callback();
             }
 
+            // Assert a regular youtube link
             _createContentAndWait('link', 'http://www.youtube.com/watch?v=lgTQ5I_H4Xk', null, function(restCtx, content) {
                 assert.equal(content.previews.status, 'done');
-                // Verify the displayName and description are set.
+                // Verify the displayName and description are set
                 assert.equal(content.displayName, 'How to prounounce "Apereo"');
                 assert.equal(content.description, 'Here is Ian Dolphin, the Executive Director of the Apereo Foundation, with the official pronunciation of the word "Apereo".');
                 // Ensure we have a thumbnail url
@@ -854,15 +855,25 @@ describe('Preview processor', function() {
                     _verifySignedUriDownload(restCtx, content.previews.smallUrl, function() {
                         assert.ok(content.previews.mediumUrl);
                         _verifySignedUriDownload(restCtx, content.previews.mediumUrl, function() {
-                            
+
                             // Assert that short youtube links are processed as well
                             _createContentAndWait('link', 'http://youtu.be/lgTQ5I_H4Xk', null, function(restCtx, content) {
                                 assert.equal(content.previews.status, 'done');
-                                // Verify the displayName and description are set.
+                                // Verify the displayName and description are set
                                 assert.equal(content.displayName, 'How to prounounce "Apereo"');
                                 assert.equal(content.description, 'Here is Ian Dolphin, the Executive Director of the Apereo Foundation, with the official pronunciation of the word "Apereo".');
-
-                                return callback();
+                                // Ensure we have a thumbnail url
+                                assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
+                                _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
+                                    // Ensure we have small and medium images
+                                    assert.ok(content.previews.smallUrl);
+                                    _verifySignedUriDownload(restCtx, content.previews.smallUrl, function() {
+                                        assert.ok(content.previews.mediumUrl);
+                                        _verifySignedUriDownload(restCtx, content.previews.mediumUrl, function() {
+                                            return callback();
+                                        });
+                                    });
+                                });
                             });
                         });
                     });


### PR DESCRIPTION
If a user creates a link to YouTube content using the shortened URL, e.g. `http://youtu.be/JrtWhFtjXTA` the OAE preview does not embed the video.

![screen shot 2014-07-09 at 9 52 12 am](https://cloud.githubusercontent.com/assets/1731910/3525132/42db6d44-0770-11e4-8627-e450ac0c0f6a.png)

The same video, when created using the full URL (`https://www.youtube.com/watch?v=JrtWhFtjXTA`), previews fine.

![screen shot 2014-07-09 at 9 53 14 am](https://cloud.githubusercontent.com/assets/1731910/3525161/7b160c78-0770-11e4-8edf-958c0e458561.png)
