### PR TITLE
Can't delete children by has_parent query on ElasticSearch 1.1.1

### DIFF
--- a/node_modules/oae-search/lib/api.js
+++ b/node_modules/oae-search/lib/api.js
@@ -582,13 +582,8 @@ var _handleDeleteDocumentTask = function(data, callback) {
                 'deleteType': 'query',
                 'documentType': documentType,
                 'query': {
-                    'has_parent': {
-                        'parent_type': SearchConstants.search.MAPPING_RESOURCE,
-                        'query': {
-                            'ids': {
-                                'values': [data.id]
-                            }
-                        }
+                    'term': {
+                        '_parent': data.id
                     }
                 }
             });
@@ -648,7 +643,8 @@ var _deleteAll = function(deletes, callback) {
     if (del.deleteType === 'id') {
         return client.del(del.documentType, del.id, _handleDocumentsDeleted);
     } else if (del.deleteType === 'query') {
-        return client.deleteByQuery(del.documentType, del.query, null, _handleDocumentsDeleted);
+        var query = {'query': del.query};
+        return client.deleteByQuery(del.documentType, query, null, _handleDocumentsDeleted);
     }
 };
 


### PR DESCRIPTION
The following can be found in the elasticsearch logs on 1.1.1 when deleting an item from the search index

```
Failed to execute [delete_by_query {[oaetest][resource_following], query [{"has_parent":{"parent_type":"resource","query":{"ids":{"values":["d:camtest:-ytmiLQsyE"]}}}}]}]
org.elasticsearch.index.query.QueryParsingException: [oaetest] request does not support [has_parent]
    at org.elasticsearch.index.query.IndexQueryParserService.parseQuery(IndexQueryParserService.java:311)
    at org.elasticsearch.index.shard.service.InternalIndexShard.prepareDeleteByQuery(InternalIndexShard.java:436)
    at org.elasticsearch.action.deletebyquery.TransportShardDeleteByQueryAction.shardOperationOnPrimary(TransportShardDeleteByQueryAction.java:122)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction.performOnPrimary(TransportShardReplicationOperationAction.java:556)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction$1.run(TransportShardReplicationOperationAction.java:426)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
[2014-09-26 12:34:48,982][DEBUG][action.deletebyquery     ] [Legacy] [oaetest][0], node[rxJIbgJxQBaOPHpTPZHwHg], [P], s[STARTED]: Failed to execute [delete_by_query {[oaetest][content_comment], query [{"has_parent":{"parent_type":"resource","query":{"ids":{"values":["d:camtest:-ytmiLQsyE"]}}}}]}]
org.elasticsearch.index.query.QueryParsingException: [oaetest] request does not support [has_parent]
    at org.elasticsearch.index.query.IndexQueryParserService.parseQuery(IndexQueryParserService.java:311)
    at org.elasticsearch.index.shard.service.InternalIndexShard.prepareDeleteByQuery(InternalIndexShard.java:436)
    at org.elasticsearch.action.deletebyquery.TransportShardDeleteByQueryAction.shardOperationOnPrimary(TransportShardDeleteByQueryAction.java:122)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction.performOnPrimary(TransportShardReplicationOperationAction.java:556)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction$1.run(TransportShardReplicationOperationAction.java:426)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
[2014-09-26 12:34:48,985][DEBUG][action.deletebyquery     ] [Legacy] [oaetest][0], node[rxJIbgJxQBaOPHpTPZHwHg], [P], s[STARTED]: Failed to execute [delete_by_query {[oaetest][resource_members], query [{"has_parent":{"parent_type":"resource","query":{"ids":{"values":["d:camtest:-ytmiLQsyE"]}}}}]}]
org.elasticsearch.index.query.QueryParsingException: [oaetest] request does not support [has_parent]
    at org.elasticsearch.index.query.IndexQueryParserService.parseQuery(IndexQueryParserService.java:311)
    at org.elasticsearch.index.shard.service.InternalIndexShard.prepareDeleteByQuery(InternalIndexShard.java:436)
    at org.elasticsearch.action.deletebyquery.TransportShardDeleteByQueryAction.shardOperationOnPrimary(TransportShardDeleteByQueryAction.java:122)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction.performOnPrimary(TransportShardReplicationOperationAction.java:556)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction$1.run(TransportShardReplicationOperationAction.java:426)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
[2014-09-26 12:34:48,989][DEBUG][action.deletebyquery     ] [Legacy] [oaetest][0], node[rxJIbgJxQBaOPHpTPZHwHg], [P], s[STARTED]: Failed to execute [delete_by_query {[oaetest][resource_memberships], query [{"has_parent":{"parent_type":"resource","query":{"ids":{"values":["d:camtest:-ytmiLQsyE"]}}}}]}]
org.elasticsearch.index.query.QueryParsingException: [oaetest] request does not support [has_parent]
    at org.elasticsearch.index.query.IndexQueryParserService.parseQuery(IndexQueryParserService.java:311)
    at org.elasticsearch.index.shard.service.InternalIndexShard.prepareDeleteByQuery(InternalIndexShard.java:436)
    at org.elasticsearch.action.deletebyquery.TransportShardDeleteByQueryAction.shardOperationOnPrimary(TransportShardDeleteByQueryAction.java:122)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction.performOnPrimary(TransportShardReplicationOperationAction.java:556)
    at org.elasticsearch.action.support.replication.TransportShardReplicationOperationAction$AsyncShardOperationAction$1.run(TransportShardReplicationOperationAction.java:426)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
```

See https://travis-ci.org/oaeproject/Hilary/builds/36351871 for a full log
