### PR TITLE
Include the Open Sans font during collabdoc preview generation

### DIFF
--- a/node_modules/oae-preview-processor/static/collabdoc/collabdoc.css
+++ b/node_modules/oae-preview-processor/static/collabdoc/collabdoc.css
@@ -1,5 +1,8 @@
+/* Import the Open Sans font */
+@import url('//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700&subset=latin,cyrillic-ext,latin-ext,greek-ext');
+
 body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Open Sans Regular", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
     font-size: 14px;
     line-height: 20px;
     padding-left: 5px;


### PR DESCRIPTION
I think this is a matter of adding some rules in `oae-preview-processor/static/collabdoc/collabdoc.css`.

Something like:

``` css
/* Import the Open Sans font */
@import url('//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700&subset=latin,cyrillic-ext,latin-ext,greek-ext');


body {
    font-family: 'Open Sans Regular', 'Open Sans', Arial, sans-serif;
}
```
