### PR TITLE
Collabdocs predating 8.0.0 preview images are blank

### DIFF
--- a/etc/migration/8.0-to-9.0/groupcreated.js
+++ b/etc/migration/8.0-to-9.0/groupcreated.js
@@ -1,3 +1,18 @@
+/*!
+ * Copyright 2014 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 var _ = require('underscore');
 
 var Cassandra = require('oae-util/lib/cassandra');

--- a/etc/migration/9.2-to-9.3/revisions-html.js
+++ b/etc/migration/9.2-to-9.3/revisions-html.js
@@ -57,14 +57,15 @@ OAE.init(config, function(err) {
 
 
 /**
- * Migrate a set of rows by adding a `created` timestamp to each (the timestamp will be when the row was
- * last written)
+ * Ensure that each collabdoc revision's `etherpadHtml` is wrapped in the
+ * proper html and body tags. Revisions that are not wrapped, will be updated
+ * and be queued for preview processing.
  *
  * @param  {Row[]}      rows        An array of cassandra rows to update
- * @param  {Function}   callback    A standard callback function
+ * @param  {Function}   callback    Standard callback function
  * @api private
  */
-var _migrateRows = function(rows, callback) {
+var _handleRows = function(rows, callback) {
     var queries = [];
     var toReprocess = [];
 
@@ -121,5 +122,5 @@ var _migrateRows = function(rows, callback) {
  */
 var migrate = function(callback) {
     log().info('Starting migration process, please be patient as this might take a while\nThe process will exit when the migration has been completed');
-    return Cassandra.iterateAll(['revisionId', 'contentId', 'etherpadHtml'], 'Revisions', 'revisionId', {'batchSize': 30}, _migrateRows, callback);
+    return Cassandra.iterateAll(['revisionId', 'contentId', 'etherpadHtml'], 'Revisions', 'revisionId', {'batchSize': 30}, _handleRows, callback);
 };


### PR DESCRIPTION
The following happens when processing a collabdoc:
- Get the content item's latest revision
- Get the document's html fragment from the latest revision.
  - Pre 8.0.0 this used to be a fragment (so no `<html><body>`)
  - In 8.0.0 we upgraded to the latest etherpad version where this html fragment is now a full blown html page
- Get the body of the html page, wrap it in our own html structure and write it to a temp file
- Process it through webshot

Now, all documents who haven't been touched since we upgraded etherpad will still have the old html fragment on their latest revision.

We probably want to put some logic in place that checks both of them and parses out the correct HTML fragment. We could do a point release, reprocess all collabdocs and then take out the code again.
