### PR TITLE
Explicitly defining various body parser middleware

### DIFF
--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -48,7 +48,8 @@ var createTestServer = module.exports.createTestServer = function(callback, _att
     var port = 2500 + Math.floor(Math.random() * 1000);
     var app = express();
 
-    app.use(bodyParser());
+    app.use(bodyParser.urlencoded({'extended': true}));
+    app.use(bodyParser.json());
     app.use(multipart());
 
     // Try and listen on the specified port

--- a/node_modules/oae-util/lib/server.js
+++ b/node_modules/oae-util/lib/server.js
@@ -76,9 +76,8 @@ var setupServer = module.exports.setupServer = function(port, _config) {
      * applies to the *incoming request data*. If the client needs to send more than 250kb, it should consider
      * using a proper multipart form request.
      */
-    app.use(bodyParser({
-        'limit': '250kb'
-    }));
+    app.use(bodyParser.urlencoded({ 'limit': '250kb', 'extended': true}));
+    app.use(bodyParser.json({'limit': '250kb'}));
     app.use(multipart(config.files));
 
     // This needs to come BEFORE passport and AFTER cookieParser. The secret will be used to sign the cookie


### PR DESCRIPTION
Rather than using the shorthand `bodyParser()` middleware we’re now
adding the urlencoded and json middleware explicitly as the catch-all
function has been deprecated.
