### PR TITLE
Handle OAE URLs within Markdown syntax

### DIFF
--- a/node_modules/oae-messagebox/lib/api.js
+++ b/node_modules/oae-messagebox/lib/api.js
@@ -57,11 +57,24 @@ var _replaceLinks = function(body) {
         return tenant.host;
     });
 
-    // Construct a regex that will find absolute OAE links in the body
-    var regex = new RegExp('https?://(' + hosts.join('|') + ')/([-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])', 'gi');
+    // Construct a regex that will find absolute OAE links in the body.
+    // Note that we have to treat urls that are already within a markdown
+    // link separately, so we capture any `)[` if it precedes the protocol.
+    var regex = new RegExp('(\\]\\()?https?://(' + hosts.join('|') + ')(/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])', 'gi');
 
     // Replace any matched URLs with relative links in markdown format
-    return body.replace(regex, '[/$2](/$2)');
+    return body.replace(regex, function(fullMatch, subMatch1, subMatch2, subMatch3) {
+        // If `)[` precedes the protocol, then link is already a markdown,
+        // so simply omit the protocol and host from the link
+        if (subMatch1 === '](') {
+            return subMatch1 + subMatch3;
+
+        // If the link isn't already markdown, convert it to markdown,
+        // leaving out the protocol and host
+        } else {
+            return '[' + subMatch3 + '](' + subMatch3 + ')';
+        }
+    });
 };
 
 /**

--- a/node_modules/oae-messagebox/tests/test-messagebox.js
+++ b/node_modules/oae-messagebox/tests/test-messagebox.js
@@ -162,7 +162,7 @@ describe('Messagebox', function() {
         /**
          * A test that verifies absolute link replacement in created messages.
          */
-        it('verify replacing absolute links in new message', function(callback) {
+        it('verify replacing bare, absolute OAE links in new message', function(callback) {
             var url = '/path/-Z9+&@#%=~_|!:,.;/file?query=parameter#hash';
             var messageBoxId = util.format('msg-box-test-%s', ShortId.generate());
             MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', 'URL: http://cambridge.oae.com' + url, {}, function(err, message) {
@@ -172,6 +172,24 @@ describe('Messagebox', function() {
                 MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                     assert.ok(!err);
                     verifyMessage(message.id, 'URL: [' + url + '](' + url + ')', null, messages);
+                    callback();
+                });
+            });
+        });
+
+        /**
+         * A test that verifies absolute link replacement within markdown in created messages.
+         */
+        it('verify replacing markdown-embedded absolute OAE links in new message', function(callback) {
+            var url = '/path/-Z9+&@#%=~_|!:,.;/file?query=parameter#hash';
+            var messageBoxId = util.format('msg-box-test-%s', ShortId.generate());
+            MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', '[URL](http://cambridge.oae.com' + url + ')', {}, function(err, message) {
+                assert.ok(!err);
+
+                // Verify the link was replaced
+                MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
+                    assert.ok(!err);
+                    verifyMessage(message.id, '[URL](' + url + ')', null, messages);
                     callback();
                 });
             });


### PR DESCRIPTION
Following up on issue #951, the relative link reformatting breaks if the OAE URL is already within a Markdown link.

So, for example, the following

```
[Tenant](http://test.oae.com:8080/path/to/file)
```

Incorrectly results in the markdown code:

```
[Tenant]([/path/to/file](/path/to/file))
```
