### PR TITLE
Change `Default timezone for users`

### DIFF
--- a/node_modules/oae-activity/lib/internal/email.js
+++ b/node_modules/oae-activity/lib/internal/email.js
@@ -23,13 +23,13 @@ var EmailAPI = require('oae-email');
 var Locking = require('oae-util/lib/locking');
 var log = require('oae-logger').logger('oae-activity-email');
 var PrincipalsAPI = require('oae-principals');
-var PrincipalsConfig = require('oae-config').config('oae-principals');
 var PrincipalsConstants = require('oae-principals/lib/constants').PrincipalsConstants;
 var PrincipalsDAO = require('oae-principals/lib/internal/dao');
 var Redis = require('oae-util/lib/redis');
 var Sanitization = require('oae-util/lib/sanitization');
 var Telemetry = require('oae-telemetry').telemetry('activity-email');
 var TenantsAPI = require('oae-tenants');
+var TenantConfig = require('oae-config').config('oae-tenants');
 var TenantsUtil = require('oae-tenants/lib/util');
 var TZ = require('oae-util/lib/tz');
 var UIAPI = require('oae-ui');
@@ -681,7 +681,7 @@ var _getEntities = function(entity) {
  * @api private
  */
 var _createEmailBucketIdForUser = function(user) {
-    var timezone = PrincipalsConfig.getValue(user.tenant.alias, 'user', 'timezone');
+    var timezone = TenantConfig.getValue(user.tenant.alias, 'timezone', 'timezone');
     var bucketNumber = _getBucketNumber(user.id);
 
     // Gets filled up in case the user wants a weekly or daily mail

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -405,7 +405,7 @@ describe('Activity Email', function() {
                         // Set the default timezone for this tenant
                         offset++;
                         var timezone = 'Etc/GMT' + ((offset < 0) ? offset : ('+' + offset));
-                        ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-principals/user/timezone': timezone}, function(err) {
+                        ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-tenants/timezone/timezone': timezone}, function(err) {
                             assert.ok(!err);
                             userIds.push(user.id);
                             if (timezone === 'Etc/GMT+0') {
@@ -458,7 +458,7 @@ describe('Activity Email', function() {
             assert.ok(!err);
 
             // Configure the default timezone to something that's 5 hours behind
-            ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-principals/user/timezone': 'Etc/GMT+5'}, function(err) {
+            ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-tenants/timezone/timezone': 'Etc/GMT+5'}, function(err) {
                 assert.ok(!err);
 
                 // Generate some users that we can test with
@@ -528,7 +528,7 @@ describe('Activity Email', function() {
                         assert.ok(!err);
 
                         // Configure the default timezone to something that's 5 hours ahead
-                        ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-principals/user/timezone': 'Etc/GMT+5'}, function(err) {
+                        ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-tenants/timezone/timezone': 'Etc/GMT+5'}, function(err) {
                             assert.ok(!err);
 
                             // Trigger a mail for Nico
@@ -560,7 +560,7 @@ describe('Activity Email', function() {
                                             assert.ok(!err);
 
                                             // Configure the default timezone to something that's 5 hours behind
-                                            ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-principals/user/timezone': 'Etc/GMT-5'}, function(err) {
+                                            ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-tenants/timezone/timezone': 'Etc/GMT-5'}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Trigger a mail for Nico
@@ -624,7 +624,7 @@ describe('Activity Email', function() {
                         assert.ok(!err);
 
                         // Configure the default timezone to something that's 5 hours ahead
-                        ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-principals/user/timezone': 'Etc/GMT+5'}, function(err) {
+                        ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-tenants/timezone/timezone': 'Etc/GMT+5'}, function(err) {
                             assert.ok(!err);
 
                             // Trigger a mail for Nico
@@ -655,7 +655,7 @@ describe('Activity Email', function() {
                                             assert.ok(!err);
 
                                             // Configure the default timezone to something that's 5 hours behind
-                                            ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-principals/user/timezone': 'Etc/GMT-5'}, function(err) {
+                                            ConfigTestUtil.updateConfigAndWait(restContext, null, {'oae-tenants/timezone/timezone': 'Etc/GMT-5'}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Trigger a mail for Nico

--- a/node_modules/oae-principals/config/user.js
+++ b/node_modules/oae-principals/config/user.js
@@ -13,51 +13,7 @@
  * permissions and limitations under the License.
  */
 
-var _ = require('underscore');
-var util = require('util');
-
 var Fields = require('oae-config/lib/fields');
-var TZ = require('oae-util/lib/tz');
-
-var timezones = TZ.getZones();
-
-// Get an object that we can pass in the config List field as the set of options that should be
-// presented to the user. We add in the offset in the displayname of each element
-var timezoneConfigValues = _.chain(TZ.getZones())
-    .map(function(timezone, id) {
-        return _.extend({}, timezone, {'id': id});
-    })
-
-    // Secondary sort on the timezone id (e.g., Europe/Istanbul)
-    .sortBy(function(timezone) {
-        return timezone.id;
-    })
-
-    // Primary sort on the offset
-    .sortBy(function(timezone) {
-        return (-1 * timezone.offset);
-    })
-
-    // Convert it into name/value pairs for the UI
-    .map(function(timezone) {
-        var offsetHours = Math.abs(Math.floor(timezone.offset));
-        var offsetMinutes = Math.abs((timezone.offset % 1) * 60);
-
-        var sign = (timezone.offset > 0) ? '-' : '+';
-        var offsetHoursStr = (offsetHours < 10) ? '0' + offsetHours.toString() : offsetHours.toString();
-        var offsetMinutesStr = (offsetMinutes < 10) ? '0' + offsetMinutes.toString() : offsetMinutes.toString();
-
-        var offsetLabel = 'GMT';
-        if (timezone.offset !== 0) {
-            offsetLabel += util.format(' %s%s:%s', sign, offsetHoursStr, offsetMinutesStr);
-        }
-
-        return {
-            'name': util.format('%s (%s)', timezone.id, offsetLabel).replace('_', ' '),
-            'value': timezone.id
-        };
-    })
-    .value();
 
 module.exports = {
     'title': 'OAE Principals Module',
@@ -79,7 +35,6 @@ module.exports = {
                     'value': 'private'
                 }
             ]),
-            'timezone': new Fields.List('Default Timezone', 'Default timezone for users', 'Etc/UTC', timezoneConfigValues, {'suppress': true}),
             'emailPreference': new Fields.List('Default Email Preference', 'Default email preference for new users', 'immediate', [
                 {
                     'name': 'Immediate',

--- a/node_modules/oae-tenants/config/config.js
+++ b/node_modules/oae-tenants/config/config.js
@@ -13,7 +13,51 @@
  * permissions and limitations under the License.
  */
 
+var _ = require('underscore');
+var util = require('util');
+
 var Fields = require('oae-config/lib/fields');
+var TZ = require('oae-util/lib/tz');
+
+var timezones = TZ.getZones();
+
+// Get an object that we can pass in the config List field as the set of options that should be
+// presented to the user. We add in the offset in the displayname of each element
+var timezoneConfigValues = _.chain(TZ.getZones())
+    .map(function(timezone, id) {
+        return _.extend({}, timezone, {'id': id});
+    })
+
+    // Secondary sort on the timezone id (e.g., Europe/Istanbul)
+    .sortBy(function(timezone) {
+        return timezone.id;
+    })
+
+    // Primary sort on the offset
+    .sortBy(function(timezone) {
+        return (-1 * timezone.offset);
+    })
+
+    // Convert it into name/value pairs for the UI
+    .map(function(timezone) {
+        var offsetHours = Math.abs(Math.floor(timezone.offset));
+        var offsetMinutes = Math.abs((timezone.offset % 1) * 60);
+
+        var sign = (timezone.offset > 0) ? '-' : '+';
+        var offsetHoursStr = (offsetHours < 10) ? '0' + offsetHours.toString() : offsetHours.toString();
+        var offsetMinutesStr = (offsetMinutes < 10) ? '0' + offsetMinutes.toString() : offsetMinutes.toString();
+
+        var offsetLabel = 'GMT';
+        if (timezone.offset !== 0) {
+            offsetLabel += util.format(' %s%s:%s', sign, offsetHoursStr, offsetMinutesStr);
+        }
+
+        return {
+            'name': util.format('%s (%s)', timezone.id, offsetLabel).replace('_', ' '),
+            'value': timezone.id
+        };
+    })
+    .value();
 
 module.exports = {
     'title': 'OAE Tenant Module',
@@ -29,6 +73,13 @@ module.exports = {
         'description': 'Specifies if the tenant is private',
         'elements': {
             'tenantprivate': new Fields.Bool('Private Tenant', 'The tenant is private', false, {'tenantOverride': false, 'suppress': false})
+        }
+    },
+    'timezone': {
+        'name': 'Tenant Timezone',
+        'description': 'Specifies the tenant timezone',
+        'elements': {
+            'timezone': new Fields.List('Tenant Timezone', 'Tenant timezone', 'Etc/UTC', timezoneConfigValues, {'suppress': true})
         }
     }
 };


### PR DESCRIPTION
The `Default timezone for users` configuration option should be renamed to `Tenant timezone` and should be made available underneath the `Tenants` module.

Once this is rolled out to production, the timezone for each existing tenant should be set to the timezone of the corresponding institution.
