### PR TITLE
Mark links that redirect to a new domain as non-embeddable

### DIFF
--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -702,55 +702,63 @@ describe('Preview processor', function() {
             }
 
             TestsUtil.createTestServer(function(app, server, port) {
+                TestsUtil.createTestServer(function(app2, server2, port2) {
 
-                // Determines whether or not we disallow embedding
-                var xFrameOptions = null;
+                    // Determines whether or not we disallow embedding
+                    var xFrameOptions = null;
 
-                // Add an endpoint to the mocked server that redirects
-                app.get('/redirect', function(req, res) {
-                    res.redirect('http://google.com');
-                });
+                    // Add an endpoint to the mocked server that redirects to the second mocked server
+                    app.get('/redirect', function(req, res) {
+                        res.redirect('http://localhost:' + port2);
+                    });
 
-                // Deny iframe embedding for all URLs
-                app.use(function(req, res, next) {
-                    if (xFrameOptions) {
-                        res.set('x-frame-options', xFrameOptions);
-                    }
-                    return res.send('This is the best page on the webz');
-                });
+                    // Deny iframe embedding for all URLs
+                    app.use(function(req, res, next) {
+                        if (xFrameOptions) {
+                            res.set('x-frame-options', xFrameOptions);
+                        }
+                        return res.send('This is the best page on the webz');
+                    });
 
-                // Our mocked server will disallow embedding any page in an iframe
-                xFrameOptions = 'DENY';
-                _createContentAndWait('link', 'http://localhost:' + port, null, function(restCtx, content) {
-                    assert.equal(content.previews.status, 'done');
-                    assert.equal(content.previews.embeddable, false);
+                    // Second mock server will always set X-Frame-Options to SAMEORIGIN
+                    app2.use(function(req, res, next) {
+                        res.set('x-frame-options', 'SAMEORIGIN');
+                        return res.send('This is the second best page on the webz');
+                    });
 
-                    // Ensure we have a thumbnail url
-                    assert.ok(content.previews.thumbnailUrl);
-                    assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
-                    _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
+                    // Our mocked server will disallow embedding any page in an iframe
+                    xFrameOptions = 'DENY';
+                    _createContentAndWait('link', 'http://localhost:' + port, null, function(restCtx, content) {
+                        assert.equal(content.previews.status, 'done');
+                        assert.equal(content.previews.embeddable, false);
 
-                        // Remove the embedding restriction from our mocked server, the site should now be embeddable
-                        xFrameOptions = null;
-                        _createContentAndWait('link', 'http://localhost:' + port, null, function(restCtx, content) {
-                            assert.equal(content.previews.status, 'done');
-                            assert.equal(content.previews.embeddable, true);
+                        // Ensure we have a thumbnail url
+                        assert.ok(content.previews.thumbnailUrl);
+                        assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
+                        _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
 
-                            // Ensure we have a thumbnail url
-                            assert.ok(content.previews.thumbnailUrl);
-                            assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
-                            _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
-                                // Create a link to the redirected endpoint, which should not be embeddable
-                                _createContentAndWait('link', 'http://localhost:' + port + '/redirect', null, function(restCtx, content) {
-                                    assert.equal(content.previews.status, 'done');
-                                    assert.equal(content.previews.embeddable, false);
+                            // Remove the embedding restriction from our mocked server, the site should now be embeddable
+                            xFrameOptions = null;
+                            _createContentAndWait('link', 'http://localhost:' + port, null, function(restCtx, content) {
+                                assert.equal(content.previews.status, 'done');
+                                assert.equal(content.previews.embeddable, true);
 
-                                    // Ensure we have a thumbnail url
-                                    assert.ok(content.previews.thumbnailUrl);
-                                    assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
-                                    _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
+                                // Ensure we have a thumbnail url
+                                assert.ok(content.previews.thumbnailUrl);
+                                assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
+                                _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
+                                    // Create a link to the redirected endpoint, which should not be embeddable
+                                    _createContentAndWait('link', 'http://localhost:' + port + '/redirect', null, function(restCtx, content) {
+                                        assert.equal(content.previews.status, 'done');
+                                        assert.equal(content.previews.embeddable, false);
 
-                                        return callback();
+                                        // Ensure we have a thumbnail url
+                                        assert.ok(content.previews.thumbnailUrl);
+                                        assert.strictEqual(content.previews.thumbnailUrl.indexOf('/api/download/signed'), 0);
+                                        _verifySignedUriDownload(restCtx, content.previews.thumbnailUrl, function() {
+
+                                            return callback();
+                                        });
                                     });
                                 });
                             });


### PR DESCRIPTION
It is possible for users to put "Short URLs" into content links which simply redirect to a page whose X-Frame-Options header is set to SAMEORIGIN, however we try and embed it because the link shortener site doesn't have that header set.

To resolve this issue, and also other moderation issues that can arise from cross-domain redirects (e.g., we cannot moderate the target host of links to "safe sites" because they can redirect anywhere), we should probably just not embed or generate previews for links that redirect to a new domain.
