### PR TITLE
Group profile should return creator's full profile instead of just id

### DIFF
--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -72,32 +72,39 @@ var getFullGroupProfile = module.exports.getFullGroupProfile = function(ctx, gro
             return callback(err);
         }
 
-        // Determine what roles, if any, the current user has on the group
-        _getAllRoles(ctx, groupId, function(err, roles) {
+        PrincipalsUtil.getPrincipal(ctx, group.createdBy, function(err, createdBy) {
             if (err) {
                 return callback(err);
             }
+            group.createdBy = createdBy;
 
-            var hasRole = (!_.isEmpty(roles));
-            if (!_canView(ctx, group, hasRole)) {
-                return callback({'code': 401, 'msg': 'You do not have access to this group'});
-            }
+            // Determine what roles, if any, the current user has on the group
+            _getAllRoles(ctx, groupId, function(err, roles) {
+                if (err) {
+                    return callback(err);
+                }
 
-            // A tenant or global administrator should be marked as a member and a manager
-            var isAdmin =  (ctx.user() && ctx.user().isAdmin(group.tenant.alias));
+                var hasRole = (!_.isEmpty(roles));
+                if (!_canView(ctx, group, hasRole)) {
+                    return callback({'code': 401, 'msg': 'You do not have access to this group'});
+                }
 
-            group.isMember = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MEMBER) || _.contains(roles, PrincipalsConstants.roles.MANAGER));
-            group.isManager = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MANAGER));
-            group.canJoin = _canJoin(ctx, group, hasRole);
+                // A tenant or global administrator should be marked as a member and a manager
+                var isAdmin =  (ctx.user() && ctx.user().isAdmin(group.tenant.alias));
 
-            if (group.isMember) {
-                // Generate a signature that can be used for push notifications
-                group.signature = Signature.createExpiringResourceSignature(ctx, groupId);
+                group.isMember = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MEMBER) || _.contains(roles, PrincipalsConstants.roles.MANAGER));
+                group.isManager = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MANAGER));
+                group.canJoin = _canJoin(ctx, group, hasRole);
 
-            }
+                if (group.isMember) {
+                    // Generate a signature that can be used for push notifications
+                    group.signature = Signature.createExpiringResourceSignature(ctx, groupId);
 
-            PrincipalsEmitter.emit(PrincipalsConstants.events.GET_GROUP_PROFILE, ctx, group);
-            return callback(null, group);
+                }
+
+                PrincipalsEmitter.emit(PrincipalsConstants.events.GET_GROUP_PROFILE, ctx, group);
+                return callback(null, group);
+            });
         });
     });
 };

--- a/node_modules/oae-principals/lib/restmodel.js
+++ b/node_modules/oae-principals/lib/restmodel.js
@@ -65,6 +65,7 @@
  *
  * @Required    [canJoin,displayName,id,isMember,isManager,joinable,lastModified,profilePath,resourceType,tenant,visibility]
  * @Property    {string}            canJoin                 Whether or not the current user can join the group
+ * @Property    {BasicUser}         createdBy               The user that created the group
  * @Property    {string}            description             The description for the group
  * @Property    {string}            displayName             The display name for the group
  * @Property    {string}            id                      The id of the group

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -366,7 +366,8 @@ describe('Groups', function() {
                         assert.equal(fetchedGroup.description, 'Group description');
                         assert.equal(fetchedGroup.visibility, 'private');
                         assert.equal(fetchedGroup.joinable, 'request');
-                        assert.equal(fetchedGroup.createdBy.substr(0, 10), 'u:camtest:');
+                        assert.equal(fetchedGroup.createdBy.id.substr(0, 10), 'u:camtest:');
+                        assert.equal(fetchedGroup.createdBy.displayName, 'John Doe');
                         assert.ok(fetchedGroup.created);
                         assert.equal(fetchedGroup.resourceType, 'group');
                         assert.equal(createdGroup.profilePath, '/group/' + createdGroup.tenant.alias + '/' + AuthzUtil.getResourceFromId(createdGroup.id).resourceId);


### PR DESCRIPTION
Translated from 3akai-ux issue https://github.com/oaeproject/3akai-ux/pull/3968

> There was a point in time where we modified all `getFullProfile` function to include the full user profile of the creator. However, that doesn't seem to be present for groups (anymore). The back-end code should be adjusted to include the full profile (e.g. `https://github.com/oaeproject/Hilary/blob/master/node_modules/oae-content/lib/api.js#L155`) and appropriate tests should be added. 
> 
> @sathomas : Can you create a Hilary ticket for this and either have a go at it yourself or assign to @stuartf ?

Also, we should update the swagger docs for `/api/group/{groupid}`

