### PR TITLE
REST documentation doesn't support multiple response messages for the same response code.

### DIFF
--- a/node_modules/oae-util/lib/swagger.js
+++ b/node_modules/oae-util/lib/swagger.js
@@ -192,10 +192,7 @@ var register = module.exports.register = function(filePath, callback) {
                 });
 
                 // Add any http response messages
-                endpoint.responseMessages = [];
-                _.each(endpoint.httpResponses, function(httpResponse) {
-                    endpoint.responseMessages.push({'code': httpResponse.code, 'message': httpResponse.description});
-                });
+                endpoint.responseMessages = endpoint.httpResponses;
 
                 // Add the endpoint to the appropriate server
                 _.each(endpoint.server.split(','), function(server) {


### PR DESCRIPTION
An endpoint documented as

```
/**
 * @REST getUiStaticbatch
 *
 * Get the content of a set of static files
 *
 * @Server      admin,tenant
 * @Method      GET
 * @Path        /ui/staticbatch
 * @QueryParam  {string[]}      files           Path of the file to retrieve
 * @Return      {StaticBatch}                   Object representing the retrieved files
 * @HttpResponse                200             (Static content available)
 * @HttpResponse                400             A valid file path needs to be provided
 * @HttpResponse                400             At least one file must be provided
 * @HttpResponse                400             Only absolute paths are allowed
 * @HttpResponse                400             The files parameter must be an array
 */
```

Shows up on the UI as

![screenshot 2014-09-04 12 29 21](https://cloud.githubusercontent.com/assets/1731910/4152670/ed46f4da-3450-11e4-8fbb-a0dd6767fbdf.png)
