### PR TITLE
Statistics module and storage counting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules/*
 !node_modules/oae-preview-processor
 !node_modules/oae-principals
 !node_modules/oae-search
+!node_modules/oae-stats
 !node_modules/oae-telemetry
 !node_modules/oae-tenants
 !node_modules/oae-tests

--- a/config.js
+++ b/config.js
@@ -419,3 +419,21 @@ config.etherpad = {
 config.tincanapi = {
     'timeout': 4000
 };
+
+/**
+* `config.stats`
+*
+* Configuration namespace for the stats logic
+*
+* @param  {Object}      storage             Defines the storage stats related configuration
+* @param  {Boolean}     storage.enabled     Whether or not the storage stats should be enabled. Keep in mind this only works on POSIX systems
+* @param  {Number}      storage.interval    How often (in seconds) the storage stats should be updated. Default: every 4 hours
+* @param  {Number}      storage.expiry      The maximum amount of time (in seconds) a a single collection of storage statistics can last. Any longer runs are considered errors and should be investigated. Default: an hour
+*/
+config.stats = {
+    'storage': {
+        'enabled': false,
+        'interval': 4 * 60 * 60,
+        'expiry': 60 * 60
+    }
+};

--- a/node_modules/oae-content/lib/backends/amazons3.js
+++ b/node_modules/oae-content/lib/backends/amazons3.js
@@ -182,18 +182,30 @@ var getDownloadStrategy = module.exports.getDownloadStrategy = function(ctx, uri
 };
 
 /**
- * Returns the bucket we'll be using for storing files in.
- * @param  {Context}    ctx     The current execution context.
+ * @borrows Interface.getStorageCount as Amazons3.getStorageCount
+ */
+var getStorageCount = module.exports.getStorageCount = function(tenantAlias, callback) {
+    log().warn('Not implemented yet');
+    return callback(null, 0);
+};
+
+/**
+ * Return the bucket we'll be using for storing files in
+ *
+ * @param  {Context}    ctx     The current execution context
  * @return {String}             The bucket name
+ * @api private
  */
 var _getBucketName = function(ctx) {
     return Config.getValue(ctx.tenant().alias, 'storage', 'amazons3-bucket');
 };
 
 /**
- * Gets a client that can connect to S3 and is configured via the admin interface.
- * @param  {Context}    ctx     The current execution context.
- * @return {S3}                 An S3 client.
+ * Get a client that can connect to S3 and is configured via the admin interface
+ *
+ * @param  {Context}    ctx     The current execution context
+ * @return {S3}                 An S3 client
+ * @api private
  */
 var _getClient = function(ctx) {
 

--- a/node_modules/oae-content/lib/backends/interface.js
+++ b/node_modules/oae-content/lib/backends/interface.js
@@ -65,3 +65,13 @@ var remove = module.exports.remove = function(ctx, uri, callback) {};
  * @return {DownloadStrategy}           The download strategy that specifies how to download this resource
  */
 var getDownloadStrategy = module.exports.getDownloadStrategy = function(ctx, uri) {};
+
+/**
+ * Get the total storage count for a tenant in bytes
+ *
+ * @param  {String}     tenantAlias         The alias of the tenant for which to retrieve the total storage count
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Number}     callback.count      The total storage count for this tenant in bytes
+ */
+var getStorageCount = module.exports.getStorageCount = function(tenantAlias, callback) {};

--- a/node_modules/oae-content/lib/backends/local.js
+++ b/node_modules/oae-content/lib/backends/local.js
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+var exec = require('child_process').exec;
 var fs = require('fs');
 var mkdirp = require('mkdirp');
 var Path = require('path');
@@ -152,6 +153,35 @@ var getDownloadStrategy = module.exports.getDownloadStrategy = function(ctx, uri
     return new DownloadStrategy(ContentConstants.backend.DOWNLOAD_STRATEGY_INTERNAL, '/files/' + BackendUtil.splitUri(uri).location);
 };
 
+/**
+ * @borrows Interface.getDownloadStrategy as Local.getDownloadStrategy
+ */
+var getStorageCount = module.exports.getStorageCount = function(tenantAlias, callback) {
+    var contentDirectory = util.format('%s/c/%s', getRootDirectory(), tenantAlias);
+    _getStorageCount(contentDirectory, function(err, contentStorage) {
+        if (err) {
+            return callback(err);
+        }
+
+        var usersDirectory = util.format('%s/u/%s', getRootDirectory(), tenantAlias);
+        _getStorageCount(usersDirectory, function(err, usersStorage) {
+            if (err) {
+                return callback(err);
+            }
+            var groupsDirectory = util.format('%s/g/%s', getRootDirectory(), tenantAlias);
+            _getStorageCount(groupsDirectory, function(err, groupsStorage) {
+                if (err) {
+                    return callback(err);
+                }
+
+                var totalStorage = contentStorage + usersStorage + groupsStorage;
+                return callback(null, totalStorage);
+            });
+        });
+    });
+};
+
+
 /////////////////////
 // Private methods //
 /////////////////////
@@ -170,5 +200,53 @@ var _ensureDirectoryExists = function(dir, callback) {
             return callback({'code': 500, 'msg': err});
         }
         callback();
+    });
+};
+
+/**
+ * Get the size of a directory by looking at the filesystem
+ *
+ * @param  {String}     directory           The path of the directory to check
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Number}     callback.count      The size of the directory in bytes
+ * @api private
+ */
+var _getStorageCount = function(directory, callback) {
+    fs.exists(directory, function(exists) {
+        // If a directory doesn't exist, it doesn't take up any space
+        if (!exists) {
+            return callback(null, 0);
+
+        // Although running on Windows is not recommended, we complain if somebody tries
+        // to get the size of a directory on Windows
+        } else if (process.platform === 'win32') {
+            log().warn({'directory': directory}, 'Getting the storage count for a directory on Windows is not support');
+            return callback(null, 0);
+        }
+
+        // If it exists we try to find how large the tree is by calling `du`
+        var cmd = util.format('du -s %s', directory);
+        var options = {
+            'env': {
+                // We set the blocksize to 1024 so at least OS x and Ubuntu
+                // return the same value. We multiply this value later on
+                'BLOCKSIZE': 1024
+            }
+        };
+        log().trace({'cmd': cmd, 'options': options}, 'Getting storage count for a directory');
+        exec(cmd, options, function (err, stdout, stderr) {
+            if (err) {
+                log().error({'err': err, 'directory': directory, 'stdout': stdout, 'stderr': stderr});
+                return callback({'code': 500, 'msg': 'Unable to retrieve the storage count'});
+            }
+
+            var count = stdout.split('\t')[0];
+            count = parseInt(count, 10);
+
+            // Get the count in bytes
+            count *= 1024;
+            return callback(null, count);
+        });
     });
 };

--- a/node_modules/oae-content/lib/backends/remote.js
+++ b/node_modules/oae-content/lib/backends/remote.js
@@ -56,3 +56,10 @@ var getDownloadStrategy = module.exports.getDownloadStrategy = function(ctx, uri
     // scheme portion of the URI
     return new DownloadStrategy(ContentConstants.backend.DOWNLOAD_STRATEGY_DIRECT, BackendUtil.splitUri(uri).location);
 };
+
+/**
+ * @borrows Interface.getStorageCount as Remote.getStorageCount
+ */
+var getStorageCount = module.exports.getStorageCount = function(tenantAlias, callback) {
+    return callback(null, 0);
+};

--- a/node_modules/oae-content/lib/backends/test.js
+++ b/node_modules/oae-content/lib/backends/test.js
@@ -63,3 +63,10 @@ var getDownloadStrategy = module.exports.getDownloadStrategy = function(ctx, uri
     var file = LocalStorage.getRootDirectory() + '/' + BackendUtil.splitUri(uri).location;
     return new DownloadStrategy('test', file);
 };
+
+/**
+ * @borrows Interface.getStorageCount as Amazons3.getStorageCount
+ */
+var getStorageCount = module.exports.getStorageCount = function(tenantAlias, callback) {
+    LocalStorage.getStorageCount(tenantAlias, callback);
+};

--- a/node_modules/oae-content/lib/constants.js
+++ b/node_modules/oae-content/lib/constants.js
@@ -78,3 +78,7 @@ ContentConstants.backend = {
 ContentConstants.search = {
     'MAPPING_CONTENT_COMMENT': 'content_comment'
 };
+
+ContentConstants.stats = {
+    'STORAGE': 'storage'
+};

--- a/node_modules/oae-content/lib/init.js
+++ b/node_modules/oae-content/lib/init.js
@@ -20,6 +20,7 @@ var Cleaner = require('oae-util/lib/cleaner');
 var log = require('oae-logger').logger('oae-content');
 
 var ContentSearch = require('./search');
+var ContentStats = require('./stats');
 var Etherpad = require('./internal/etherpad');
 var LocalStorage = require('./backends/local');
 
@@ -34,8 +35,11 @@ module.exports = function(config, callback) {
     // Ensure that the preview listeners get registered
     require('./previews');
 
-    // Initialize the etherpad client.
+    // Initialize the etherpad client
     Etherpad.refreshConfiguration(config.etherpad);
+
+    // Initialize the stats collector
+    ContentStats.refreshConfiguration(config.stats.storage);
 
     ContentSearch.init(function(err) {
         if (err) {

--- a/node_modules/oae-content/lib/internal/util.js
+++ b/node_modules/oae-content/lib/internal/util.js
@@ -45,18 +45,40 @@ var TIME_1_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
  * @throws {Error}              Thrown if there is no backend available that matches the `uri`
  */
 var getStorageBackend = module.exports.getStorageBackend = function(ctx, uri) {
-    var backendName = null;
     if (uri) {
-        backendName = uri.split(':')[0];
+        var backendName = uri.split(':')[0];
+        return _getStorageBackendByName(backendName);
     } else {
-        // Use the tenant's default
-        backendName = ContentConfig.getValue(ctx.tenant().alias, 'storage', 'backend');
-        if (!backendName) {
-            log(ctx).error('There was no storage backend configured, this should not happen');
-            throw new Error('There was no storage backend configured for name: ' + backendName);
-        }
+        return getStorageBackendForTenant(ctx.tenant().alias);
     }
+};
 
+/**
+ * Get the storage backend that is currently configured for a tenant
+ *
+ * @param  {String}     tenantAlias     The alias of the tenant for which to retrieve the storage backend
+ * @return {Backend}                    The appropriate backend
+ * @throws {Error}                      Thrown if there is no backend available that matches the given `backendName`
+ * @api private
+ */
+var getStorageBackendForTenant = module.exports.getStorageBackendForTenant = function(tenantAlias) {
+    var backendName = ContentConfig.getValue(tenantAlias, 'storage', 'backend');
+    if (!backendName) {
+        log().error({'tenantAlias': tenantAlias}, 'There was no storage backend configured, this should not happen');
+        throw new Error('There was no storage backend configured for name: ' + backendName);
+    }
+    return _getStorageBackendByName(backendName);
+};
+
+/**
+ * Get a storage backend by its name
+ *
+ * @param  {String}     backendName     The storage backend to retun
+ * @return {Backend}                    The appropriate backend
+ * @throws {Error}                      Thrown if there is no backend available that matches the given `backendName`
+ * @api private
+ */
+var _getStorageBackendByName = function(backendName) {
     try {
         return require('oae-content/lib/backends/' + backendName);
     } catch (err) {

--- a/node_modules/oae-content/lib/stats.js
+++ b/node_modules/oae-content/lib/stats.js
@@ -1,0 +1,170 @@
+/*!
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+
+var Locking = require('oae-util/lib/locking');
+var log = require('oae-logger').logger('oae-content');
+var StatsAPI = require('oae-stats');
+var TenantsAPI = require('oae-tenants');
+
+var ContentConstants = require('oae-content/lib/constants').ContentConstants;
+var ContentUtil = require('./internal/util');
+
+var collectionInterval = null;
+var config = null;
+
+// The constant that will be used to guarantee only 1 node in the cluster is collecting the statistics
+var STORAGE_STATS_LOCKKEY = 'oae-content/stats-storage-lockkey';
+
+/**
+ * Refresh the content storage statistics collector
+ *
+ * @param  {Object} _config The configuration object for the storage collection. See `config.stats.storage` in the main `config.js`
+ */
+var refreshConfiguration = module.exports.refreshConfiguration = function(_config) {
+    config = _config;
+
+    // Stop the old timer if there is one
+    if (collectionInterval) {
+        clearInterval(collectionInterval);
+    }
+
+    if (config.enabled) {
+        // Start a new timer that collects the storage stats everytime it ticks
+        collectionInterval = setInterval(collectStats, config.interval * 1000);
+    }
+    setTimeout(collectStats, 3000);
+};
+
+/**
+ * Tries to collect the storage statistics for all the enabled tenants in the system. This function will
+ * first try to get a lock guaranteeing only one node in the cluster can collect the storage statistics
+ * at any given time. The lock is released when the storage statistics for all tenants have been collected.
+ *
+ * @param  {Function}   [callback]      Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ */
+var collectStats = module.exports.collectStats = function(callback) {
+    callback = callback || function(err) {
+        if (err) {
+            log().error({'err': err}, 'An error occured when collecting the storage counts');
+        }
+    };
+
+    // Try to get a lock on 
+    Locking.acquire(STORAGE_STATS_LOCKKEY, config.expiry * 1000, function(err, lockToken) {
+        if (err) {
+            log().error({'err': err}, 'An error occurred when trying to get a lock for collecting storage statistics');
+            return callback(err);
+        } else if (!lockToken) {
+            // We could not acquire a lock, someone else came around and is collecting the stats
+            return callback(err);
+        }
+
+        _startCollecting(function(collectionError) {
+            if (collectionError) {
+                log().error({'err': collectionError}, 'An expected error ocurred when collecting the storage stats');
+                // Do not callback here, we should release the lock first
+            }
+
+            // Release the lock
+            Locking.release(STORAGE_STATS_LOCKKEY, lockToken, function(lockError, hadLock) {
+                if (lockError) {
+                    log().warn({'err': lockError, 'type': type}, 'An unexpected error occurred while releasing the lock for collecting storage stats');
+
+                    // If there was an error releasing the lock, worst case scenario would be that the lock eventually expires
+                    // and a cluster node picks it up soon after that and continues collecting stats
+                    return callback(collectionError);
+                }
+
+                log().trace('Successfully released lock for collecting stats');
+
+                if (!hadLock) {
+                    // This means that the lock expired before we finished collecting stats, which likely means the lock expiry
+                    // is not configured high enough. Send an error, because some of the collection logic might cause a performance
+                    // degradation when ran concurrently
+                    log().error({
+                        'collectionExpiry': bucketInfo.collectionExpiry
+                    }, 'The lock expired before we finished collecting the statistics. This probably means that it takes longer than ' +
+                        'the "collectionExpiry" number of seconds for the storage collector to run. Consider increasing "collectionExpiry"');
+                }
+
+                return callback(collectionError);
+            });
+        });
+    });
+};
+
+/**
+ * Collects the storage counts for all the enabled tenants in the system
+ *
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ * @api private
+ */
+var _startCollecting = function(callback) {
+    // Get all the tenants for which the stats should be collected
+    var tenants = TenantsAPI.getTenants(true);
+    tenants = _.keys(tenants);
+
+    // Collect them all
+    _collectTenants(tenants, function(counts) {
+        // Persist the collected values with the stats api
+        var stats = _.map(counts, function(count) {
+            return {
+                'name': ContentConstants.stats.STORAGE,
+                'tenantAlias': count.tenantAlias,
+                'value': count.count
+            };
+        });
+
+        StatsAPI.setStatistics(stats, callback);
+    });
+};
+
+/**
+ * Collect the storage counts for a set of tenants
+ *
+ * @param  {String[]}   tenants             The aliases of the tenants which need to be checked
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Object[]}   callback.counts     A set of objects, each one holding the storage size for a tenant
+ * @api private
+ */
+var _collectTenants = function(tenants, callback, _counts) {
+    _counts = _counts || [];
+
+    // We're done if there are no more tenants to collect
+    if (tenants.length === 0) {
+        return callback(_counts);
+    }
+
+    // Collect the next tenant
+    var tenantAlias = tenants.pop();
+    var backend = ContentUtil.getStorageBackendForTenant(tenantAlias);
+    backend.getStorageCount(tenantAlias, function(err, storageCount) {
+        if (err) {
+            log().error({'err': err, 'tenant': tenantAlias}, 'Failed to collect the storage stats for this tenant');
+        } else {
+            _counts.push({
+                'tenantAlias': tenantAlias,
+                'count': storageCount
+            });
+        }
+
+        _collectTenants(tenants, callback, _counts);
+    });
+};

--- a/node_modules/oae-stats/lib/api.js
+++ b/node_modules/oae-stats/lib/api.js
@@ -1,0 +1,103 @@
+/*!
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+
+var log = require('oae-logger').logger('oae-stats');
+var Validator = require('oae-util/lib/validator').Validator;
+
+var StatsDAO = require('./internal/dao');
+
+/**
+ * Get all the stats for a given tenant
+ *
+ * @param  {Context}    ctx                 The context of the current request
+ * @param  {String}     tenantAlias         The alias of the tenant for which the stats should be retrieved
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Object[]}   callback.stats      The statistics for this tenant. Each object holds a `name` and `value` key
+ */
+var getAllStatistics = module.exports.getAllStatistics = function(ctx, tenantAlias, callback) {
+    var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'Anonymous users cannot request stats'}).isLoggedInUser(ctx);
+    validator.check(tenantAlias, {'code': 400, 'msg': 'A tenant alias must be specified'}).notEmpty();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    if (!ctx.user().isAdmin(tenantAlias)) {
+        return callback({'code': 401, 'msg': 'Only administrators can requests stats'});
+    }
+
+    StatsDAO.getAllStatistics(tenantAlias, callback);
+};
+
+/**
+ * Get a specific statistic for a given tenant
+ *
+ * @param  {Context}    ctx                 The context of the current request
+ * @param  {String}     tenantAlias         The alias of the tenant for which to retrieve the statistic
+ * @param  {String}     name                The name of the statistic to retrieve
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Number}     callback.value      The desired statistic
+ */
+var getStatistic = module.exports.getStatistic = function(ctx, tenantAlias, name, callback) {
+    var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'Anonymous users cannot request stats'}).isLoggedInUser(ctx);
+    validator.check(tenantAlias, {'code': 400, 'msg': 'A tenant alias must be specified'}).notEmpty();
+    validator.check(name, {'code': 400, 'msg': 'A stat name must be specified'}).notEmpty();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    if (!ctx.user().isAdmin(tenantAlias)) {
+        return callback({'code': 401, 'msg': 'Only administrators can requests stats'});
+    }
+
+    StatsDAO.getStatistic(tenantAlias, name, callback);
+};
+
+/**
+ * Set one or more statistics
+ *
+ * @param  {Object[]}   stats           The stats to persist. Each object should have a `name`, a `tenantAlias` and a numeric `value`
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ */
+var setStatistics = module.exports.setStatistics = function(stats, callback) {
+    // Don't process empty stats objects
+    if (_.isEmpty(stats)) {
+        return callback();
+    }
+
+    var validator = new Validator();
+    _.each(stats, function(stat) {
+        validator.check(stat.tenantAlias, {'code': 400, 'msg': 'Missing tenantAlias'}).notEmpty();
+        validator.check(stat.name, {'code': 400, 'msg': 'Missing name'}).notEmpty();
+        validator.check(stat.value, {'code': 400, 'msg': 'Missing value'}).notEmpty();
+        validator.check(stat.value, {'code': 400, 'msg': 'Invalid value'}).isNumeric();
+    });
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    // Persist the stats in Cassandra
+    StatsDAO.setStatistics(stats, callback);
+
+    // POSSIBLETODO: Also ship the metrics to statsd so they can be graphed with graphite
+};
+
+// POSSIBLETODO: Add some logic so we can ship metrics directly to statsd

--- a/node_modules/oae-stats/lib/init.js
+++ b/node_modules/oae-stats/lib/init.js
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var Cassandra = require('oae-util/lib/cassandra');
+
+module.exports = function(config, callback) {
+    ensureSchema(callback);
+};
+
+/**
+ * Ensure that the all of the stats-related schemas are created. If they already exist, this method will not do anything
+ *
+ * @param  {Function}         callback       Standard callback function
+ * @param  {Object}           callback.err   Error object, containing the error message
+ * @api private
+ */
+var ensureSchema = function(callback) {
+    Cassandra.createColumnFamilies({
+        'StatsByTenant': 'CREATE TABLE "StatsByTenant" ("tenantAlias" text, "name" text, "value" double, PRIMARY KEY("tenantAlias", "name"))'
+    }, callback);
+};

--- a/node_modules/oae-stats/lib/internal/dao.js
+++ b/node_modules/oae-stats/lib/internal/dao.js
@@ -1,0 +1,85 @@
+/*!
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+
+var Cassandra = require('oae-util/lib/cassandra');
+
+
+/**
+ * Get all the statistics for a given tenant
+ *
+ * @param  {String}     tenantAlias         The alias of the tenant for which the stats should be retrieved
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Object[]}   callback.stats      The statistics for this tenant. Each object holds a `name` and `value` key
+ */
+var getAllStatistics = module.exports.getAllStatistics = function(tenantAlias, callback) {
+    Cassandra.runQuery('SELECT * FROM "StatsByTenant" WHERE "tenantAlias" = ?', [tenantAlias], function(err, rows) {
+        if (err) {
+            return callback(err);
+        }
+
+        var stats = [];
+        _.each(rows, function(row) {
+            var hash = Cassandra.rowToHash(row);
+            stats.push({
+                'name': hash['name'],
+                'value': hash['value']
+            });
+        });
+        return callback(null, stats);
+    });
+};
+
+/**
+ * Get a specific statistic for a given tenant
+ *
+ * @param  {String}     tenantAlias         The alias of the tenant for which to retrieve the statistic
+ * @param  {String}     name                The name of the statistic to retrieve
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Number}     callback.value      The value for the desired statistic
+ */
+var getStatistic = module.exports.getStatistic = function(tenantAlias, name, callback) {
+    Cassandra.runQuery('SELECT "value" FROM "StatsByTenant" WHERE "tenantAlias" = ? AND "name" = ?', [tenantAlias, name], function(err, rows) {
+        if (err) {
+            return callback(err);
+        } else if (rows.length === 0) {
+            return callback({'code': 404, 'msg': 'No statistic found by that name'});
+        }
+
+        var value = rows[0].get('value').value;
+        return callback(null, value);
+    });
+};
+
+/**
+ * Persists one or more statistic(s) to the database
+ *
+ * @param  {Object[]}   stats           The stats to persist. Each object should have a `name`, a `tenantAlias` and a numeric `value`
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ */
+var setStatistics = module.exports.setStatistics = function(stats, callback) {
+    var batch = [];
+    _.each(stats, function(stat) {
+        batch.push({
+            'query': 'UPDATE "StatsByTenant" SET "value" = ? WHERE "tenantAlias" = ? AND "name" = ?',
+            'parameters': [stat.value, stat.tenantAlias, stat.name]
+        });
+    });
+    Cassandra.runBatchQuery(batch, callback);
+};

--- a/node_modules/oae-stats/lib/rest.js
+++ b/node_modules/oae-stats/lib/rest.js
@@ -1,0 +1,78 @@
+/*!
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var OAE = require('oae-util/lib/oae');
+
+var StatsAPI = require('./api');
+
+/*!
+ * Convenience method to get all the statistics for a certain tenant. The tenant
+ * is determined by checking the request parameters first. If no tenant is found, it
+ * is defaulted to the tenant the request was made on.
+ *
+ * @param  {Request}    req     The ExpressJS request object
+ * @param  {Response}   res     The ExpressJS response object
+ * @api private
+ */
+var _handleGetAllStats = function(req, res) {
+    var tenantAlias = req.params.tenantAlias || req.ctx.tenant().alias;
+
+    StatsAPI.getAllStatistics(req.ctx, tenantAlias, function(err, stats) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        res.send(200, {'items': stats});
+    });
+};
+
+/*!
+ * Convenience method to get a specific statistic for a certain tenant. The tenant
+ * is determined by checking the request parameters first. If no tenant is found, it
+ * is defaulted to the tenant the request was made on.
+ *
+ * @param  {Request}    req     The ExpressJS request object
+ * @param  {Response}   res     The ExpressJS response object
+ * @api private
+ */
+var _handleGetStatistic = function(req, res) {
+    var tenantAlias = req.params.tenantAlias || req.ctx.tenant().alias;
+    var name = req.params.name;
+
+    StatsAPI.getStatistic(req.ctx, tenantAlias, name, function(err, value) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        res.send(200, {
+            'name': name,
+            'value': value
+        });
+    });
+};
+
+
+/*!
+ * Get configuration schemas for the global admin tenant and user tenants
+ */
+OAE.globalAdminRouter.on('get', '/api/stats/:tenantAlias', _handleGetAllStats);
+OAE.tenantRouter.on('get', '/api/stats', _handleGetAllStats);
+
+/*!
+ * Get configuration schemas for the global admin tenant and user tenants
+ */
+OAE.globalAdminRouter.on('get', '/api/stats/:tenantAlias/:name', _handleGetStatistic);
+OAE.tenantRouter.on('get', '/api/stats/:name', _handleGetStatistic);
+

--- a/node_modules/oae-stats/package.json
+++ b/node_modules/oae-stats/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "oae-stats",
+    "main": "./lib/api.js",
+    "version": "0.0.1"
+}

--- a/node_modules/oae-stats/tests/test-stats.js
+++ b/node_modules/oae-stats/tests/test-stats.js
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+var _ = require('underscore');
+var assert = require('assert');
+
+var Cassandra = require('oae-util/lib/cassandra');
+var RestAPI = require('oae-rest');
+var RestContext = require('oae-rest/lib/model').RestContext;
+var TestsUtil = require('oae-tests');
+
+var StatsAPI = require('oae-stats');
+
+describe('Stats', function() {
+
+    // Standard REST contexts to use to execute requests as different types of users
+    var anonymousCamRestContext = null;
+    var anonymousGlobalRestContext = null;
+    var camAdminRestContext = null;
+    var globalAdminRestContext = null;
+
+    /**
+     * Function that will fill up the anonymous and the tenant admin context
+     */
+    before(function(callback) {
+        // Create the standard REST contexts
+        anonymousCamRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+        anonymousGlobalRestContext = TestsUtil.createGlobalRestContext();
+        camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+        globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
+
+        // Get rid of any test stats data
+        Cassandra.runQuery('TRUNCATE "StatsByTenant"', [], function(err) {
+            assert.ok(!err);
+            return callback();
+        });
+    });
+
+    /**
+     * Can be used to sort an array of stats
+     *
+     * @param  {Object}     a   The first stat
+     * @param  {Objcet}     b   The second stat
+     * @return {Number}         Number that can be used to order a against b
+     */
+    var _statsSorter = function(a, b) {
+        if (a.name === b.name) {
+            return a.value - b.value;
+        } else {
+            return a.name.localeCompare(b.name);
+        }
+    };
+
+    /**
+     * Assert that a set of given stats are present in the `allStats` set
+     * for a given `tenantAlias`
+     *
+     * @param  {Object[]}   allStats        All the stats
+     * @param  {String}     tenantAlias     The tenant alias that should be used to filter `allStats`
+     * @param  {Object[]}   stats           That stats that should be in the filtered `allStats`
+     * @throws {Error}                      An assertion error is thrown if the stats are not what was expected
+     */
+    var _assertExpectedStats = function(allStats, tenantAlias, stats) {
+        var expectedStats = _.chain(allStats)
+                            .filter(function(stat) {
+                                return (stat.tenantAlias === tenantAlias);
+                            })
+                            .map(function(stat) {
+                                return {'name': stat.name, 'value': stat.value};
+                            }).value();
+
+        // Sort both statistics so we can assert they are the same using `assert.deepEqual`
+        expectedStats.sort(_statsSorter);
+        stats.sort(_statsSorter);
+        assert.deepEqual(stats, expectedStats);
+    };
+
+    /**
+     * Setup the fixture by generating some random stats and generating a new user
+     *
+     * @param  {Function}   callback            Standard callback function
+     * @param  {Object}     callback.err        An error object, if any
+     * @param  {Object[]}   callback.stats      The created stats
+     * @param  {Object}     callback.user       The created user as returned by `TestsUtil.generateTestUsers`
+     */
+    var _setupFixture = function(callback) {
+        // Generate some dummy stats
+        var stats = [
+            {'tenantAlias': global.oaeTests.tenants.cam.alias, 'name': TestsUtil.generateRandomText(1), 'value': _.random(1, 1000)},
+            {'tenantAlias': global.oaeTests.tenants.cam.alias, 'name': TestsUtil.generateRandomText(1), 'value': _.random(1, 1000)},
+            {'tenantAlias': global.oaeTests.tenants.gt.alias, 'name': TestsUtil.generateRandomText(1), 'value': _.random(1, 1000)},
+            {'tenantAlias': global.oaeTests.tenants.gt.alias, 'name': TestsUtil.generateRandomText(1), 'value': _.random(1, 1000)}
+        ];
+        StatsAPI.setStatistics(stats, function(err) {
+            assert.ok(!err);
+
+            // Generate the user
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simon) {
+                assert.ok(!err);
+
+                stats.sort(_statsSorter);
+
+                return callback(stats, simon);
+            });
+        });
+    };
+
+    describe('#getAllStatistics', function() {
+
+        /**
+         * Test that verifies that only administrators can retrieve statistics
+         */
+        it('verify only administrators can retrieve statistics', function(callback) {
+            _setupFixture(function(allStats, simon) {
+
+                // Verify anonymous users can't retrieve stats
+                RestAPI.Stats.getAllStatistics(anonymousCamRestContext, null, function(err, stats) {
+                    assert.equal(err.code, 401);
+                    assert.ok(!stats);
+
+                    RestAPI.Stats.getAllStatistics(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, function(err, stats) {
+                        assert.equal(err.code, 401);
+                        assert.ok(!stats);
+
+                        // Verify non-admin users cannot retrieve stats
+                        RestAPI.Stats.getAllStatistics(simon.restContext, null, function(err, stats) {
+                            assert.equal(err.code, 401);
+                            assert.ok(!stats);
+
+                            // Verify tenant administrators can only retrieve their own statistics
+                            RestAPI.Stats.getAllStatistics(camAdminRestContext, global.oaeTests.tenants.gt.alias, function(err, stats) {
+                                assert.ok(err);
+                                assert.ok(!stats);
+
+                                // Sanity-check the tenant admin can retrieve his own tenant's statistics
+                                RestAPI.Stats.getAllStatistics(camAdminRestContext, null, function(err, stats) {
+                                    assert.ok(!err);
+                                    _assertExpectedStats(allStats, global.oaeTests.tenants.cam.alias, stats.items);
+
+                                    // Sanity-check the global admin can retrieve all the stats
+                                    RestAPI.Stats.getAllStatistics(globalAdminRestContext, global.oaeTests.tenants.cam.alias, function(err, stats) {
+                                        assert.ok(!err);
+                                        _assertExpectedStats(allStats, global.oaeTests.tenants.cam.alias, stats.items);
+
+                                        RestAPI.Stats.getAllStatistics(globalAdminRestContext, global.oaeTests.tenants.gt.alias, function(err, stats) {
+                                            assert.ok(!err);
+                                            _assertExpectedStats(allStats, global.oaeTests.tenants.gt.alias, stats.items);
+
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('#getStatistic', function() {
+        /**
+         * Test that verifies that only administrators can retrieve a statistic
+         */
+        it('verify only administrators can retrieve a statistic', function(callback) {
+            _setupFixture(function(allStats, simon) {
+
+                var camStat = _.find(allStats, function(stat) { return (stat.tenantAlias === global.oaeTests.tenants.cam.alias); });
+                var gtStat = _.find(allStats, function(stat) { return (stat.tenantAlias === global.oaeTests.tenants.gt.alias); });
+
+                // Verify anonymous users can't retrieve a stat
+                RestAPI.Stats.getStatistic(anonymousCamRestContext, null, camStat.name, function(err, stat) {
+                    assert.equal(err.code, 401);
+                    assert.ok(!stat);
+
+                    RestAPI.Stats.getStatistic(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, camStat.name, function(err, stat) {
+                        assert.equal(err.code, 401);
+                        assert.ok(!stat);
+
+                        // Verify non-admin users cannot retrieve a stat
+                        RestAPI.Stats.getStatistic(simon.restContext, null, camStat.name, function(err, stat) {
+                            assert.equal(err.code, 401);
+                            assert.ok(!stat);
+
+                            // Verify tenant administrators can only retrieve their own statistics
+                            RestAPI.Stats.getStatistic(camAdminRestContext, global.oaeTests.tenants.gt.alias, camStat.name, function(err, stat) {
+                                assert.ok(err);
+                                assert.ok(!stat);
+
+                                // Sanity-check the tenant admin can retrieve his own tenant's statistics
+                                RestAPI.Stats.getStatistic(camAdminRestContext, null, camStat.name, function(err, stat) {
+                                    assert.ok(!err);
+                                    assert.deepEqual(stat.name, camStat.name);
+                                    assert.deepEqual(stat.value, camStat.value);
+
+                                    // Sanity-check the global admin can retrieve a stat
+                                    RestAPI.Stats.getStatistic(globalAdminRestContext, global.oaeTests.tenants.cam.alias, camStat.name, function(err, stat) {
+                                        assert.ok(!err);
+                                        assert.deepEqual(stat.name, camStat.name);
+                                        assert.deepEqual(stat.value, camStat.value);
+
+                                        RestAPI.Stats.getStatistic(globalAdminRestContext, global.oaeTests.tenants.gt.alias, gtStat.name, function(err, stat) {
+                                            assert.ok(!err);
+                                            assert.deepEqual(stat.name, gtStat.name);
+                                            assert.deepEqual(stat.value, gtStat.value);
+
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "oae-preview-processor": "",
     "oae-rest": "latest",
     "oae-search": "",
+    "oae-stats": "",
     "oae-telemetry": "",
     "oae-tenants": "",
     "oae-tests": "",


### PR DESCRIPTION
A simple statistics module that allows other modules to push statistics
on a by tenant basis. Eventually there’ll be a possibility to push stats
into statsd.

Currently only a content storage stat has been implemented. This stat
displays the total storage used by a tenant in bytes. The storage stat
collector can be enabled and configured in config.js.
Current configuration options:
- enabled: Whether or not the collector should run on this node
- interval: The interval when the stats should be updated
- expiry: How long a collection can take before something is considered awry

By default only one node in the cluster can refresh the content storage
stats (due to locking). This is so we don't drown the disk in IO operations.
