### PR TITLE
Added `clearAllData` test function that truncates some tables

### DIFF
--- a/node_modules/oae-following/tests/test-search.js
+++ b/node_modules/oae-following/tests/test-search.js
@@ -30,8 +30,12 @@ var gtAdminRestContext = null;
 
 /**
  * Function that will fill up the anonymous and admin REST context
+ *
+ * Because we truncate the `Principals` table in one of our tests we need
+ * to re-create the rest contexts for each test so we can ensure our admin
+ * session will always point to a valid principal record
  */
-before(function(callback) {
+beforeEach(function(callback) {
     camAnonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
     camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
     gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
@@ -233,31 +237,33 @@ describe('Following Search', function() {
      * Test that verifies that followers are reindexed when the search index is built with reindexAll
      */
     it('verify following search reindexes with reindex all', function(callback) {
-        // Create 2 users, one following the other
-        FollowingTestsUtil.createFollowerAndFollowed(camAdminRestContext, function(follower, followed) {
+        TestsUtil.clearAllData(function() {
+            // Create 2 users, one following the other
+            FollowingTestsUtil.createFollowerAndFollowed(camAdminRestContext, function(follower, followed) {
 
-            // Search the following feed of the follower and the followers feed of the followed user and ensure that the users appear in the respective results
-            FollowingTestsUtil.searchFollowerAndFollowing(follower.user.id, follower.restContext, followed.user.id, followed.restContext, function(followerUserDoc, followedUserDoc) {
-                assert.ok(followerUserDoc);
-                assert.ok(followedUserDoc);
+                // Search the following feed of the follower and the followers feed of the followed user and ensure that the users appear in the respective results
+                FollowingTestsUtil.searchFollowerAndFollowing(follower.user.id, follower.restContext, followed.user.id, followed.restContext, function(followerUserDoc, followedUserDoc) {
+                    assert.ok(followerUserDoc);
+                    assert.ok(followedUserDoc);
 
-                // Delete the search index
-                SearchTestsUtil.deleteAll(function() {
+                    // Delete the search index
+                    SearchTestsUtil.deleteAll(function() {
 
-                    // Ensure the following relationship can no longer be found when searching them
-                    FollowingTestsUtil.searchFollowerAndFollowing(follower.user.id, follower.restContext, followed.user.id, followed.restContext, function(followerUserDoc, followedUserDoc) {
-                        assert.ok(!followerUserDoc);
-                        assert.ok(!followedUserDoc);
+                        // Ensure the following relationship can no longer be found when searching them
+                        FollowingTestsUtil.searchFollowerAndFollowing(follower.user.id, follower.restContext, followed.user.id, followed.restContext, function(followerUserDoc, followedUserDoc) {
+                            assert.ok(!followerUserDoc);
+                            assert.ok(!followedUserDoc);
 
-                        // Reindex all resources
-                        SearchTestsUtil.reindexAll(TestsUtil.createGlobalAdminRestContext(), function() {
+                            // Reindex all resources
+                            SearchTestsUtil.reindexAll(TestsUtil.createGlobalAdminRestContext(), function() {
 
-                            // Ensure the follower and following search index are searchable again
-                            FollowingTestsUtil.searchFollowerAndFollowing(follower.user.id, follower.restContext, followed.user.id, followed.restContext, function(followerUserDoc, followedUserDoc) {
-                                assert.ok(followerUserDoc);
-                                assert.ok(followedUserDoc);
+                                // Ensure the follower and following search index are searchable again
+                                FollowingTestsUtil.searchFollowerAndFollowing(follower.user.id, follower.restContext, followed.user.id, followed.restContext, function(followerUserDoc, followedUserDoc) {
+                                    assert.ok(followerUserDoc);
+                                    assert.ok(followedUserDoc);
 
-                                return callback();
+                                    return callback();
+                                });
                             });
                         });
                     });

--- a/node_modules/oae-principals/tests/test-search.js
+++ b/node_modules/oae-principals/tests/test-search.js
@@ -29,7 +29,10 @@ describe('Search', function() {
     var camAdminRestContext = null;
     var gtAdminRestContext = null;
 
-    before(function(callback) {
+    // Because we truncate the `Principals` table in one of our tests we need
+    // to re-create the rest contexts for each test so we can ensure our admin
+    // session will always point to a valid principal record
+    beforeEach(function(callback) {
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
@@ -166,70 +169,72 @@ describe('Search', function() {
          * Test that verifies that users, groups, members and memberships documents are all reindexed when the search index is built with reindexAll
          */
         it('verify users and groups reindex with reindex all', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
-                assert.ok(!err);
+            TestsUtil.clearAllData(function() {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
+                    assert.ok(!err);
 
-                TestsUtil.generateTestGroups(user.restContext, 1, function(group) {
-                    group = group.group;
+                    TestsUtil.generateTestGroups(user.restContext, 1, function(group) {
+                        group = group.group;
 
-                    // Sanity check we can search all 4 documents (user, group, member, membership)
-                    SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'user', 'q': user.user.displayName}, function(err, results) {
-                        assert.ok(!err);
-                        assert.ok(_getDocById(results, user.user.id));
-
-                        SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'group', 'q': group.displayName}, function(err, results) {
+                        // Sanity check we can search all 4 documents (user, group, member, membership)
+                        SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'user', 'q': user.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            assert.ok(_getDocById(results, group.id));
+                            assert.ok(_getDocById(results, user.user.id));
 
-                            SearchTestsUtil.searchAll(user.restContext, 'memberships-library', [user.user.id], null, function(err, results) {
+                            SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'group', 'q': group.displayName}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(_getDocById(results, group.id));
 
-                                SearchTestsUtil.searchAll(user.restContext, 'members', [group.id], null, function(err, results) {
+                                SearchTestsUtil.searchAll(user.restContext, 'memberships-library', [user.user.id], null, function(err, results) {
                                     assert.ok(!err);
-                                    assert.ok(_getDocById(results, user.user.id));
+                                    assert.ok(_getDocById(results, group.id));
 
-                                    // Completely delete the search index
-                                    SearchTestsUtil.deleteAll(function() {
+                                    SearchTestsUtil.searchAll(user.restContext, 'members', [group.id], null, function(err, results) {
+                                        assert.ok(!err);
+                                        assert.ok(_getDocById(results, user.user.id));
 
-                                        // Ensure the user, group, members, memberships can no longer be found in search
-                                        SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'user', 'q': user.user.displayName}, function(err, results) {
-                                            assert.ok(!err);
-                                            assert.ok(!_getDocById(results, user.user.id));
+                                        // Completely delete the search index
+                                        SearchTestsUtil.deleteAll(function() {
 
-                                            SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'group', 'q': group.displayName}, function(err, results) {
+                                            // Ensure the user, group, members, memberships can no longer be found in search
+                                            SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'user', 'q': user.user.displayName}, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.ok(!_getDocById(results, group.id));
+                                                assert.ok(!_getDocById(results, user.user.id));
 
-                                                SearchTestsUtil.searchAll(user.restContext, 'memberships-library', [user.user.id], null, function(err, results) {
+                                                SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'group', 'q': group.displayName}, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.ok(!_getDocById(results, group.id));
 
-                                                    SearchTestsUtil.searchAll(user.restContext, 'members', [group.id], null, function(err, results) {
+                                                    SearchTestsUtil.searchAll(user.restContext, 'memberships-library', [user.user.id], null, function(err, results) {
                                                         assert.ok(!err);
-                                                        assert.ok(!_getDocById(results, user.user.id));
+                                                        assert.ok(!_getDocById(results, group.id));
 
-                                                        // Reindex the whole search index
-                                                        SearchTestsUtil.reindexAll(TestsUtil.createGlobalAdminRestContext(), function() {
+                                                        SearchTestsUtil.searchAll(user.restContext, 'members', [group.id], null, function(err, results) {
+                                                            assert.ok(!err);
+                                                            assert.ok(!_getDocById(results, user.user.id));
 
-                                                            // Ensure all 4 document types are searchable again (user, group, member, membership)
-                                                            SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'user', 'q': user.user.displayName}, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.ok(_getDocById(results, user.user.id));
+                                                            // Reindex the whole search index
+                                                            SearchTestsUtil.reindexAll(TestsUtil.createGlobalAdminRestContext(), function() {
 
-                                                                SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'group', 'q': group.displayName}, function(err, results) {
+                                                                // Ensure all 4 document types are searchable again (user, group, member, membership)
+                                                                SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'user', 'q': user.user.displayName}, function(err, results) {
                                                                     assert.ok(!err);
-                                                                    assert.ok(_getDocById(results, group.id));
+                                                                    assert.ok(_getDocById(results, user.user.id));
 
-                                                                    SearchTestsUtil.searchAll(user.restContext, 'memberships-library', [user.user.id], null, function(err, results) {
+                                                                    SearchTestsUtil.searchAll(user.restContext, 'general', null, {'resourceTypes': 'group', 'q': group.displayName}, function(err, results) {
                                                                         assert.ok(!err);
                                                                         assert.ok(_getDocById(results, group.id));
 
-                                                                        SearchTestsUtil.searchAll(user.restContext, 'members', [group.id], null, function(err, results) {
+                                                                        SearchTestsUtil.searchAll(user.restContext, 'memberships-library', [user.user.id], null, function(err, results) {
                                                                             assert.ok(!err);
-                                                                            assert.ok(_getDocById(results, user.user.id));
+                                                                            assert.ok(_getDocById(results, group.id));
 
-                                                                            return callback();
+                                                                            SearchTestsUtil.searchAll(user.restContext, 'members', [group.id], null, function(err, results) {
+                                                                                assert.ok(!err);
+                                                                                assert.ok(_getDocById(results, user.user.id));
+
+                                                                                return callback();
+                                                                            });
                                                                         });
                                                                     });
                                                                 });

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -37,9 +37,13 @@ describe('General Search', function() {
     var globalAdminOnTenantRestContext = null;
 
     /**
-     * Function that will fill up the anonymous and admin REST context
+     * Function that will fill up the anonymous and admin REST context.
+     *
+     * Because we truncate the `Principals` table in one of our tests we need
+     * to re-create the rest contexts for each test so we can ensure our admin
+     * session will always point to a valid principal record
      */
-    before(function(callback) {
+    beforeEach(function(callback) {
         // Fill up anonymous rest context
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         // Fill up tenant admin rest contexts
@@ -435,42 +439,44 @@ describe('General Search', function() {
          * appropriately with their messages.
          */
         it('verify reindexAll reindexes messages as children of their parent resource items', function(callback) {
+            TestsUtil.clearAllData(function() {
 
-            // Create the user to test with
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
-                assert.ok(!err);
-
-                var searchTerm = 'zxkdjfhdjghdjrghsfhgjsldkfjghsldkjfgh';
-
-                // Create the content item and discussion we will test searching for
-                RestAPI.Content.createLink(user.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], function(err, content) {
+                // Create the user to test with
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                     assert.ok(!err);
-                    RestAPI.Discussions.createDiscussion(user.restContext, 'How about them Leafs?', 'Official Toronto Maple Leafs Thread', 'public', [], [], function(err, discussion) {
+
+                    var searchTerm = 'zxkdjfhdjghdjrghsfhgjsldkfjghsldkjfgh';
+
+                    // Create the content item and discussion we will test searching for
+                    RestAPI.Content.createLink(user.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], function(err, content) {
                         assert.ok(!err);
+                        RestAPI.Discussions.createDiscussion(user.restContext, 'How about them Leafs?', 'Official Toronto Maple Leafs Thread', 'public', [], [], function(err, discussion) {
+                            assert.ok(!err);
 
-                        // Verify that we do not get the content item or discussion in any of the search resourceTypes permutations
-                        _verifySearchResults(user.restContext, content.id, discussion.id, false, false, searchTerm, function() {
+                            // Verify that we do not get the content item or discussion in any of the search resourceTypes permutations
+                            _verifySearchResults(user.restContext, content.id, discussion.id, false, false, searchTerm, function() {
 
-                            // Create a comment and message on the content item and discussion
-                            RestAPI.Content.createComment(user.restContext, content.id, searchTerm, null, function(err, comment) {
-                                assert.ok(!err);
-                                RestAPI.Discussions.createMessage(user.restContext, discussion.id, searchTerm, null, function(err, message) {
+                                // Create a comment and message on the content item and discussion
+                                RestAPI.Content.createComment(user.restContext, content.id, searchTerm, null, function(err, comment) {
                                     assert.ok(!err);
+                                    RestAPI.Discussions.createMessage(user.restContext, discussion.id, searchTerm, null, function(err, message) {
+                                        assert.ok(!err);
 
-                                    // Ensure both the content item and message are searchable by their messages
-                                    _verifySearchResults(user.restContext, content.id, discussion.id, true, true, searchTerm, function() {
+                                        // Ensure both the content item and message are searchable by their messages
+                                        _verifySearchResults(user.restContext, content.id, discussion.id, true, true, searchTerm, function() {
 
-                                        // Delete the search index
-                                        SearchTestsUtil.deleteAll(function() {
+                                            // Delete the search index
+                                            SearchTestsUtil.deleteAll(function() {
 
-                                            // Ensure we can no longer search for either content or discussion item
-                                            _verifySearchResults(user.restContext, content.id, discussion.id, false, false, searchTerm, function() {
+                                                // Ensure we can no longer search for either content or discussion item
+                                                _verifySearchResults(user.restContext, content.id, discussion.id, false, false, searchTerm, function() {
 
-                                                // Reindex all resources
-                                                SearchTestsUtil.reindexAll(TestsUtil.createGlobalAdminRestContext(), function() {
+                                                    // Reindex all resources
+                                                    SearchTestsUtil.reindexAll(TestsUtil.createGlobalAdminRestContext(), function() {
 
-                                                    // Ensure we can now search both content and discussion item again by their message bodies
-                                                    return _verifySearchResults(user.restContext, content.id, discussion.id, true, true, searchTerm, callback);
+                                                        // Ensure we can now search both content and discussion item again by their message bodies
+                                                        return _verifySearchResults(user.restContext, content.id, discussion.id, true, true, searchTerm, callback);
+                                                    });
                                                 });
                                             });
                                         });

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -21,13 +21,22 @@ var ShortId = require('shortid');
 var stream = require('stream');
 var util = require('util');
 
+var AuthenticationAPI = require('oae-authentication');
+var AuthenticationConstants = require('oae-authentication/lib/constants').AuthenticationConstants;
+var Cassandra = require('oae-util/lib/cassandra');
 var ConfigTestUtil = require('oae-config/lib/test/util');
 var Context = require('oae-context').Context;
+var LoginId = require('oae-authentication/lib/model').LoginId;
 var multipart = require('oae-util/lib/middleware/multipart');
 var OaeUtil = require('oae-util/lib/util');
+var PrincipalsAPI = require('oae-principals');
+var Pubsub = require('oae-util/lib/pubsub');
+var Redis = require('oae-util/lib/redis');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var RestUtil = require('oae-rest/lib/util');
+var Tenant = require('oae-tenants/lib/model').Tenant;
+var TenantsAPI = require('oae-tenants');
 var TenantsTestUtil = require('oae-tenants/lib/test/util');
 var User = require('oae-principals/lib/model').User;
 
@@ -65,6 +74,139 @@ var createTestServer = module.exports.createTestServer = function(callback, _att
     server.once('error', function(err) {
         server.removeAllListeners('listening');
         return createTestServer(callback, _attempts + 1);
+    });
+};
+
+/**
+ * Clear all the data from the Cassandra column families
+ *
+ * @param  {Function}   callback    Standard callback function
+ * @throws {Error}                  An assertion error is thrown if an unexpected error occurs
+ */
+var clearAllData = module.exports.clearAllData = function(callback) {
+    var columnFamiliesToClear = ['Content', 'Discussions', 'Folders', 'Principals', 'AuthenticationLoginId', 'AuthenticationUserLoginId'];
+
+    /*!
+     * Once all column families have been truncated, we re-populate the administrators
+     */
+    var truncated = _.after(columnFamiliesToClear.length, function() {
+        // Flush the data from redis, so we can recreate our admins
+        Redis.flush(function(err) {
+            assert.ok(!err);
+
+            // Mock a global admin request context so we can create a proper global administrator in the system
+            var globalTenant = TenantsAPI.getTenant('admin');
+            var globalUser = new User(globalTenant.alias, 'u:admin:admin', 'Global Administrator', {
+                'visibility': 'admin',
+                'isGlobalAdmin': true
+            });
+            var globalContext = new Context(globalTenant, globalUser);
+
+            // Create the global admin user if they don't exist yet with the username "administrator"
+            AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', null, function(err) {
+                assert.ok(!err);
+
+                // Re-create the tenant administrators
+                return _setUpTenantAdmins(callback);
+            });
+        });
+    });
+
+    // Truncate each column family
+    _.each(columnFamiliesToClear, function(cf) {
+        var query = util.format('TRUNCATE "%s"', cf);
+        Cassandra.runQuery(query, [], function(err) {
+            assert.ok(!err);
+            truncated();
+        });
+    });
+};
+
+
+/**
+ * Create 3 default tenants that can be used for testing the REST endpoints. These
+ * tenants will be exposed on a global `oaeTests` object.
+ *
+ * @param  {Function}       callback    Standard callback function
+ * @throws {Error}                      An assertion error is thrown when an unexpected error occurs
+ */
+var setUpTenants = module.exports.setUpTenants = function(callback) {
+    global.oaeTests = {'tenants': {}};
+
+    // Create the Global Tenant admin context to authenticate with
+    global.oaeTests.tenants.global = new Tenant('admin', 'Global tenant', 'localhost:2000', {'isGlobalAdminServer': true});
+    var globalAdminRestContext = createGlobalAdminRestContext();
+
+    // Create the Cambridge tenant
+    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'camtest', 'Cambridge University Test', 'cambridge.oae.com', function(err, tenant) {
+        assert.ok(!err);
+        global.oaeTests.tenants.cam = tenant;
+
+        // Create the Georgia Tech tenant
+        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'gttest', 'Georgia Tech Test', 'gt.oae.com', function(err, tenant) {
+            assert.ok(!err);
+            global.oaeTests.tenants.gt = tenant;
+
+            // Create a tenant with a hostname set to 'localhost:2001' (ie: the host/port
+            // combination where the server is running on). This allows tests to use
+            // the cross tenant sign authentication
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'localhost', 'Tenant with a hostname set to localhost', 'localhost:2001', function(err, tenant) {
+                assert.ok(!err);
+                global.oaeTests.tenants.localhost = tenant;
+
+                // Set up the tenant admins
+                _setUpTenantAdmins(callback);
+            });
+        });
+    });
+};
+
+/**
+ * Create a tenant admin for the specified tenant.
+ *
+ * @param  {Tenant}     tenant        The tenant to create an admin on
+ * @param  {Function}   callback      Standard callback function
+ * @api private
+ */
+var _setupTenantAdmin = function(tenant, callback) {
+    var adminLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, 'administrator', { 'password': 'administrator' });
+    var mockUserId = 'u:' + tenant.alias + ':admin';
+    var adminUser = new User(tenant.alias, mockUserId, 'The admin User', {
+        'isGlobalAdmin': false,
+        'isTenantAdmin': true
+    });
+
+    var ctx = new Context(tenant, adminUser);
+    AuthenticationAPI.createUser(ctx, adminLoginId, adminUser.displayName, null, function(err, createdUser) {
+        assert.ok(!err);
+
+        return PrincipalsAPI.setTenantAdmin(ctx, createdUser.id, true, callback);
+    });
+};
+
+/**
+ * Create a tenant admin for each of the created tenants
+ *
+ * @param  {Object}      callback    Standard callback
+ * @api private
+ */
+var _setUpTenantAdmins = function(callback) {
+    var camTenant = global.oaeTests.tenants.cam;
+    var gtTenant = global.oaeTests.tenants.gt;
+    var localTenant = global.oaeTests.tenants.localhost;
+
+    _setupTenantAdmin(camTenant, function(err) {
+        assert.ok(!err);
+
+        _setupTenantAdmin(gtTenant, function(err) {
+            assert.ok(!err);
+
+            _setupTenantAdmin(localTenant, function(err) {
+                assert.ok(!err);
+
+                return callback();
+            });
+        });
     });
 };
 

--- a/node_modules/oae-tests/runner/beforeTests.js
+++ b/node_modules/oae-tests/runner/beforeTests.js
@@ -25,23 +25,16 @@ var fs = require('fs');
 process.env['OAE_BOOTSTRAP_LOG_LEVEL'] = 'trace';
 process.env['OAE_BOOTSTRAP_LOG_FILE'] = './tests.log';
 
-var AuthenticationAPI = require('oae-authentication');
-var AuthenticationConstants = require('oae-authentication/lib/constants').AuthenticationConstants;
 var Cassandra = require('oae-util/lib/cassandra');
-var Context = require('oae-context').Context;
-var LoginId = require('oae-authentication/lib/model').LoginId;
 var OAE = require('oae-util/lib/oae');
 var OaeUtil = require('oae-util/lib/util');
 var MQ = require('oae-util/lib/mq');
 var PreviewAPI = require('oae-preview-processor/lib/api');
-var PrincipalsAPI = require('oae-principals');
 var Redis = require('oae-util/lib/redis');
 var RestAPI = require('oae-rest');
 var RestUtil = require('oae-rest/lib/util');
-var SearchAPI = require('oae-search');
 var Tenant = require('oae-tenants/lib/model').Tenant;
 var TenantsTestUtil = require('oae-tenants/lib/test/util');
-var User = require('oae-principals/lib/model.user').User;
 
 var TestsUtil = require('oae-tests/lib/util');
 
@@ -100,96 +93,6 @@ config.telemetry.enabled = false;
 // test
 var dropKeyspaceBeforeTest = (process.env.OAE_TEST_DROP_KEYSPACE_BEFORE !== 'false');
 
-/**
- * Create 2 default tenants that can be used for testing our REST endpoints.
- *
- * @param  {Function}    callback    Standard callback function that should be called when the tenants have been created and have started up
- */
-var setUpTenants = function(callback) {
-    global.oaeTests = {'tenants': {}};
-
-    // Create the Global Tenant admin context to authenticate with
-    global.oaeTests.tenants.global = new Tenant(config.servers.globalAdminAlias, 'Global tenant', config.servers.globalAdminHost, {'isGlobalAdminServer': true});
-    var globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
-
-    // Create the Cambridge tenant
-    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'camtest', 'Cambridge University Test', 'cambridge.oae.com', function(err, tenant) {
-        if (err) {
-            log().error({'err': err});
-            return callback(err);
-        }
-
-        global.oaeTests.tenants.cam = tenant;
-        // Create the Georgia Tech tenant
-        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'gttest', 'Georgia Tech Test', 'gt.oae.com', function(err, tenant) {
-            if (err) {
-                return callback(err);
-            }
-
-            global.oaeTests.tenants.gt = tenant;
-
-            // Create a tenant with a hostname set to 'localhost:2001' (ie: the host/port combination where the server is running on)
-            // This allows tests to use the cross tenant sign authentication.
-            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'localhost', 'Tenant with a hostname set to localhost', 'localhost:2001', function(err, tenant) {
-                if (err) {
-                    return callback(err);
-                }
-                global.oaeTests.tenants.localhost = tenant;
-
-                // We set up the tenant admins
-                setUpTenantAdmins(callback);
-            });
-        });
-    });
-};
-
-/**
- * Create a tenant admin for the specified tenant.
- *
- * @param  {Tenant}     tenant        The tenant to create an admin on
- * @param  {Function}   callback      Standard callback function that should be called when the tenant has been created
- */
-var setupTenantAdmin = function(tenant, callback) {
-    var adminLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, 'administrator', { 'password': 'administrator' });
-    var mockUserId = 'u:' + tenant.alias + ':admin';
-    var adminUser = new User(tenant.alias, mockUserId, 'The admin User', {
-        'isGlobalAdmin': false,
-        'isTenantAdmin': true
-    });
-
-    var ctx = new Context(tenant, adminUser);
-    AuthenticationAPI.createUser(ctx, adminLoginId, adminUser.displayName, null, function(err, createdUser) {
-        if (err) {
-            return callback(err);
-        }
-
-        return PrincipalsAPI.setTenantAdmin(ctx, createdUser.id, true, callback);
-    });
-};
-
-
-/**
- * Create a tenant admin for each of the created tenants
- * @param  {Object}      callback    Standard callback function that should be called when the tenant admins have been created
- */
-var setUpTenantAdmins = function(callback) {
-    var camTenant = global.oaeTests.tenants.cam;
-    var gtTenant = global.oaeTests.tenants.gt;
-    var localTenant = global.oaeTests.tenants.localhost;
-
-    setupTenantAdmin(camTenant, function(err) {
-        if (err) {
-            return callback(err);
-        }
-        setupTenantAdmin(gtTenant, function(err) {
-            if (err) {
-                return callback(err);
-            }
-            setupTenantAdmin(localTenant, callback);
-        });
-    });
-};
-
 // First set up the keyspace and all of the column families required for all of the different OAE modules
 before(function(callback) {
     this.timeout(60000);
@@ -227,14 +130,14 @@ before(function(callback) {
                     });
 
                     // Defer the test setup until after the task handlers are successfully bound and all the queues are drained.
-                    // This will always be fired after OAE.init has successfully finished.
+                    // This will always be fired after OAE.init has successfully finished
                     MQ.on('ready', function(err) {
                         if (err) {
                             return callback(new Error(err.msg));
                         }
 
-                        // Set up a couple of test tenants.
-                        setUpTenants(function(err) {
+                        // Set up a couple of test tenants
+                        TestsUtil.setUpTenants(function(err) {
                             if (err) {
                                 return callback(new Error(err.msg));
                             }
@@ -266,7 +169,7 @@ afterEach(function(callback) {
 });
 
 // Executed once all of the tests for all of the different modules have finished running or
-// when one of the tests has caused an error. Drop the keyspace after all the tests are done.
+// when one of the tests has caused an error. Drop the keyspace after all the tests are done
 after(function(callback) {
     // Clean up after ourselves
     Redis.flush(function(err) {


### PR DESCRIPTION
This will allow for faster reindexAll operations and should reduce some
of the load during Travis tests

There's no need to review this yet. I want to see if this has any impact on the instability of our tests.
