### PR TITLE
User search results ignore single characters

### DIFF
--- a/config.js
+++ b/config.js
@@ -193,6 +193,19 @@ config.search = {
                         'type': 'custom',
                         'tokenizer': 'letter',
                         'filter': ['lowercase', 'content_edgengram']
+                    },
+                    'display_name': {
+                        'type': 'custom',
+                        'tokenizer': 'display_name_tokenizer',
+                        'filter': ['lowercase']
+                    }
+                },
+                'tokenizer': {
+                    'display_name_tokenizer': {
+                        "type" : "edgeNGram",
+                        "min_gram" : "2",
+                        "max_gram" : "10",
+                        "token_chars": []
                     }
                 },
                 'filter': {

--- a/node_modules/oae-search/lib/schema/resourceSchema.js
+++ b/node_modules/oae-search/lib/schema/resourceSchema.js
@@ -76,7 +76,8 @@ module.exports = {
     'displayName': {
         'type': 'string',
         'store': 'yes',
-        'index': 'no'
+        'index': 'analyzed',
+        'analyzer': 'display_name'
     },
     'description': {
         'type': 'string',

--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -649,7 +649,7 @@ var filterExplicitAccess = module.exports.filterExplicitAccess = function(ctx, c
  */
 var createQueryStringQuery = module.exports.createQueryStringQuery = function(q, fields, boost) {
     if (_.isEmpty(fields)) {
-        fields = ['q_high^2.0', 'q_low^0.75'];
+        fields = ['displayName^3.0', 'q_high^2.0', 'q_low^0.75'];
     }
 
     var query = null;

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -2464,6 +2464,30 @@ describe('General Search', function() {
         };
 
         /**
+         * Test that verifies that displayName matches are boosted higher than other matches
+         */
+        it('verify displayName matches are boosted higher than other matches', function(callback) {
+            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon Gaeremynck', null, function(err, simonGaeremynck) {
+                assert.ok(!err);
+                RestAPI.User.createUser(gtAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon The Great', null, function(err, simonTheGreat) {
+                    assert.ok(!err);
+
+                    // When searching for 'Simon G', the 'Simon Gaeremynck' user should
+                    // appear before the 'Simon The Great' user
+                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': 'Simon G', 'scope': '_all'}, function(err, results) {
+                        assert.ok(!err);
+                        var simonGaeremynckIndex = indexOfDocument(results, simonGaeremynck.id);
+                        var simonTheGreatIndex = indexOfDocument(results, simonTheGreat.id);
+                        assert.notStrictEqual(simonGaeremynckIndex, -1);
+                        assert.notStrictEqual(simonTheGreatIndex, -1);
+                        assert.ok(simonGaeremynckIndex < simonTheGreatIndex);
+                        return callback();
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies that documents from the same tenant are boosted
          */
         it('verify documents from the same tenant are boosted', function(callback) {


### PR DESCRIPTION
This is likely for performance but hopefully it could be made slightly less restrictive. That would help those of us who often forget our colleagues' full names.

Only first name matched:

![](http://i.imgur.com/bD2lvFU.png)

Expected result one keystroke later:

![](http://i.imgur.com/O8moBTP.png)

This is somewhat related to #1078.