### PR TITLE
facebook api 2.0 breaks facebook auth

### DIFF
--- a/node_modules/oae-authentication/lib/strategies/facebook/init.js
+++ b/node_modules/oae-authentication/lib/strategies/facebook/init.js
@@ -46,12 +46,12 @@ module.exports = function() {
         var passportStrategy = new FacebookStrategy({
             'clientID': clientID,
             'clientSecret': clientSecret,
-            'profileFields': ['id', 'username', 'displayName', 'photos', 'emails'],
+            'profileFields': ['id', 'displayName', 'photos', 'emails'],
             'callbackURL': AuthenticationUtil.constructCallbackUrl(tenant, AuthenticationConstants.providers.FACEBOOK)
         }, function(accessToken, refreshToken, profile, done) {
             log().trace({'tenant': tenant, 'profile': profile}, 'Received Facebook authentication callback');
 
-            var externalId = profile.username;
+            var externalId = profile.id;
             var displayName = profile.displayName;
             var opts = {'locale': profile._json.locale};
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "optimist": "latest",
     "passport": "latest",
     "passport-cas": "git://github.com/oaeproject/passport-cas#samlValidateLoginUrl",
-    "passport-facebook": "latest",
+    "passport-facebook": "git://github.com/oaeproject/passport-facebook",
     "passport-google-oauth": "latest",
     "passport-http": "latest",
     "passport-http-bearer": "latest",


### PR DESCRIPTION
```
[2014-09-22T17:55:42.836Z] ERROR: oae-authentication/2093 on app0: An error occurred during login (host=stemincubator.oaeproject.org)
    FacebookGraphAPIError: (#12) username is deprecated for versions v2.0 and higher
     at /opt/oae/node_modules/passport-facebook/lib/strategy.js:167:21
     at passBackControl (/opt/oae/node_modules/oauth/lib/oauth2.js:124:9)
     at IncomingMessage.<anonymous> (/opt/oae/node_modules/oauth/lib/oauth2.js:143:7)
     at IncomingMessage.EventEmitter.emit (events.js:117:20)
     at _stream_readable.js:920:16
     at process._tickCallback (node.js:415:13)
```
