### PR TITLE
internal links inside markdown pre/code shouldn't be re-written

### DIFF
--- a/node_modules/oae-messagebox/lib/api.js
+++ b/node_modules/oae-messagebox/lib/api.js
@@ -63,7 +63,16 @@ var _replaceLinks = function(body) {
     var regex = new RegExp('(.?)https?://(' + hosts.join('|') + ')(/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])(.?)', 'gi');
 
     // Replace any matched URLs with relative links in markdown format
-    return body.replace(regex, function(fullMatch, preURLChar, host, path, postURLChar) {
+    return body.replace(regex, function(fullMatch, preURLChar, host, path, postURLChar, offset) {
+        // If there are an odd number of backtics before the match it's inside a quote and should be left as is
+        var inQuote = body.substring(0, offset + 1).split('`').length % 2 === 0;
+        // If the line the match is on starts with 4 spaces it's a block quote and should be left as is
+        var inBlockQuote = body.substr(body.substring(0, offset + 1).lastIndexOf('\n') + 1, 4) === '    ';
+
+        if (inQuote || inBlockQuote) {
+            return fullMatch;
+        }
+
         // Check for a match in the title of a markdown link. Note that the target link
         // will be replaced in the next if clause
         if (preURLChar === '[' && postURLChar === ']') {

--- a/node_modules/oae-messagebox/lib/api.js
+++ b/node_modules/oae-messagebox/lib/api.js
@@ -66,8 +66,25 @@ var _replaceLinks = function(body) {
     return body.replace(regex, function(fullMatch, preURLChar, host, path, postURLChar, offset) {
         // If there are an odd number of backtics before the match it's inside a quote and should be left as is
         var inQuote = body.substring(0, offset + 1).split('`').length % 2 === 0;
-        // If the line the match is on starts with 4 spaces it's a block quote and should be left as is
-        var inBlockQuote = body.substr(body.substring(0, offset + 1).lastIndexOf('\n') + 1, 4) === '    ';
+        // If the line the match is on starts with 4 spaces and all preceding lines since the last blank line do too
+        // it's a block quote and should be left as is
+        var inBlockQuote = false;
+        var lineIndex = body.substring(0, offset + 1).lastIndexOf('\n');
+        // If the matched line starts with 4 spaces
+        if (body.substr(lineIndex + 1, 4) === '    ') {
+            var preMatchBody = body.substring(0, lineIndex + 1);
+            var lastParaIndex = preMatchBody.lastIndexOf('\n\n');
+            if (lastParaIndex !== -1) {
+                var lastParaLine = body.substring(0, lastParaIndex + 1).split('\n').length;
+                // Get just the lines between the last double linebreak and our match
+                var lines = preMatchBody.split('\n');
+                lines = lines.slice(lastParaLine, lines.length - 1);
+                // Check that all lines in this block start with 4 spaces
+                inBlockQuote = lines.length === 0 || _.every(lines, function(line) {
+                    return line.substring(0, 4) === '    ';
+                });
+            }
+        }
 
         if (inQuote || inBlockQuote) {
             return fullMatch;

--- a/node_modules/oae-messagebox/tests/test-messagebox.js
+++ b/node_modules/oae-messagebox/tests/test-messagebox.js
@@ -196,12 +196,13 @@ describe('Messagebox', function() {
                                     verifyMessage(messages[0].id, 'URLs: ' + markdownFullUrl + markdownFullUrl, null, messages);
 
                                     // Verify that quoted links aren't replaced
-                                    var quotedMarkdown = '`' + fullUrl + '` ` text ' + fullUrl + '`\n\n    ' + fullUrl + '\n    text ' + fullUrl;
+                                    var quotedMarkdown = '`' + fullUrl + '` ` text ' + fullUrl + '`\n    ' + fullUrl + '\n\n    ' + fullUrl + '\n    text ' + fullUrl;
                                     MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', quotedMarkdown, {}, function(err, message) {
                                         assert.ok(!err);
                                         MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                                             assert.ok(!err);
-                                            verifyMessage(messages[0].id, quotedMarkdown, null, messages);
+                                            var quotedExpected = '`' + fullUrl + '` ` text ' + fullUrl + '`\n    ' + markdownFullUrl + '\n\n    ' + fullUrl + '\n    text ' + fullUrl;
+                                            verifyMessage(messages[0].id, quotedExpected, null, messages);
                                             return callback();
                                         });
                                     });

--- a/node_modules/oae-messagebox/tests/test-messagebox.js
+++ b/node_modules/oae-messagebox/tests/test-messagebox.js
@@ -196,7 +196,7 @@ describe('Messagebox', function() {
                                     verifyMessage(messages[0].id, 'URLs: ' + markdownFullUrl + markdownFullUrl, null, messages);
 
                                     // Verify that quoted links aren't replaced
-                                    var quotedMarkdown = '`' + fullUrl + '` ` text ' + fullUrl + '`\n    ' + fullUrl + '\n    text ' + fullUrl;
+                                    var quotedMarkdown = '`' + fullUrl + '` ` text ' + fullUrl + '`\n\n    ' + fullUrl + '\n    text ' + fullUrl;
                                     MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', quotedMarkdown, {}, function(err, message) {
                                         assert.ok(!err);
                                         MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {

--- a/node_modules/oae-messagebox/tests/test-messagebox.js
+++ b/node_modules/oae-messagebox/tests/test-messagebox.js
@@ -195,7 +195,16 @@ describe('Messagebox', function() {
                                     var markdownFullUrl = '[' + url + '](' + url + ')';
                                     verifyMessage(messages[0].id, 'URLs: ' + markdownFullUrl + markdownFullUrl, null, messages);
 
-                                    return callback();
+                                    // Verify that quoted links aren't replaced
+                                    var quotedMarkdown = '`' + fullUrl + '` ` text ' + fullUrl + '`\n    ' + fullUrl + '\n    text ' + fullUrl;
+                                    MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', quotedMarkdown, {}, function(err, message) {
+                                        assert.ok(!err);
+                                        MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
+                                            assert.ok(!err);
+                                            verifyMessage(messages[0].id, quotedMarkdown, null, messages);
+                                            return callback();
+                                        });
+                                    });
                                 });
                             });
                         });


### PR DESCRIPTION
`oae-messagebox/lib/api.js` has a function `_replaceLinks` that gets run on message bodies and replaces absolute URLs to OAE tenants with relative links. If such a link is inside markdown backtics it should remain unmodified.