### PR TITLE
Introduce editor role for collaborative documents

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -762,33 +762,27 @@ var handlePublish = module.exports.handlePublish = function(data, callback) {
  */
 var joinCollabDoc = module.exports.joinCollabDoc = function(ctx, contentId, callback) {
     // Check if we have access to this piece of content.
-    canManage(ctx, contentId, function(err, canManage, contentObj) {
+    canEdit(ctx, contentId, function(err, canEdit, contentObj) {
         if (err) {
             return callback(err);
+        } else if (!canEdit) {
+            return callback({'code': 401, 'msg': 'You need to be a manager or editor of this piece of content to be able to join it'});
+        } else if (contentObj.resourceSubType !== 'collabdoc') {
+            return callback({'code': 400, 'msg': 'This is not a collaborative document'});
         }
 
-        canEdit(ctx, contentId, function(err, canEdit, contentObj) {
+        // Join the pad
+        Etherpad.joinPad(ctx, contentObj, function(err, data) {
             if (err) {
                 return callback(err);
-            } else if (!canManage && !canEdit) {
-                return callback({'code': 401, 'msg': 'You need to be a manager or editor of this piece of content to be able to join it'});
-            } else if (contentObj.resourceSubType !== 'collabdoc') {
-                return callback({'code': 400, 'msg': 'This is not a collaborative document'});
             }
 
-            // Join the pad
-            Etherpad.joinPad(ctx, contentObj, function(err, data) {
+            ContentDAO.Etherpad.saveAuthorId(data.author.authorID, ctx.user().id, function(err) {
                 if (err) {
                     return callback(err);
                 }
 
-                ContentDAO.Etherpad.saveAuthorId(data.author.authorID, ctx.user().id, function(err) {
-                    if (err) {
-                        return callback(err);
-                    }
-
-                    return callback(null, {'url': data.url});
-                });
+                return callback(null, {'url': data.url});
             });
         });
     });

--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -409,7 +409,7 @@ var _createFile = function(ctx, displayName, description, visibility, file, addi
  * @param  {String}         displayName             The display name of the collaborative document
  * @param  {String}         [description]           A longer description for the collaborative document
  * @param  {String}         [visibility]            The visibility of the collaborative document. One of `public`, `loggedin`, `private`
- * @param  {Object}         [additionalMembers]     Object where the keys represent principal ids that need to be added to the content upon creation and the values represent the role that principal will have. Possible values are "viewer" and "manager"
+ * @param  {Object}         [additionalMembers]     Object where the keys represent principal ids that need to be added to the content upon creation and the values represent the role that principal will have. Possible values are "viewer", "editor" and "manager"
  * @param  {String[]}       [folders]               The ids of the folders to which this collaborative document should be added
  * @param  {Function}       callback                Standard callback function
  * @param  {Object}         callback.err            An error that occurred, if any
@@ -452,7 +452,7 @@ var createCollabDoc = module.exports.createCollabDoc = function(ctx, displayName
  * @param  {String}         displayName             The display name of the content item
  * @param  {String}         [description]           A longer description for the content item
  * @param  {String}         visibility              The visibility of the collaborative document. One of `public`, `loggedin`, `private`
- * @param  {Object}         additionalMembers       Object where the keys represent principal ids that need to be added to the content upon creation and the values represent the role that principal will have. Possible values are "viewer" and "manager"
+ * @param  {Object}         additionalMembers       Object where the keys represent principal ids that need to be added to the content upon creation and the values represent the role that principal will have. Possible values are "viewer" and "manager", as well as "editor" for collabdocs
  * @param  {String}         folders                 The ids of the folders to which this content item should be added
  * @param  {Object}         otherValues             JSON object where the keys represent other metadata values that need to be stored, and the values represent the metadata values
  * @param  {Object}         revisionData            JSON object where the keys represent revision columns that need to be stored, and the values represent the revision values
@@ -765,24 +765,30 @@ var joinCollabDoc = module.exports.joinCollabDoc = function(ctx, contentId, call
     canManage(ctx, contentId, function(err, canManage, contentObj) {
         if (err) {
             return callback(err);
-        } else if (!canManage) {
-            return callback({'code': 401, 'msg': 'You need to be a manager of this piece of content to be able to join it'});
-        } else if (contentObj.resourceSubType !== 'collabdoc') {
-            return callback({'code': 400, 'msg': 'This is not a collaborative document'});
         }
 
-        // Join the pad
-        Etherpad.joinPad(ctx, contentObj, function(err, data) {
+        canEdit(ctx, contentId, function(err, canEdit, contentObj) {
             if (err) {
                 return callback(err);
+            } else if (!canManage && !canEdit) {
+                return callback({'code': 401, 'msg': 'You need to be a manager or editor of this piece of content to be able to join it'});
+            } else if (contentObj.resourceSubType !== 'collabdoc') {
+                return callback({'code': 400, 'msg': 'This is not a collaborative document'});
             }
 
-            ContentDAO.Etherpad.saveAuthorId(data.author.authorID, ctx.user().id, function(err) {
+            // Join the pad
+            Etherpad.joinPad(ctx, contentObj, function(err, data) {
                 if (err) {
                     return callback(err);
                 }
 
-                return callback(null, {'url': data.url});
+                ContentDAO.Etherpad.saveAuthorId(data.author.authorID, ctx.user().id, function(err) {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    return callback(null, {'url': data.url});
+                });
             });
         });
     });
@@ -988,6 +994,44 @@ var canManage = module.exports.canManage = function(ctx, contentId, callback) {
 };
 
 /**
+ * Check whether or not the current user can edit a piece of content
+ *
+ * @param  {Context}        ctx                 Standard context object containing the current user and the current tenant
+ * @param  {String}         contentId           The id of the content object we want to check
+ * @param  {Function}       callback            Standard callback function
+ * @param  {Object}         callback.err        An error that occurred, if any
+ * @param  {Boolean}        callback.canEdit    Whether or not the user can edit the content
+ * @param  {Content}        callback.content    The retrieved content object containing its basic profile
+ */
+var canEdit = module.exports.canEdit = function(ctx, contentId, callback) {
+    // Parameter validation
+    var validator = new Validator();
+    validator.check(contentId, {'code': 400, 'msg': 'A content id must be provided'}).isResourceId();
+    validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to manage content'}).isLoggedInUser(ctx);
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    getContent(ctx, contentId, function(err, contentObj) {
+        if (err) {
+            if (err.code === 401) {
+                return callback(null, false);
+            } else {
+                return callback(err);
+            }
+        }
+
+        ContentAuthz.canEditContent(ctx, contentObj, function(err, canEdit) {
+            if (err) {
+                return callback(err);
+            }
+
+            return callback(null, canEdit, contentObj);
+        });
+    });
+};
+
+/**
  * Update, add or remove the role of a set of principals on a piece of content
  *
  * @param  {Context}         ctx                 Standard context object containing the current user and the current tenant
@@ -1135,6 +1179,12 @@ var _checkNewContentPermissions = function(ctx, contentObj, newPermissions, call
  * @api private
  */
 var _setContentPermissions = function(ctx, contentObj, newPermissions, callback) {
+    // The `editor` role is only available on collabdocs
+    if (contentObj.resourceSubType !== 'collabdoc') {
+        newPermissions = _.omit(newPermissions, function(role, id) {
+            return role === 'editor';
+        });
+    }
     // Update the roles CF
     AuthzAPI.updateRoles(contentObj.id, newPermissions, function(err) {
         if (err) {

--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -944,9 +944,10 @@ var _canShareContent = function(ctx, contentObj, callback) {
                 if (err) {
                     callback(err);
                 }
-                return callback(null, _.some(roles, function(role) {
+                var _isEditorOrManager = _.some(roles, function(role) {
                     return _.contains([ContentConstants.roles.EDITOR, ContentConstants.roles.MANAGER], role);
-                }));
+                });
+                return callback(null, _isEditorOrManager);
             });
         }
 

--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -939,8 +939,15 @@ var _canShareContent = function(ctx, contentObj, callback) {
             // If we can interact with the item, we can always share it
             return callback(null, true);
         } else if (contentObj.visibility === AuthzConstants.visibility.PRIVATE) {
-            // If the content is private, we need to be a manager to share it
-            return AuthzAPI.hasRole(user.id, contentObj.id, ContentConstants.roles.MANAGER, callback);
+            // If the content is private, we need to be a manager or editor to share it
+            return AuthzAPI.getAllRoles(ctx.user().id, contentObj.id, function(err, roles) {
+                if (err) {
+                    callback(err);
+                }
+                return callback(null, _.some(roles, function(role) {
+                    return _.contains([ContentConstants.roles.EDITOR, ContentConstants.roles.MANAGER], role);
+                }));
+            });
         }
 
         // There is no implicit access and the content item is not private, so if we have any

--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -143,7 +143,7 @@ var getFullContentProfile = module.exports.getFullContentProfile = function(ctx,
 };
 
 /**
- * Add the `isManager` flag, `createdBy` user object, `canShare` flag and the `latestRevision` in case it's a collaborative document.
+ * Add the `isManager` flag, `createdBy` user object, `canShare` flag as well as `latestRevision` and `isEditor` in case it's a collaborative document.
  *
  * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
  * @param  {Content}    contentObj                  The content object to add the extra profile information on.
@@ -178,15 +178,23 @@ var _getFullContentProfile = function(ctx, contentObj, isManager, callback) {
                 return callback(null, contentObj);
             }
 
-            // If the content item is a collaborative document, add the latest revision data
+            // If the content item is a collaborative document, add the latest revision data and isEditor
             _getRevision(ctx, contentObj, contentObj.latestRevisionId, function(err, revision) {
                 if (err) {
                     return callback(err);
                 }
 
                 contentObj.latestRevision = revision;
-                ContentAPI.emit(ContentConstants.events.GET_CONTENT_PROFILE, ctx, contentObj);
-                return callback(null, contentObj);
+                ContentAuthz.canEditContent(ctx, contentObj, function(err, isEditor) {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    contentObj.isEditor = isEditor;
+
+                    ContentAPI.emit(ContentConstants.events.GET_CONTENT_PROFILE, ctx, contentObj);
+                    return callback(null, contentObj);
+                });
             });
         });
     });

--- a/node_modules/oae-content/lib/authz.js
+++ b/node_modules/oae-content/lib/authz.js
@@ -54,7 +54,14 @@ var canEditContent = module.exports.canEditContent = function(ctx, content, call
         return callback(null, true);
     }
 
-    return AuthzAPI.hasRole(ctx.user().id, content.id, ContentConstants.roles.EDITOR, callback);
+    return AuthzAPI.getAllRoles(ctx.user().id, content.id, function(err, roles) {
+        if (err) {
+            callback(err);
+        }
+        return callback(null, _.some(roles, function(role) {
+            return _.contains([ContentConstants.roles.EDITOR, ContentConstants.roles.MANAGER], role);
+        }));
+    });
 };
 
 /**

--- a/node_modules/oae-content/lib/authz.js
+++ b/node_modules/oae-content/lib/authz.js
@@ -39,6 +39,25 @@ var canManageContent = module.exports.canManageContent = function(ctx, content, 
 };
 
 /**
+ * Determine if the user invoking the current request is allowed to edit a given content item
+ *
+ * @param  {Context}        ctx                     Standard context object containing the current user and the current tenant
+ * @param  {Content}        content                 The content object we want to check
+ * @param  {Function}       callback                Standard callback function
+ * @param  {Object}         callback.err            An error that occurred, if any
+ * @param  {Boolean}        callback.canManage      Whether or not the user can edit the content item
+ */
+var canEditContent = module.exports.canEditContent = function(ctx, content, callback) {
+    if (!ctx.user()) {
+        return callback(null, false);
+    } else if (ctx.user().isAdmin(content.tenant.alias)) {
+        return callback(null, true);
+    }
+
+    return AuthzAPI.hasRole(ctx.user().id, content.id, ContentConstants.roles.EDITOR, callback);
+};
+
+/**
  * Determine if the current user has access to a piece of content. This function assumes that
  * the piece of content passed in actually exists
  *

--- a/node_modules/oae-content/lib/constants.js
+++ b/node_modules/oae-content/lib/constants.js
@@ -18,8 +18,9 @@ var ContentConstants = module.exports.ContentConstants = {};
 ContentConstants.roles = {
     // Determines not only all known roles, but the ordered priority they take as the "effective" role. (e.g., if
     // you are both a viewer and a manager, your effective role is "manager", so it must be later in the list)
-    'ALL_PRIORITY': ['viewer', 'manager'],
+    'ALL_PRIORITY': ['viewer', 'editor', 'manager'],
 
+    'EDITOR': 'editor',
     'MANAGER': 'manager',
     'VIEWER': 'viewer'
 };

--- a/node_modules/oae-content/lib/rest.js
+++ b/node_modules/oae-content/lib/rest.js
@@ -52,6 +52,7 @@ var _handleSignedDownload = function(req, res) {
  * @FormParam   {string}            resourceSubType     The content item type                                                                       [collabdoc]
  * @FormParam   {string}            [description]       A longer description for the collaborative document
  * @FormParam   {string[]}          [managers]          Unique identifier(s) for users and groups to add as managers of the collaborative document. The user creating the collaborative document will be added as a manager automatically
+ * @FormParam   {string[]}          [editors]           Unique identifier(s) for users and groups to add as editors of the collaborative document
  * @FormParam   {string[]}          [viewers]           Unique identifier(s) for users and groups to add as members of the collaborative document
  * @FormParam   {string[]}          [folders]           Unique identifier(s) for folders to which the collaborative document should be added
  * @FormParam   {string}            [visibility]        The visibility of the collaborative document. Defaults to the configured tenant default     [loggedin,private,public]
@@ -130,6 +131,7 @@ var _handleSignedDownload = function(req, res) {
 OAE.tenantRouter.on('post', '/api/content/create', function(req, res) {
     // Ensure proper arrays for the multi-value parameters
     req.body.managers = OaeUtil.toArray(req.body.managers);
+    req.body.editors = OaeUtil.toArray(req.body.editors);
     req.body.viewers = OaeUtil.toArray(req.body.viewers);
     req.body.folders = OaeUtil.toArray(req.body.folders);
 
@@ -138,6 +140,9 @@ OAE.tenantRouter.on('post', '/api/content/create', function(req, res) {
     var additionalMembers = {};
     _.each(req.body.managers, function(userId) {
         additionalMembers[userId] = ContentConstants.roles.MANAGER;
+    });
+    _.each(req.body.editors, function(userId) {
+        additionalMembers[userId] = ContentConstants.roles.EDITOR;
     });
     _.each(req.body.viewers, function(userId) {
         additionalMembers[userId] = ContentConstants.roles.VIEWER;
@@ -152,7 +157,7 @@ OAE.tenantRouter.on('post', '/api/content/create', function(req, res) {
             return res.send(err.code, err.msg);
         }
 
-        // Set the response type to text/plain for file uploads, as the UI uses an iFrame upload mechanism 
+        // Set the response type to text/plain for file uploads, as the UI uses an iFrame upload mechanism
         // to support IE9 file uploads. If the response type is not set to text/plain, IE9 will try to
         // download the response
         if (req.files && req.files.file) {
@@ -174,7 +179,7 @@ OAE.tenantRouter.on('post', '/api/content/create', function(req, res) {
  * @param  {String}         [link]                  The URL when creating a content item of resourceSubType `link`
  * @param  {File}           [uploadedFile]          The file object when creating a content item of resourceSubType `file`
  * @param  {String[]}       folderIds               The ids of folders where the content item should be added to
- * @param  {Object}         additionalMembers       Object where the keys represent principal ids that need to be added to the content upon creation and the values represent the role that principal will have. Possible values are "viewer" and "manager"
+ * @param  {Object}         additionalMembers       Object where the keys represent principal ids that need to be added to the content upon creation and the values represent the role that principal will have. Possible values are "viewer" and "manager", as well as "editor" for collabdocs
  * @param  {Function}       callback                Standard callback function
  * @param  {Object}         callback.err            An error object, if any
  * @param  {Content}        callback.content        The created content object

--- a/node_modules/oae-content/lib/test/util.js
+++ b/node_modules/oae-content/lib/test/util.js
@@ -461,7 +461,7 @@ var createCollabDoc = module.exports.createCollabDoc = function(adminRestContext
 
         // Create a collaborative document where all the users are managers
         var name = TestsUtil.generateTestUserId('collabdoc');
-        RestAPI.Content.createCollabDoc(userValues[0].restContext, name, 'description', 'public', userIds, [], [], function(err, contentObj) {
+        RestAPI.Content.createCollabDoc(userValues[0].restContext, name, 'description', 'public', userIds, [], [], [], function(err, contentObj) {
             assert.ok(!err);
 
             // Create a function that will get executed once each user has joined the document

--- a/node_modules/oae-content/tests/test-activity.js
+++ b/node_modules/oae-content/tests/test-activity.js
@@ -385,7 +385,7 @@ describe('Content Activity', function() {
                 assert.ok(!err);
 
                 // Create a collaborative document where both Simon and Branden are managers and Nico as a viewer
-                RestAPI.Content.createCollabDoc(simon.restContext, TestsUtil.generateTestUserId('collabdoc'), 'description', 'public', [branden.user.id], [nico.user.id], [], function(err, contentObj) {
+                RestAPI.Content.createCollabDoc(simon.restContext, TestsUtil.generateTestUserId('collabdoc'), 'description', 'public', [branden.user.id], [], [nico.user.id], [], function(err, contentObj) {
                     assert.ok(!err);
 
                     RestAPI.Content.joinCollabDoc(branden.restContext, contentObj.id, function(err, data) {

--- a/node_modules/oae-content/tests/test-collabdoc.js
+++ b/node_modules/oae-content/tests/test-collabdoc.js
@@ -80,7 +80,7 @@ describe('Collaborative documents', function() {
                 RestAPI.Content.joinCollabDoc(ctx, link.id, function(err) {
                     assert.equal(err.code, 400);
 
-                    RestAPI.Content.createCollabDoc(ctx, 'Test doc', 'description', 'private', [], [], [], function(err, contentObj) {
+                    RestAPI.Content.createCollabDoc(ctx, 'Test doc', 'description', 'private', [], [], [], [], function(err, contentObj) {
                         assert.ok(!err);
 
                         RestAPI.Content.joinCollabDoc(ctx, ' ', function(err) {
@@ -157,7 +157,7 @@ describe('Collaborative documents', function() {
 
             // Simon creates a collaborative document that's private
             var name = TestsUtil.generateTestUserId();
-            RestAPI.Content.createCollabDoc(simonCtx, name, 'description', 'private', [], [], [], function(err, contentObj) {
+            RestAPI.Content.createCollabDoc(simonCtx, name, 'description', 'private', [], [], [], [], function(err, contentObj) {
                 assert.ok(!err);
 
                 RestAPI.Content.joinCollabDoc(simonCtx, contentObj.id, function(err, data) {
@@ -428,11 +428,22 @@ describe('Collaborative documents', function() {
                         RestAPI.Content.restoreRevision(branden.restContext, contentObj.id, revisions.results[0].revisionId, function(err) {
                             assert.equal(err.code, 401);
 
-                            // Sanity check
-                            RestAPI.Content.getRevisions(simon.restContext, contentObj.id, null, null, function(err, revisions) {
+                            // Elevate Branden to an editor and verify that he still can't restore old versions
+                            var permissions = {};
+                            permissions[branden.user.id] = 'editor';
+                            RestAPI.Content.updateMembers(simon.restContext, contentObj.id, permissions, function(err) {
                                 assert.ok(!err);
-                                assert.equal(revisions.results.length, 2);
-                                return callback();
+
+                                RestAPI.Content.restoreRevision(branden.restContext, contentObj.id, revisions.results[0].revisionId, function(err) {
+                                    assert.equal(err.code, 401);
+
+                                    // Sanity check
+                                    RestAPI.Content.getRevisions(simon.restContext, contentObj.id, null, null, function(err, revisions) {
+                                        assert.ok(!err);
+                                        assert.equal(revisions.results.length, 2);
+                                        return callback();
+                                    });
+                                });
                             });
                         });
                     });
@@ -450,7 +461,7 @@ describe('Collaborative documents', function() {
             var simonCtx = _.values(users)[0].restContext;
 
             var name = TestsUtil.generateTestUserId('collabdoc');
-            RestAPI.Content.createCollabDoc(simonCtx, name, 'description', 'public', [], [], [], function(err, contentObj) {
+            RestAPI.Content.createCollabDoc(simonCtx, name, 'description', 'public', [], [], [], [], function(err, contentObj) {
                 assert.ok(!err);
 
                 // Try updating any of the etherpad properties

--- a/node_modules/oae-content/tests/test-collabdoc.js
+++ b/node_modules/oae-content/tests/test-collabdoc.js
@@ -146,13 +146,14 @@ describe('Collaborative documents', function() {
     });
 
     /**
-     * Test that verifies that you can only join a collaborative document if you have manager permissions
+     * Test that verifies that you can only join a collaborative document if you have manager or editor permissions
      */
     it('verify joining a pad respects the content permissions', function(callback) {
-        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
             assert.ok(!err);
             var simonCtx = _.values(users)[0].restContext;
             var brandenCtx = _.values(users)[1].restContext;
+            var stuartCtx = _.values(users)[2].restContext;
 
             // Simon creates a collaborative document that's private
             var name = TestsUtil.generateTestUserId();
@@ -188,7 +189,20 @@ describe('Collaborative documents', function() {
                                     RestAPI.Content.joinCollabDoc(brandenCtx, contentObj.id, function(err, data) {
                                         assert.ok(!err);
                                         assert.ok(data);
-                                        callback();
+
+                                        // Add Stuart as an editor, he should be able to join
+                                        members[_.keys(users)[2]] = 'editor';
+                                        RestAPI.Content.updateMembers(simonCtx, contentObj.id, members, function(err) {
+                                            assert.ok(!err);
+
+                                            // Stuart should now be able to access it
+                                            RestAPI.Content.joinCollabDoc(stuartCtx, contentObj.id, function(err, data) {
+                                                assert.ok(!err);
+                                                assert.ok(data);
+
+                                                callback();
+                                            });
+                                        });
                                     });
                                 });
                             });

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -2963,15 +2963,22 @@ describe('Content', function() {
                                     RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                                         assert.equal(err.code, 400);
 
-                                        // Sanity check
+                                        // The value `editor` is only valid on collabdocs
                                         permissions = {};
-                                        permissions[contexts['simon'].user.id] = 'manager';
+                                        permissions[contexts['simon'].user.id] = 'editor';
                                         RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
-                                            assert.ok(!err);
-                                            RestAPI.Content.updateContent(contexts['simon'].restContext, contentObj.id, {'displayName': 'Sweet stuff'}, function(err, updatedContentObj) {
+                                            assert.equal(err.code, 400);
+
+                                            // Sanity check
+                                            permissions = {};
+                                            permissions[contexts['simon'].user.id] = 'manager';
+                                            RestAPI.Content.updateMembers(contexts['nicolaas'].restContext, contentObj.id, permissions, function(err) {
                                                 assert.ok(!err);
-                                                assert.equal(updatedContentObj.displayName, 'Sweet stuff');
-                                                callback();
+                                                RestAPI.Content.updateContent(contexts['simon'].restContext, contentObj.id, {'displayName': 'Sweet stuff'}, function(err, updatedContentObj) {
+                                                    assert.ok(!err);
+                                                    assert.equal(updatedContentObj.displayName, 'Sweet stuff');
+                                                    callback();
+                                                });
                                             });
                                         });
                                     });

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -2755,7 +2755,7 @@ describe('Content', function() {
 
                     RestAPI.Content.deleteContent(contexts['nicolaas'].restContext, contentObj.id, function(err) {
                         assert.ok(!err);
-                        callback();
+                        return callback();
                     });
                 });
             });

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -1624,12 +1624,12 @@ describe('Content', function() {
         it('verify create collaborative document', function(callback) {
             setUpUsers(function(contexts) {
                 // Create one as anon user
-                RestAPI.Content.createCollabDoc(anonymousRestContext, 'Test Content 1', 'Test content description 1', 'public', [], [], [], function(err, contentObj) {
+                RestAPI.Content.createCollabDoc(anonymousRestContext, 'Test Content 1', 'Test content description 1', 'public', [], [], [], [], function(err, contentObj) {
                     assert.ok(err);
                     assert.ok(!contentObj);
 
                     // Create one with all required fields
-                    RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 2', 'Test content description 2', 'public', [], [], [], function(err, contentObj, response) {
+                    RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 2', 'Test content description 2', 'public', [], [], [], [], function(err, contentObj, response) {
                         assert.ok(!err);
                         assert.ok(contentObj.id);
 
@@ -1637,33 +1637,33 @@ describe('Content', function() {
                         assert.strictEqual(response.headers['content-type'], 'application/json');
 
                         // Create one without description
-                        RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 3', null, 'public', [], [], [], function(err, contentObj) {
+                        RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 3', null, 'public', [], [], [], [], function(err, contentObj) {
                             assert.ok(!err);
                             assert.ok(contentObj.id);
 
                             // Create one with a description that's longer than the allowed maximum size
                             var longDescription = TestsUtil.generateRandomText(1000);
-                            RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test content', longDescription, 'public', [], [], [], function(err, contentObj) {
+                            RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test content', longDescription, 'public', [], [], [], [], function(err, contentObj) {
                                 assert.ok(err);
                                 assert.equal(err.code, 400);
                                 assert.ok(err.msg.indexOf('10000') > 0);
                                 assert.ok(!contentObj);
 
                                 // Create one without title
-                                RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, null, 'Test content description 4', 'public', [], [], [], function(err, contentObj) {
+                                RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, null, 'Test content description 4', 'public', [], [], [], [], function(err, contentObj) {
                                     assert.ok(err);
                                     assert.ok(!contentObj);
 
                                     // Create one with a displayName that's longer than the allowed maximum size
                                     var longDisplayName = TestsUtil.generateRandomText(100);
-                                    RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, longDisplayName, 'descripton', 'public', [], [], [], function(err, contentObj) {
+                                    RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, longDisplayName, 'descripton', 'public', [], [], [], [], function(err, contentObj) {
                                         assert.ok(err);
                                         assert.equal(err.code, 400);
                                         assert.ok(err.msg.indexOf('1000') > 0);
                                         assert.ok(!contentObj);
 
                                         // Create one without permission
-                                        RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 5', 'Test content description 5', null, [], [], [], function(err, contentObj) {
+                                        RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 5', 'Test content description 5', null, [], [], [], [], function(err, contentObj) {
                                             assert.ok(!err);
                                             assert.ok(contentObj.id);
                                             // Check if the permission has been set to private (default)
@@ -1673,7 +1673,7 @@ describe('Content', function() {
                                                 assert.ok(!contentObj.downloadPath);
 
                                                 // Verify that an empty description is accepted
-                                                RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 5', '', 'public', [], [], [], function(err, contentObj) {
+                                                RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 5', '', 'public', [], [], [], [], function(err, contentObj) {
                                                     assert.ok(!err);
                                                     assert.ok(contentObj.id);
                                                     callback();
@@ -1826,7 +1826,7 @@ describe('Content', function() {
         it('verify create content with default members collaborative document', function(callback) {
             setUpUsers(function(contexts) {
                 // Create a private content item and share with 2 people
-                RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 2', 'Test content description 2', 'private', [contexts['simon'].user.id], [contexts['stuart'].user.id], [], function(err, contentObj) {
+                RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 2', 'Test content description 2', 'private', [contexts['simon'].user.id], [], [contexts['stuart'].user.id], [], function(err, contentObj) {
                     assert.ok(!err);
                     assert.ok(contentObj.id);
 
@@ -2246,7 +2246,7 @@ describe('Content', function() {
                         assert.ok(err);
                         assert.equal(err.code, 400);
 
-                        RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 1', 'Test content description 1', 'public', [], [], [], function(err, contentObj) {
+                        RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test Content 1', 'Test content description 1', 'public', [], [], [], [], function(err, contentObj) {
                             assert.ok(!err);
                             assert.ok(contentObj);
                             RestAPI.Content.updateContent(contexts['nicolaas'].restContext, contentObj.id, {'link': 'http://www.google.com'}, function(err, updatedContentObj) {
@@ -2743,6 +2743,24 @@ describe('Content', function() {
         });
     });
 
+    /**
+     * Verify collabdoc editors can't delete
+     */
+    it('verify collabdoc editors can\'t delete', function(callback) {
+        setUpUsers(function(contexts) {
+            RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test CollabDoc', 'Doc description', 'public', [], [contexts['stuart'].user.id], [], [], function(err, contentObj) {
+                assert.ok(!err);
+                RestAPI.Content.deleteContent(contexts['stuart'].restContext, contentObj.id, function(err) {
+                    assert.equal(err.code, 401);
+
+                    RestAPI.Content.deleteContent(contexts['nicolaas'].restContext, contentObj.id, function(err) {
+                        assert.ok(!err);
+                        callback();
+                    });
+                });
+            });
+        });
+    });
 
     describe('Content permissions', function() {
 
@@ -3125,6 +3143,23 @@ describe('Content', function() {
                                 return callback();
                             });
                         });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies collabdoc editors can't change permissions
+         */
+        it('verify collabdoc editors can\'t change permissions', function(callback) {
+            setUpUsers(function(contexts) {
+                RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test CollabDoc', 'Doc description', 'public', [], [contexts['stuart'].user.id], [], [], function(err, contentObj) {
+                    assert.ok(!err);
+                    var members = {};
+                    members[contexts['simon'].user.id] = 'viewer';
+                    // Editor can't add new members
+                    assertUpdateContentMembersFails(contexts['nicolaas'].restContext, contexts['stuart'].restContext, contentObj.id, members, 401, function() {
+                        callback();
                     });
                 });
             });

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -3149,17 +3149,17 @@ describe('Content', function() {
         });
 
         /**
-         * Test that verifies collabdoc editors can't change permissions
+         * Test that verifies collabdoc editors can't change permissions, but can share
          */
         it('verify collabdoc editors can\'t change permissions', function(callback) {
             setUpUsers(function(contexts) {
                 RestAPI.Content.createCollabDoc(contexts['nicolaas'].restContext, 'Test CollabDoc', 'Doc description', 'public', [], [contexts['stuart'].user.id], [], [], function(err, contentObj) {
                     assert.ok(!err);
                     var members = {};
-                    members[contexts['simon'].user.id] = 'viewer';
+                    members[contexts['anthony'].user.id] = 'viewer';
                     // Editor can't add new members
-                    assertUpdateContentMembersFails(contexts['nicolaas'].restContext, contexts['stuart'].restContext, contentObj.id, members, 401, function() {
-                        callback();
+                    ContentTestUtil.assertUpdateContentMembersFails(contexts['nicolaas'].restContext, contexts['stuart'].restContext, contentObj.id, members, 401, function() {
+                        ContentTestUtil.assertShareContentSucceeds(contexts['nicolaas'].restContext, contexts['stuart'].restContext, contentObj.id, _.keys(members), callback);
                     });
                 });
             });

--- a/node_modules/oae-folders/tests/test-folders.js
+++ b/node_modules/oae-folders/tests/test-folders.js
@@ -480,7 +480,7 @@ describe('Folders', function() {
                             FoldersTestUtil.assertUpdateFolderFails(nico.restContext, folder.id, {'visibility': 'private'}, 401, function() {
 
                                 // Tenant admins from other tenants cannot update the folder
-                                FoldersTestUtil.assertUpdateFolderFails(gtAdminRestContext, folder.id, {'visibility': 'private'}, 401, function() {                                
+                                FoldersTestUtil.assertUpdateFolderFails(gtAdminRestContext, folder.id, {'visibility': 'private'}, 401, function() {
 
                                     // Sanity check the folder was not updated
                                     FoldersTestUtil.assertGetFolderSucceeds(simong.restContext, folder.id, function(checkFolder) {
@@ -664,7 +664,7 @@ describe('Folders', function() {
                                     // Update the content items in the folder
                                     RestAPI.Folders.updateFolderContentVisibility(simong.restContext, folder.id, 'loggedin', function(err, data) {
                                         assert.ok(!err);
-                                    
+
                                         // Only 1 item should've failed
                                         assert.strictEqual(data.failedContent.length, 1);
                                         assert.strictEqual(data.failedContent[0].id, nicosLink.id);
@@ -2747,7 +2747,7 @@ describe('Folders', function() {
                     // Create some content and add it to the folders
                     RestAPI.Content.createLink(simong.restContext, 'test', 'test', 'public', 'http://www.google.ca', null, [], folderIds, function(err, link) {
                         assert.ok(!err);
-                        RestAPI.Content.createCollabDoc(simong.restContext, 'test', 'test', 'public', null, [], folderIds, function(err, collabDoc) {
+                        RestAPI.Content.createCollabDoc(simong.restContext, 'test', 'test', 'public', null, [], [], folderIds, function(err, collabDoc) {
                             assert.ok(!err);
                             RestAPI.Content.createFile(simong.restContext, 'test', 'test', 'public', _getFileStream, null, [], folderIds, function(err, file) {
                                 assert.ok(!err);

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -268,7 +268,7 @@ describe('Preview processor', function() {
                 } else if (resourceSubType === 'link') {
                     RestAPI.Content.createLink(restCtx, link, null, 'private', link,  [], [], [], contentCreated);
                 } else if (resourceSubType === 'collabdoc') {
-                    RestAPI.Content.createCollabDoc(restCtx, 'Test document', 'Test document', 'private', [], [], [], function(err, contentObj) {
+                    RestAPI.Content.createCollabDoc(restCtx, 'Test document', 'Test document', 'private', [], [], [], [], function(err, contentObj) {
                         assert.ok(!err);
                         RestAPI.Content.joinCollabDoc(restCtx, contentObj.id, function(err, data) {
                             assert.ok(!err);
@@ -1433,7 +1433,7 @@ describe('Preview processor', function() {
             TestsUtil.generateTestUsers(signedAdminRestContext, 1, function(err, response) {
                 assert.ok(!err);
                 var restCtx = _.values(response)[0].restContext;
-                RestAPI.Content.createCollabDoc(restCtx, 'Test document', 'Test document', 'private', [], [], [], function(err, contentObj) {
+                RestAPI.Content.createCollabDoc(restCtx, 'Test document', 'Test document', 'private', [], [], [], [], function(err, contentObj) {
                     assert.ok(!err);
 
                     // Wait till it has been processed.


### PR DESCRIPTION
A new role, `editor`, should be defined for collaborative documents only. People with the `editor` role should be able to edit the Etherpad document, but shouldn't be able to do any other management of the doc (delete, etc.).