### PR TITLE
Changing tenant host does not refresh authentication provider configurations that are dependent on tenant host

### DIFF
--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -43,8 +43,13 @@ var strategies = {};
 // Setup functions for different strategies, keyed by the strategy name
 var strategySetup = {};
 
-// When a tenant starts up, configure it's authentication strategies
+// When a tenant starts up, configure its authentication strategies
 TenantsAPI.on('start', function(tenant) {
+    refreshStrategies(tenant);
+});
+
+// When a tenant is refreshed, refresh its authentication strategies
+TenantsAPI.on('refresh', function(tenant) {
     refreshStrategies(tenant);
 });
 

--- a/node_modules/oae-authentication/tests/test-external-strategies.js
+++ b/node_modules/oae-authentication/tests/test-external-strategies.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var assert = require('assert');
 var request = require('request');
 var url = require('url');
+var util = require('util');
 var xml2js = require('xml2js');
 
 var ConfigTestUtil = require('oae-config/lib/test/util');
@@ -201,6 +202,34 @@ describe('Authentication', function() {
     describe('External authentication', function() {
 
         /**
+         * Revert the localhost tenant's hostname to its old value
+         */
+        afterEach(function(callback) {
+            callback = _.once(callback);
+
+            var tenantUpdate = {'host': global.oaeTests.tenants.localhost.host};
+            RestAPI.Tenants.updateTenant(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, tenantUpdate, function(err) {
+                if (err) {
+                    if (err.msg === 'The hostname has already been taken') {
+                        // This means the test did not change the localhost tenant's hostname
+                        // so we can ignore this error and immediately move on to the next test
+                        return callback();
+                    } else {
+                        var msg = 'Did not expect an error message when reverting the localhost hostname.';
+                        msg += 'This might cause failures further down the line.';
+                        assert.fail(err.msg, '', msg);
+                        return;
+                    }
+                }
+            });
+
+            // When we did update the test we need to wait untill the authentication strategies have been refreshed
+            AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+                return callback();
+            });
+        });
+
+        /**
          * Verifies that /api/auth/google sends the client to google
          */
         it('verify forward to google', function(callback) {
@@ -280,6 +309,61 @@ describe('Authentication', function() {
          */
         it('verify the Facebook callback endpoint can deal with URL tampering ', function(callback) {
             verifyCallbackTampering('facebook', 'GET', {'code': 'not-valid'}, callback);
+        });
+
+
+        /**
+         * Test that verifies that the authentication strategies are refreshed when a tenant is updated
+         */
+        it('verify the authentication strategies are refreshed when a tenant is updated', function(callback) {
+            _enableStrategy('google', function(done) {
+
+                // Sanity check that Google is requesting authentication for localhost:2001
+                var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.localhost.host);
+                restContext.followRedirect = false;
+                RestAPI.Authentication.googleRedirect(restContext, function(err, body, response) {
+                    assert.ok(!err);
+
+                    // Assert a redirect
+                    assert.equal(response.statusCode, 302);
+
+                    // Assert we're redirecting with the localhost:2001 hostname
+                    var redirectUri = util.format('http://%s/api/auth/google/callback', global.oaeTests.tenants.localhost.host);
+                    var parsedUrl = url.parse(response.headers.location, true);
+                    assert.strictEqual(parsedUrl.query.redirect_uri, redirectUri);
+
+                    // Update the localhost tenant (and ensure that it's truly different, otherwise this test is useless)
+                    var tenantUpdate = {'host': '127.0.0.1:2001'};
+                    assert.notEqual(tenantUpdate.host, global.oaeTests.tenants.localhost.host);
+                    RestAPI.Tenants.updateTenant(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, tenantUpdate, function(err) {
+                        assert.ok(!err);
+                    });
+
+                    // Wait until the authentication api has finished refreshing its strategies
+                    AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+
+                        // Assert we refreshed the strategies for the localhost tenant
+                        assert.equal(tenant.alias, global.oaeTests.tenants.localhost.alias);
+                        assert.equal(tenant.host, tenantUpdate.host);
+
+                        // Verify the authentication strategies are using the new tenant hostname
+                        restContext = TestsUtil.createTenantRestContext(tenantUpdate.host);
+                        restContext.followRedirect = false;
+                        RestAPI.Authentication.googleRedirect(restContext, function(err, body, response) {
+                            assert.ok(!err);
+
+                            // Assert a redirect
+                            assert.equal(response.statusCode, 302);
+
+                            // Assert we're redirecting with the new hostname
+                            redirectUri = util.format('http://%s/api/auth/google/callback', tenantUpdate.host);
+                            parsedUrl = url.parse(response.headers.location, true);
+                            assert.strictEqual(parsedUrl.query.redirect_uri, redirectUri);
+                            return done();
+                        });
+                    });
+                });
+            }, callback);
         });
     });
 


### PR DESCRIPTION
The result is that callbacks for google apps, twitter and probably more redirecting to the wrong host.

Either the host should always be pulled on the fly (potentially not possible since that get configured into connect), or we need to cascade tenant updates to also refresh their configurations. 
