### PR TITLE
Add the userid in emails their message id

### DIFF
--- a/node_modules/oae-email/lib/api.js
+++ b/node_modules/oae-email/lib/api.js
@@ -371,7 +371,9 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
 
     // Set the Message-Id header based on the message hash. We apply the
     // tenant host as the FQDN as it improves the spam score by providing
-    // a source location of the message
+    // a source location of the message we also put the userid of the user
+    // we sent the message to on the local side so we can determine what oae
+    // user we sent a message to in sendgrid
     emailInfo.messageId = util.format('%s.%s@%s', opts.hash, toUser.id.replace(/:/g, '-'), tenant.host);
 
     // If we're not sending out HTML, we can send out the email now

--- a/node_modules/oae-email/tests/test-email.js
+++ b/node_modules/oae-email/tests/test-email.js
@@ -440,7 +440,7 @@ describe('Emails', function() {
 
     });
 
-    describe('Spam Score', function() {
+    describe('Spam Prevention', function() {
 
         /**
          * Test that ensures the Message-Id of email messages are in a format that SpamAssassin will
@@ -471,6 +471,35 @@ describe('Emails', function() {
                 });
             });
         });
+
+        /**
+         * Test that ensures we have the userid in the messageid so we can find the source of a message
+         */
+        it('verify emails have a userid in their message id', function(callback) {
+
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
+                assert.ok(!err);
+
+                // Create a content item which should trigger an email
+                RestAPI.Content.createLink(mrvisser.restContext, 'Google', 'Google', 'private', 'http://www.google.com', [], [simong.user.id], function(err, link) {
+                    assert.ok(!err);
+                    assert.ok(link);
+
+                    // Ensure the email has an ID that contains the userid
+                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                        assert.ok(messages);
+                        assert.ok(!_.isEmpty(messages));
+                        assert.ok(messages[0].messageId);
+                        // `:` can't appear in email headers
+                        var transformedUserId = simong.user.id.replace(/:/g, '-');
+
+                        assert.ok(messages[0].headers['message-id'].match(transformedUserId));
+                        return callback();
+                    });
+                });
+            });
+        });
+
     });
 
     describe('Email de-duplication', function() {


### PR DESCRIPTION
Adding the userid in the [`messageId`](https://github.com/oaeproject/Hilary/blob/master/node_modules/oae-email/lib/api.js#L375) would allow us to identify the user object in OAE that received an e-mail by its ID. 

This is a quick fix until we have globally unique email addresses and can lookup users by emails.
