### PR TITLE
Search results should favor users/groups that the current user is following/followed

### DIFF
--- a/node_modules/oae-search/lib/searches/general.js
+++ b/node_modules/oae-search/lib/searches/general.js
@@ -20,6 +20,7 @@ var AuthzConstants = require('oae-authz/lib/constants').AuthzConstants;
 var ContentConstants = require('oae-content/lib/constants').ContentConstants;
 var DiscussionsConstants = require('oae-discussions/lib/constants').DiscussionsConstants;
 var FoldersConstants = require('oae-folders/lib/constants').FoldersConstants;
+var FollowingConstants = require('oae-following/lib/constants').FollowingConstants;
 var OaeUtil = require('oae-util/lib/util');
 var Telemetry = require('oae-telemetry').telemetry('search-general');
 var TenantsAPI = require('oae-tenants');
@@ -103,6 +104,7 @@ var _createQuery = function(ctx, opts) {
     var hasContent = _includesResourceType(opts, 'content');
     var hasDiscussion = _includesResourceType(opts, 'discussion');
     var hasFolder = _includesResourceType(opts, 'folder');
+    var hasUser = _includesResourceType(opts, 'user');
 
     // If we will be including results that match child documents, we'll want to
     // boost the resource match to avoid the messages dominating resources
@@ -129,6 +131,11 @@ var _createQuery = function(ctx, opts) {
     // For folders, include their comments
     if (hasFolder) {
         query.bool.should.push(SearchUtil.createHasChildQuery(FoldersConstants.search.MAPPING_FOLDER_MESSAGE, SearchUtil.createQueryStringQuery(opts.q, ['body']), 'max'));
+    }
+
+    // For users, boost followed users
+    if (ctx.user() && hasUser) {
+        query.bool.should.push(SearchUtil.createHasChildQuery(FollowingConstants.search.MAPPING_RESOURCE_FOLLOWERS, SearchUtil.filterTerm('followers', ctx.user().id), 'max'));
     }
 
     return query;

--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -690,10 +690,10 @@ var createQueryStringQuery = module.exports.createQueryStringQuery = function(q,
  *
  * @param  {String}     type            The type of children.
  * @param  {Object}     childQuery      A Query object that will filter the children
- * @param  {String}     [scoreType]     The supported score types are max, sum, avg or none. If not specified, the score_type parameter won't be set in the query, so the query can be used in filters. If the score type is set to another value than none, the scores of all the matching child documents are aggregated into the associated parent documents.
+ * @param  {String}     [scoreMode]     The supported score modes are max, sum, avg or none. If not specified, the score_mode parameter won't be set in the query, so the query can be used in filters. If the score type is set to another value than none, the scores of all the matching child documents are aggregated into the associated parent documents.
  * @return {Object}                     A Query object that can be used in the query portion of the ElasticSearch Query DSL
  */
-var createHasChildQuery = module.exports.createHasChildQuery = function(type, childQuery, scoreType) {
+var createHasChildQuery = module.exports.createHasChildQuery = function(type, childQuery, scoreMode) {
     if (!childQuery) {
         return null;
     }
@@ -705,11 +705,11 @@ var createHasChildQuery = module.exports.createHasChildQuery = function(type, ch
         }
     };
 
-    // Because we can't use a has_child query with a scoreType in a filter,
-    // we only add the scoreType when it's been defined, so callers can specify
+    // Because we can't use a has_child query with a scoreMode in a filter,
+    // we only add the scoreMode when it's been defined, so callers can specify
     // when to add it
-    if (scoreType) {
-        query.has_child.score_type = scoreType;
+    if (scoreMode) {
+        query.has_child.score_mode = scoreMode;
     }
 
     return query;

--- a/node_modules/oae-search/tests/test-search-util.js
+++ b/node_modules/oae-search/tests/test-search-util.js
@@ -330,14 +330,14 @@ describe('Search Util', function() {
         it('verify creating a has_child query', function(callback) {
 
             // Ensure specifying no query string results in no query object
-            assert.ok(!SearchUtil.createHasChildQuery('type', null, 'scoreType'));
+            assert.ok(!SearchUtil.createHasChildQuery('type', null, 'scoreMode'));
 
-            var filter = SearchUtil.createHasChildQuery('type', 'childQuery', 'scoreType');
+            var filter = SearchUtil.createHasChildQuery('type', 'childQuery', 'scoreMode');
             assert.ok(filter.has_child);
 
             assert.equal(filter.has_child.type, 'type');
             assert.equal(filter.has_child.query, 'childQuery');
-            assert.equal(filter.has_child.score_type, 'scoreType');
+            assert.equal(filter.has_child.score_mode, 'scoreMode');
             return callback();
         });
     });


### PR DESCRIPTION
Seems like the search results should boost users and groups that the current user is following (or those that follow the current user). This would be especially helpful for the sharing auto-suggest, since users are likely to be following users with whom they wish to share content.

As a specific example, I'm following one user (Jonathan Whiting) on `oae.gatech.edu` and, not coincidentally, I expect to share a lot of content with him. When I want to share an item, however, just typing "Jonathan" in the auto-suggest isn't sufficient to load that user; instead, the auto-suggest items are "polluted" with dozens of other irrelevant (to me) "Jonathan"s from Marist.
