### PR TITLE
Add test specifically for document publish idempotency

### DIFF
--- a/node_modules/oae-content/tests/test-collabdoc.js
+++ b/node_modules/oae-content/tests/test-collabdoc.js
@@ -489,6 +489,48 @@ describe('Collaborative documents', function() {
     });
 
     /**
+     * Test that verifies that no new revisions are created when an etherpad document is published
+     * without change
+     */
+    it('verify publishing unchanged etherpad document results in no new revisions', function(callback) {
+        ContentTestUtil.createCollabDoc(camAdminRestContext, 1, 1, function(contentObj, users, simon) {
+
+            // Publish the document with no changes made to it
+            ContentTestUtil.publishCollabDoc(contentObj.id, simon.user.id, function() {
+
+                // Ensure it only has 1 revision, the initial one
+                RestAPI.Content.getRevisions(simon.restContext, contentObj.id, null, null, function(err, revisions) {
+                    assert.ok(!err);
+                    assert.equal(revisions.results.length, 1);
+
+                    // Generate a new revision with some new text in it
+                    editAndPublish(simon, contentObj, ['Some text'], function() {
+
+                        // Ensure we now have 2 revisions
+                        RestAPI.Content.getRevisions(simon.restContext, contentObj.id, null, null, function(err, revisions) {
+                            assert.ok(!err);
+                            assert.equal(revisions.results.length, 2);
+
+                            // Make the same edit and publish, ensuring that a new revision is not
+                            // created
+                            editAndPublish(simon, contentObj, ['Some text'], function() {
+
+                                // Ensure we still only have 2 revisions (1 empty, one with "Some
+                                // Text")
+                                RestAPI.Content.getRevisions(simon.restContext, contentObj.id, null, null, function(err, revisions) {
+                                    assert.ok(!err);
+                                    assert.equal(revisions.results.length, 2);
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    /**
      * Test that verifies that an empty revision can be restored
      */
     it('verify empty revisions can be restored', function(callback) {


### PR DESCRIPTION
There's a cryptic test that fails if you don't have your etherpad config text set to empty. This is a more descriptive test to fail in that case.