### PR TITLE
Build failure when using `void` in REST docs

### DIFF
--- a/node_modules/oae-util/tests/test-swagger.js
+++ b/node_modules/oae-util/tests/test-swagger.js
@@ -121,7 +121,7 @@ describe('Swagger', function() {
                                 assert.ok(_.isString(operation.summary), 'Operation summary must be a String');
                                 assert.ok(_.isString(operation.responseClass), 'Operation responseClass must be a String');
                                 var responseClass = operation.responseClass.replace(/^List\[/, '').replace(/\]/, '');
-                                if (!_.contains(Swagger.Constants.primitives, responseClass)) {
+                                if (!_.contains(Swagger.Constants.primitives, responseClass) && responseClass !== 'void') {
                                     assert.ok(data.models[responseClass], util.format('ResponseClass type "%s" is undefined in models', responseClass));
                                 }
 


### PR DESCRIPTION
```
1) Swagger API Declarations verify get api declarations:
     Uncaught AssertionError: ResponseClass type "void" is undefined in models
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-util/tests/test-swagger.js:125:44
      at Array.forEach (native)
      at Function._.each._.forEach (/home/travis/build/oaeproject/Hilary/node_modules/underscore/underscore.js:79:11)
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-util/tests/test-swagger.js:114:31
      at Array.forEach (native)
      at Function._.each._.forEach (/home/travis/build/oaeproject/Hilary/node_modules/underscore/underscore.js:79:11)
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-util/tests/test-swagger.js:110:27
      at Request._callback (/home/travis/build/oaeproject/Hilary/node_modules/oae-rest/lib/util.js:9:8823)
      at Request.self.callback (/home/travis/build/oaeproject/Hilary/node_modules/oae-rest/node_modules/request/request.js:121:22)
      at Request.EventEmitter.emit (events.js:98:17)
```
