### PR TITLE
Email notifications not readable on iPhone

### DIFF
--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -205,6 +205,7 @@
                 height: 100%;
                 padding: 20px;
                 -webkit-font-smoothing: antialiased;
+                -webkit-text-size-adjust: 150%;
             }
 
             body, h1, h2, h3, h4, h5, h6, a, span, td, div {


### PR DESCRIPTION
The activity summaries in an email notification are too small to read on an iPhone.

![photo](https://cloud.githubusercontent.com/assets/109850/3743496/db29ba10-1779-11e4-957e-f3c395528101.PNG)
