### PR TITLE
running oae-content tests in isolation fails

### DIFF
--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -906,6 +906,9 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
     // Force emails into debug mode
     config.email.debug = true;
 
+    // Set mail grace period to 0 so emails are sent immediately
+    config.activity.mail.gracePeriod = 0;
+
     // Disable mixpanel tracking
     config.mixpanel.enabled = false;
 


### PR DESCRIPTION
Running the full test suite succeeds, but running `grunt test-module:oae-content` fails:

    4 failing
    
    1) Content Activity Routes verify that publishing a collaborative document generates a notification:
       Uncaught AssertionError: 0 == 2
        at /home/stuart/src/hilary/node_modules/oae-content/tests/test-activity.js:411:48
        at /home/stuart/src/hilary/node_modules/oae-email/lib/test/util.js:105:32
        at allDone (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/email.js:201:20)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:119:16
        at _collectBuckets (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:138:16)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:149:16
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:215:28
        at /home/stuart/src/hilary/node_modules/redback/lib/advanced_structures/Lock.js:80:20
        at b (domain.js:183:18)
        at try_callback (/home/stuart/src/hilary/node_modules/redis/index.js:592:9)

    2) Content Activity Email verify content-comment email and privacy:
       Uncaught AssertionError: 0 == 1
        at /home/stuart/src/hilary/node_modules/oae-content/tests/test-activity.js:2239:44
        at /home/stuart/src/hilary/node_modules/oae-email/lib/test/util.js:105:32
        at allDone (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/email.js:201:20)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:119:16
        at _collectBuckets (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:138:16)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:149:16
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:215:28
        at /home/stuart/src/hilary/node_modules/redback/lib/advanced_structures/Lock.js:80:20
        at b (domain.js:183:18)
        at try_callback (/home/stuart/src/hilary/node_modules/redis/index.js:592:9)

    3) Content Activity Email verify content-create email and privacy:
       Uncaught AssertionError: 0 == 1
        at /home/stuart/src/hilary/node_modules/oae-content/tests/test-activity.js:2325:40
        at /home/stuart/src/hilary/node_modules/oae-email/lib/test/util.js:105:32
        at allDone (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/email.js:201:20)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:119:16
        at _collectBuckets (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:138:16)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:149:16
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:215:28
        at /home/stuart/src/hilary/node_modules/redback/lib/advanced_structures/Lock.js:80:20
        at b (domain.js:183:18)
        at try_callback (/home/stuart/src/hilary/node_modules/redis/index.js:592:9)

    4) Content Activity Email verify content-share email and privacy:
       Uncaught AssertionError: 0 == 1
        at /home/stuart/src/hilary/node_modules/oae-content/tests/test-activity.js:2394:48
        at /home/stuart/src/hilary/node_modules/oae-email/lib/test/util.js:105:32
        at allDone (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/email.js:201:20)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:119:16
        at _collectBuckets (/home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:138:16)
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:149:16
        at /home/stuart/src/hilary/node_modules/oae-activity/lib/internal/buckets.js:215:28
        at /home/stuart/src/hilary/node_modules/redback/lib/advanced_structures/Lock.js:80:20
        at b (domain.js:183:18)
        at try_callback (/home/stuart/src/hilary/node_modules/redis/index.js:592:9)