### PR TITLE
Fixed warnings on startup

### DIFF
--- a/node_modules/oae-ui/lib/api.js
+++ b/node_modules/oae-ui/lib/api.js
@@ -192,24 +192,44 @@ var getWidgetManifests = module.exports.getWidgetManifests = function() {
  */
 var cacheWidgetManifests = function() {
     widgetManifestCache = {};
-    // Cache all of the widget config files under node_modules
-    readdirp({ 'root': uiDirectory + '/node_modules/', 'directoryFilter': ['!.bin'], 'fileFilter': 'manifest.json' })
-        .on('data', function (entry) {
-            // Extract the widget id from the path, which is expected
-            // to be the final part of the path
-            var widgetId = entry.parentDir.split(path.sep).pop();
-            try {
-                var widgetManifest = fs.readFileSync(entry.fullPath, 'utf8');
-                widgetManifestCache[widgetId] = JSON.parse(widgetManifest);
-            } catch (err) {
-                widgetManifestCache[widgetId] = {};
-                log().error({'err': err, 'widgetId': widgetId, 'path': entry.fullPath}, 'Could not parse the widget manifest file.');
-            }
-            widgetManifestCache[widgetId].id = widgetId;
-            widgetManifestCache[widgetId].path = entry.parentDir + '/';
-        })
-        .on('warn', function (err) { log().warn({'err': err}, 'A non-fatal error occured whilst caching a widget manifest'); })
-        .on('error', function (err) { log().error({'err': err}, 'A fatal error occured whilst caching a widget manifest'); });
+    readdirp({
+        // Cache all of the widget config files under node_modules
+        'root': uiDirectory + '/node_modules/',
+
+        // Only recurse in folders that contain widgets
+        'directoryFilter': _widgetDirectoryFilter,
+
+        // We're only interested in the manifest files
+        'fileFilter': 'manifest.json'
+    })
+    .on('data', function (entry) {
+        // Extract the widget id from the path, which is expected
+        // to be the final part of the path
+        var widgetId = entry.parentDir.split(path.sep).pop();
+        try {
+            var widgetManifest = fs.readFileSync(entry.fullPath, 'utf8');
+            widgetManifestCache[widgetId] = JSON.parse(widgetManifest);
+        } catch (err) {
+            widgetManifestCache[widgetId] = {};
+            log().error({'err': err, 'widgetId': widgetId, 'path': entry.fullPath}, 'Could not parse the widget manifest file');
+        }
+        widgetManifestCache[widgetId].id = widgetId;
+        widgetManifestCache[widgetId].path = entry.parentDir + '/';
+    })
+    .on('warn', function (err) { log().warn({'err': err}, 'A non-fatal error occured whilst caching a widget manifest'); })
+    .on('error', function (err) { log().error({'err': err}, 'A fatal error occured whilst caching a widget manifest'); });
+};
+
+/**
+ * Filter for the `readdirp` module that filters directories
+ * to those directories that are within a valid widget tree
+ *
+ * @param  {Entry}      entry   A `readdirp` entry object
+ * @return {Boolean}            `true` if `readdirp` should further recurse into the directory, `false` otherwise
+ * @api private
+ */
+var _widgetDirectoryFilter = function(entry) {
+    return (entry.fullPath.indexOf('/node_modules/oae-') !== -1);
 };
 
 //////////////////
@@ -822,30 +842,37 @@ var translate = module.exports.translate = function(str, locale, variables) {
  * @api private
  */
 var _cacheI18nKeys = function(callback) {
-    _cacheI18nKeysInDirectory('/shared/oae/bundles', function(err) {
+    _cacheI18nKeysInDirectory('/shared/oae/bundles', null, function(err) {
         if (err) {
             return callback(err);
         }
 
-        return _cacheI18nKeysInDirectory('/node_modules', callback);
+        return _cacheI18nKeysInDirectory('/node_modules', _widgetDirectoryFilter, callback);
     });
 };
 
 /**
  * Caches all the bundle files in a ui directory in-memory
  *
- * @param  {String}     directory       The directory that contains the i18n bundles
- * @param  {Function}   callback        Standard callback function
- * @param  {Object}     callback.err    An error that occurred, if any
+ * @param  {String}     directory           The directory that contains the i18n bundles, relative to the UI root directory
+ * @param  {Object}     directoryFilter     A filter to include or exclude directories that should be recursed in. See https://github.com/thlorenz/readdirp#filters for more information
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error that occurred, if any
  * @api private
  */
-var _cacheI18nKeysInDirectory = function(directory, callback) {
+var _cacheI18nKeysInDirectory = function(directory, directoryFilter, callback) {
     // Ensure that we don't call our callback twice
     var done = _.once(callback);
 
     // Get all the bundles in the UI directory tree
     readdirp({
+        // Recurse through everything in the specified directory
         'root': uiDirectory + directory,
+
+        // An optional directory filter
+        'directoryFilter': directoryFilter,
+
+        // We're only interested in the properties files
         'fileFilter': '*.properties'
     })
     .on('data', function (entry) {

--- a/node_modules/oae-util/lib/swagger.js
+++ b/node_modules/oae-util/lib/swagger.js
@@ -91,9 +91,13 @@ var documentModule = module.exports.documentModule = function(moduleName, callba
             files.push(entry.fullPath);
         })
         .on('error', function(err) {
-            log().warn({'err': err}, 'Problem recursing directories while documenting ' + moduleName);
+            // Modules are not required to have a lib folder, so we don't log "No Entry" errors
+            if (err.code !== 'ENOENT') {
+                log().warn({'err': err}, 'Problem recursing directories while documenting ' + moduleName);
+            }
             return callback();
-        }).on('end', function() {
+        })
+        .on('end', function() {
             if (_.isEmpty(files)) {
                 return callback();
             }


### PR DESCRIPTION
For a while now we've had some warnings during the start-up phase that annoyed me.
This PR fixes the following:
- Not logging error during swagger recursion when /lib does not exist (as it is legal)
- Specifying widget directory filter for caching widget manifests/i18n bundles

These still remain:

```
[2014-09-20T17:46:23.192Z]  WARN: signature/33164 on dhcp-172-17-169-188.eduroam.wireless.private.cam.ac.uk:
    You are using the default key to sign URLs, this is *NOT* secure and should be changed immediately.
    The system will continue to function, but it is strongly recommended that you change your key.
[2014-09-20T17:46:24.646Z]  WARN: mq/33164 on dhcp-172-17-169-188.eduroam.wireless.private.cam.ac.uk:  (queueName=oae-preview-processor/generatePreviews)
    Error: Attempted to unbind listener from non-existant job queue. Ignoring
        at EventEmitter.module.exports.unsubscribeQueue (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/mq.js:508:52)
        at Object.module.exports.unbind (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/taskqueue.js:132:8)
        at module.exports.disable (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-preview-processor/lib/api.js:110:15)
        at EventEmitter.module.exports.refreshPreviewConfiguration (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-preview-processor/lib/api.js:153:5)
        at module.exports (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-preview-processor/lib/init.js:42:16)
        at initModule (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/modules.js:82:46)
        at /Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/modules.js:88:21
        at _createColumnFamilies (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/cassandra.js:330:16)
        at /Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/cassandra.js:338:9
        at /Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/cassandra.js:299:13
[2014-09-20T17:46:24.646Z]  INFO: oae-preview-processor/33164 on dhcp-172-17-169-188.eduroam.wireless.private.cam.ac.uk: Unbound the preview processor from the generate previews task queue.
[2014-09-20T17:46:24.647Z]  WARN: mq/33164 on dhcp-172-17-169-188.eduroam.wireless.private.cam.ac.uk:  (queueName=oae-preview-processor/regeneratePreviews)
    Error: Attempted to unbind listener from non-existant job queue. Ignoring
        at EventEmitter.module.exports.unsubscribeQueue (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/mq.js:508:52)
        at Object.module.exports.unbind (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/taskqueue.js:132:8)
        at /Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-preview-processor/lib/api.js:119:19
        at EventEmitter.module.exports.unsubscribeQueue (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/mq.js:509:16)
        at Object.module.exports.unbind (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/taskqueue.js:132:8)
        at module.exports.disable (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-preview-processor/lib/api.js:110:15)
        at EventEmitter.module.exports.refreshPreviewConfiguration (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-preview-processor/lib/api.js:153:5)
        at module.exports (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-preview-processor/lib/init.js:42:16)
        at initModule (/Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/modules.js:82:46)
        at /Users/sg555/projects/apereo/oae/Hilary/node_modules/oae-util/lib/modules.js:88:21
```

The first one should stay as it's pretty important. We could do the other ones when we remove the REST coupling from the preview processor.
