### PR TITLE
Search - Boost the current tenant

### DIFF
--- a/node_modules/oae-search/lib/searches/general.js
+++ b/node_modules/oae-search/lib/searches/general.js
@@ -80,10 +80,29 @@ var _search = function(ctx, opts, callback) {
             return callback(err);
         }
 
+        // Create the filtered query
         var filter = SearchUtil.filterAnd(filterResources, filterScopeAndAccess);
+        var filteredQuery = SearchUtil.createFilteredQuery(query, filter);
+
+        // Give results from the current tenant a slight boost
+        var boostingQuery = {
+            'function_score': {
+                'score_mode': 'sum',
+                'boost_mode': 'sum',
+                'functions': [{
+                    'filter': {
+                        'term': {
+                            'tenantAlias': ctx.tenant().alias
+                        }
+                    },
+                    'boost_factor': 1.5
+                }],
+                'query': filteredQuery
+            }
+        };
 
         // Wrap the query and filter into the top-level Query DSL "query" object
-        return callback(null, SearchUtil.createQuery(query, filter, opts));
+        return callback(null, SearchUtil.createQuery(boostingQuery, null, opts));
     });
 };
 

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -29,6 +29,7 @@ describe('General Search', function() {
 
     // Rest context that can be used every time we need to make a request as an anonymous user
     var anonymousRestContext = null;
+    var anonymousGtRestContext = null;
     // Rest contexts that can be used every time we need to make a request as a tenant admin
     var camAdminRestContext = null;
     var gtAdminRestContext = null;
@@ -46,6 +47,7 @@ describe('General Search', function() {
     beforeEach(function(callback) {
         // Fill up anonymous rest context
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+        anonymousGtRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host);
         // Fill up tenant admin rest contexts
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
@@ -2439,6 +2441,61 @@ describe('General Search', function() {
                                 assert.ok(hadGroup);
                                 return callback();
                             });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Get the index of a user in a set of search results
+         *
+         * @param  {Object}     results     The search results as returend by `RestAPI.Search.search`
+         * @param  {String}     id          The user id to get the index for
+         * @return {Number}                 The index of the user in the search results array. Defaults to `-1` if the user could not be found
+         */
+        var indexOfDocument = function(results, id) {
+            for (var i = 0; i < results.results.length; i++) {
+                if (results.results[i].id === id) {
+                    return i;
+                }
+            }
+            return -1;
+        };
+
+        /**
+         * Test that verifies that documents from the same tenant are boosted
+         */
+        it('verify documents from the same tenant are boosted', function(callback) {
+            // Generate 2 identical users on 2 tenants
+            var username = TestsUtil.generateRandomText(1);
+            var displayName = TestsUtil.generateRandomText(2);
+            RestAPI.User.createUser(camAdminRestContext, username, 'password', displayName, null, function(err, camUser) {
+                assert.ok(!err);
+                RestAPI.User.createUser(gtAdminRestContext, username, 'password', displayName, null, function(err, gtUser) {
+                    assert.ok(!err);
+
+                    // When searching on the cambridge tenant, the user from the cambridge
+                    // tenant should appear before the user from the gt tenant
+                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': displayName, 'scope': '_all'}, function(err, results) {
+                        assert.ok(!err);
+                        var camDocIndex = indexOfDocument(results, camUser.id);
+                        var gtDocIndex = indexOfDocument(results, gtUser.id);
+                        assert.notStrictEqual(camDocIndex, -1);
+                        assert.notStrictEqual(gtDocIndex, -1);
+                        assert.ok(camDocIndex < gtDocIndex);
+
+                        // When searching on the gt tenant, the user from the gt
+                        // tenant should appear before the user from the cambridge tenant
+                        SearchTestsUtil.searchRefreshed(anonymousGtRestContext, 'general', null, {'q': displayName, 'scope': '_all'}, function(err, results) {
+                            assert.ok(!err);
+                            camDocIndex = indexOfDocument(results, camUser.id);
+                            gtDocIndex = indexOfDocument(results, gtUser.id);
+                            assert.notStrictEqual(camDocIndex, -1);
+                            assert.notStrictEqual(gtDocIndex, -1);
+                            assert.ok(gtDocIndex < camDocIndex);
+
+                            return callback();
                         });
                     });
                 });


### PR DESCRIPTION
This is a simple addition that boosts search results from the current tenant. I suppose we'll have to play with the boost factor. This impacts searches when sharing resources with users and the general search.