### PR TITLE
Wrong localization for added links

### DIFF
--- a/node_modules/oae-preview-processor/lib/processors/link/default.js
+++ b/node_modules/oae-preview-processor/lib/processors/link/default.js
@@ -18,15 +18,17 @@ var url = require('url');
 
 var log = require('oae-logger').logger('oae-preview-processor');
 var OaeUtil = require('oae-util/lib/util');
+var PrincipalsConfig = require('oae-config').config('oae-principals')
 
 var LinkProcessorUtil = require('oae-preview-processor/lib/processors/link/util');
 var webshot = require('oae-preview-processor/lib/internal/webshot');
 
-// The default timeouts. These will be overwritten on initialization with the values from ./config.js
-var timeouts = {
+// The default webshot options. These will be overwritten on initialization with the values from ./config.js
+var webshotOptions = {
     'renderDelay': 7500,
     'timeout': 30000,
-    'embeddableCheckTimeout': 15000
+    'embeddableCheckTimeout': 15000,
+    'customHeaders': {}
 };
 
 /**
@@ -41,10 +43,10 @@ var timeouts = {
  */
 var init = module.exports.init = function(_config, callback) {
     _config = _config || {};
-    timeouts.renderDelay = OaeUtil.getNumberParam(_config.renderDelay, timeouts.renderDelay);
-    timeouts.timeout = OaeUtil.getNumberParam(_config.renderTimeout, timeouts.timeout);
-    timeouts.embeddableCheckTimeout = OaeUtil.getNumberParam(_config.embeddableCheckTimeout, timeouts.embeddableCheckTimeout);
-    callback();
+    webshotOptions.renderDelay = OaeUtil.getNumberParam(_config.renderDelay, webshotOptions.renderDelay);
+    webshotOptions.timeout = OaeUtil.getNumberParam(_config.renderTimeout, webshotOptions.timeout);
+    webshotOptions.embeddableCheckTimeout = OaeUtil.getNumberParam(_config.embeddableCheckTimeout, webshotOptions.embeddableCheckTimeout);
+    return callback();
 };
 
 /**
@@ -72,10 +74,11 @@ var generatePreviews = module.exports.generatePreviews = function(ctx, contentOb
     var options = {
         'url': contentObj.link,
         'method': 'HEAD',
-        'timeout': timeouts.embeddableCheckTimeout,
+        'timeout': webshotOptions.embeddableCheckTimeout,
         'headers': {
             // Certain webservers will not send an `x-frame-options` header when no browser user agent is not specified
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36'
+            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.77 Safari/537.36',
+            'Accept-Language': PrincipalsConfig.getValue(contentObj.tenant.alias, 'user', 'defaultLanguage')
         }
     };
     request(options, function(err, response) {
@@ -106,7 +109,11 @@ var generatePreviews = module.exports.generatePreviews = function(ctx, contentOb
          */
         var generateThumbnail = function() {
             var path = ctx.baseDir + '/webshot.png';
-            webshot.getImage(contentObj.link, path, timeouts, function (err) {
+            // Try to localize the screenshot of the link to the default tenant's language
+            webshotOptions.customHeaders = {
+                'Accept-Language': PrincipalsConfig.getValue(contentObj.tenant.alias, 'user', 'defaultLanguage')
+            };
+            webshot.getImage(contentObj.link, path, webshotOptions, function (err) {
                 if (err) {
                     log().error({'err': err, 'contentId': ctx.contentId}, 'Could not generate an image');
                     return callback(err);
@@ -148,7 +155,7 @@ var _checkHttps = function(link, callback) {
     var options = {
         'url': link,
         'method': 'HEAD',
-        'timeout': timeouts.embeddableCheckTimeout
+        'timeout': webshotOptions.embeddableCheckTimeout
     };
     request(options, function(err, response) {
         if (err) {


### PR DESCRIPTION
I don't think there's a way to fix this reliably, so this issue can probably be closed right away, but maybe someone more clever than I has a solution.

If I upload a link (e.g. www.google.com) that I'm viewing (in English) on my browser, the preview image that's created is based on the IP geolocation of the OAE servers, so the link preview shows up in, e.g. German:

![screen shot 2014-10-16 at 9 58 46 am](https://cloud.githubusercontent.com/assets/1731910/4663538/956c8862-553c-11e4-89e1-d87a7ddbf138.png)
