### PR TITLE
Configurable tenant landing pages bug

### DIFF
--- a/node_modules/oae-tenants/config/tenant.js
+++ b/node_modules/oae-tenants/config/tenant.js
@@ -76,7 +76,7 @@ var _createBlock = function(opts) {
         'name': 'Block values',
         'description': 'Block values',
         'elements': {
-            'type': new Fields.List('Block type', 'Block type', opts.type, [
+            'type': new Fields.List('Block type', 'Block type', type, [
                 {
                     'name': 'Empty',
                     'value': 'empty'
@@ -102,10 +102,10 @@ var _createBlock = function(opts) {
                     'value': 'video'
                 }
             ],  {'suppress': true}),
-            'xs': new Fields.List('XS Block width', 'Block width at extra small resolution', opts.xs, widths, {'suppress': true}),
-            'sm': new Fields.List('SM Block width', 'Block width at small resolution', opts.sm, widths, {'suppress': true}),
-            'md': new Fields.List('MD Block width', 'Block width at medium resolution', opts.md, widths, {'suppress': true}),
-            'lg': new Fields.List('LG Block width', 'Block width at large resolution', opts.lg, widths, {'suppress': true}),
+            'xs': new Fields.List('XS Block width', 'Block width at extra small resolution', xs, widths, {'suppress': true}),
+            'sm': new Fields.List('SM Block width', 'Block width at small resolution', sm, widths, {'suppress': true}),
+            'md': new Fields.List('MD Block width', 'Block width at medium resolution', md, widths, {'suppress': true}),
+            'lg': new Fields.List('LG Block width', 'Block width at large resolution', lg, widths, {'suppress': true}),
             'minHeight': new Fields.Text('Block minimum height', 'Minimum height for the block in px', opts.minHeight, {'suppress': true}),
             'bgColor': new Fields.Text('Block background color', 'Background color for the block', opts.bgColor, {'suppress': true}),
             'titleColor': new Fields.Text('Block title color', 'Title color for the block', opts.titleColor, {'suppress': true}),


### PR DESCRIPTION
```
The admin UI doesn't appear to work correctly for image blocks. At least I can't get it to persist. The block type always reverts to Empty.
```

When I switch an unused block (e.g. block 7) to an image block, it does indeed switch back to `Empty`
