### PR TITLE
Restoring revision does not update thumbnailUrl in search

### DIFF
--- a/node_modules/oae-content/lib/search.js
+++ b/node_modules/oae-content/lib/search.js
@@ -82,7 +82,7 @@ ContentAPI.on(ContentConstants.events.UPDATED_CONTENT_MEMBERS, function(ctx, con
 });
 
 /*!
- * When a conten item's preview finishes updating, we must reindex its resource document
+ * When a content item's preview finishes updating, we must reindex its resource document
  */
 ContentAPI.on(ContentConstants.events.UPDATED_CONTENT_PREVIEW, function(ctx, contentId, content) {
     SearchAPI.postIndexTask('content', [{'id': contentId}], {
@@ -95,6 +95,16 @@ ContentAPI.on(ContentConstants.events.UPDATED_CONTENT_PREVIEW, function(ctx, con
  */
 ContentAPI.on(ContentConstants.events.UPDATED_CONTENT_BODY, function(ctx, newContentObj, oldContentObj, revision) {
     SearchAPI.postIndexTask('content', [{'id': newContentObj.id}], {
+        'resource': true
+    });
+});
+
+/*!
+ * When an older revision for a content item gets restored, we must reindex its resource document
+ * as the thumbnail url will be different
+ */
+ContentAPI.on(ContentConstants.events.RESTORED_REVISION, function(ctx, newContentObj, oldContentObj, restoredRevision) {
+   SearchAPI.postIndexTask('content', [{'id': newContentObj.id}], {
         'resource': true
     });
 });

--- a/node_modules/oae-content/tests/test-previews.js
+++ b/node_modules/oae-content/tests/test-previews.js
@@ -598,4 +598,47 @@ describe('File previews', function() {
             });
         });
     });
+
+    /**
+     * Test that verifies that when a revision is restored, the content item is reindexed
+     */
+    it('verify restoring a revision results in an updated thumbnail url for the search document', function(callback) {
+        createPreviews(function(contexts, contentObj, previews) {
+
+            RestAPI.Content.updateFileBody(contexts['nicolaas'].restContext, contentObj.id, getOAELogoStream, function(err, contentObj) {
+                assert.ok(!err);
+
+                // Set the preview items for the second revision
+                RestAPI.Content.setPreviewItems(globalAdminOnTenantRestContext, contentObj.id, contentObj.latestRevisionId, 'done', suitable_files, suitable_sizes, {}, {}, function(err) {
+                    assert.ok(!err);
+
+                    // Do a search and assert that we have a thumbnail
+                    SearchTestsUtil.searchAll(contexts['nicolaas'].restContext, 'general', null, {'resourceTypes': 'content', 'q': contentObj.description}, function(err, results) {
+                        assert.ok(!err);
+                        var contentDocA = _.find(results.results, function(result) { return (result.id === contentObj.id); });
+                        assert.ok(contentDocA);
+                        assert.ok(contentDocA.thumbnailUrl);
+
+                        // Get the revisions so we can restore the first one
+                        RestAPI.Content.getRevisions(contexts['nicolaas'].restContext, contentObj.id, null, null, function(err, revisions) {
+                            assert.ok(!err);
+                            RestAPI.Content.restoreRevision(contexts['nicolaas'].restContext, contentObj.id, revisions.results[1].revisionId, function(err, revisionObj) {
+                                assert.ok(!err);
+
+                                // Do a search and assert that a different thumbnail URL is returend
+                                SearchTestsUtil.searchAll(contexts['nicolaas'].restContext, 'general', null, {'resourceTypes': 'content', 'q': contentObj.description}, function(err, results) {
+                                    assert.ok(!err);
+                                    var contentDocB = _.find(results.results, function(result) { return (result.id === contentObj.id); });
+                                    assert.ok(contentDocB);
+                                    assert.ok(contentDocB.thumbnailUrl);
+                                    assert.notEqual(contentDocA.thumbnailUrl, contentDocB.thumbnailUrl);
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
If you upload a new revision of something it will re-index the thumbnailUrl. However, when restoring a previous revision, the search index remains with the original thumbnail
