### PR TITLE
Fix hiredis to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "optionalDependencies": {
     "bunyan-syslog": "latest",
-    "hiredis": "0.1.13",
+    "hiredis": "latest",
     "webshot": "latest"
   },
   "bundleDependencies": [


### PR DESCRIPTION
As we’re no longer using SmartOS, we can use the latest version of `hiredis`. This allows us to install the dependency on OS X as well, which gets rid of some confusing `npm install` errors.
