### PR TITLE
Previews - folder visibility intermittent test failure

### DIFF
--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -310,7 +310,8 @@ describe('Preview processor', function() {
         _createContentAndWait('file', null, getImageStream, function(contentCreatorRestContext, content) {
             assert.equal(content.previews.status, 'done');
 
-            // Add the image to the folder
+            // Add the image to the folder. Do NOT use the FoldersTestUtil method as that purges
+            // the folder content library, which could cause intermittent test failures
             RestAPI.Folders.addContentItemsToFolder(restContext, folder.id, [content.id], function(err) {
                 assert.ok(!err);
 
@@ -1612,7 +1613,7 @@ describe('Preview processor', function() {
         });
 
         /**
-         * Test that verifies that folders are reprocessed when their visibililty changes
+         * Test that verifies that folders are reprocessed when their visibility changes
          */
         it('verify folders are reprocessed when their visibility changes', function(callback) {
             // Ignore this test if the PP is disabled
@@ -1631,8 +1632,10 @@ describe('Preview processor', function() {
                         // Create a folder to test with
                         FoldersTestUtil.assertCreateFolderSucceeds(restCtxPrivate, 'test displayName', 'test description', 'private', [], [], function(folder) {
 
-                            // Add the content items
-                            FoldersTestUtil.assertAddContentItemsToFolderSucceeds(restCtxPrivate, folder.id, [publicContent.id, privateContent.id], function() {
+                            // Add the content items. Do NOT use the FoldersTestUtil method as that purges
+                            // the folder content library, which could cause intermittent test failures
+                            RestAPI.Folders.addContentItemsToFolder(restCtxPrivate, folder.id, [publicContent.id, privateContent.id], function(err) {
+                                assert.ok(!err);
 
                                 // Wait until the folder has been processed
                                 MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_GENERATE_FOLDER_PREVIEWS, function() {
@@ -2300,8 +2303,10 @@ describe('Preview processor', function() {
                 // Create a folder to test with
                 FoldersTestUtil.assertCreateFolderSucceeds(user.restContext, 'test displayName', 'test description', 'public', [], [], function(folder) {
 
-                    // Add the content item to the folder
-                    FoldersTestUtil.assertAddContentItemsToFolderSucceeds(user.restContext, folder.id, [content.id], function() {
+                    // Add the content item to the folder. Do NOT use the FoldersTestUtil method as that purges
+                    // the folder content library, which could cause intermittent test failures
+                    RestAPI.Folders.addContentItemsToFolder(user.restContext, folder.id, [content.id], function(err) {
+                        assert.ok(!err);
 
                         // Purge all queues
                         PreviewTestUtil.purgePreviewsQueue(function(err) {


### PR DESCRIPTION
The test utility purges the folder content library and then triggers a
rebuild. However if the PP is running, a rebuild will (eventually) also be
triggered which intermittently cause issues. To avoid this, the test utility
should not be used in the preview processor tests
