### PR TITLE
(Issue 1128) Use updated group timestamp to update libraries after join

### DIFF
--- a/node_modules/oae-library/lib/api.index.js
+++ b/node_modules/oae-library/lib/api.index.js
@@ -170,6 +170,14 @@ var update = module.exports.update = function(indexName, libraryVisibilities, re
         }
     };
 
+    log().trace({
+        'indexName': indexName,
+        'libraryVisibilities': libraryVisibilities,
+        'resourceId': resourceId,
+        'newRank': newRank,
+        'oldRank': oldRank
+    }, 'Updating resources in library buckets');
+
     updateCounter.incr();
 
     // What we will insert into the index
@@ -245,6 +253,13 @@ var remove = module.exports.remove = function(indexName, libraryIds, resourceId,
             }, 'Error removing resource from library');
         }
     };
+
+    log().trace({
+        'indexName': indexName,
+        'libraryIds': libraryIds,
+        'resourceId': resourceId,
+        'rank': rank
+    }, 'Removing resource for library indexes');
 
     updateCounter.incr();
 
@@ -338,6 +353,13 @@ var list = module.exports.list = function(indexName, libraryId, visibility, opts
                 };
             });
 
+            log().warn({
+                'indexName': indexName,
+                'libraryId': libraryId,
+                'visibility': visibiility,
+                'duplicateKeys': valueKeysToDelete
+            }, 'Removing duplicate keys from a library index');
+
             Cassandra.runBatchQuery(deleteQueries);
         }
 
@@ -361,6 +383,8 @@ var purge = module.exports.purge = function(indexName, libraryId, callback) {
             'parameters': [_createBucketKey(indexName, libraryId, visibility)]
         };
     });
+
+    log().trace({'indexName': indexName, 'libraryId': libraryId}, 'Purging library index');
 
     Cassandra.runBatchQuery(purgeIndexQueries, callback);
 };
@@ -412,13 +436,6 @@ var _query = function(indexName, libraryId, visibility, opts, callback) {
         internalLimit++;
     }
 
-    log().trace({
-        'indexName': indexName,
-        'libraryId': libraryId,
-        'visibility': visibility,
-        'opts': opts
-    }, 'Querying library index');
-
     // Query the items from cassandra
     var bucketKey = _createBucketKey(indexName, libraryId, visibility);
     Cassandra.runPagedQuery('LibraryIndex', 'bucketKey', bucketKey, 'rankedResourceId', opts.start, internalLimit, {'reversed': true}, function(err, rows, nextToken) {
@@ -441,6 +458,17 @@ var _query = function(indexName, libraryId, visibility, opts, callback) {
         }
 
         var result = _adjustColumnsForSlugs(opts.start, opts.limit, rows, nextToken);
+
+        log().trace({
+            'query': {
+                'indexName': indexName,
+                'libraryId': libraryId,
+                'visibility': visibility,
+                'opts': opts
+            },
+            'result': result
+        }, 'Queried library index');
+
         return callback(null, result.keys, result.nextToken);
     });
 };

--- a/node_modules/oae-library/lib/api.index.js
+++ b/node_modules/oae-library/lib/api.index.js
@@ -356,7 +356,7 @@ var list = module.exports.list = function(indexName, libraryId, visibility, opts
             log().warn({
                 'indexName': indexName,
                 'libraryId': libraryId,
-                'visibility': visibiility,
+                'visibility': visibility,
                 'duplicateKeys': valueKeysToDelete
             }, 'Removing duplicate keys from a library index');
 

--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -573,7 +573,7 @@ var joinGroup = module.exports.joinGroup = function(ctx, groupId, callback) {
 
                         // Apply the updated lastModified timestamp to the group storage object so
                         // library updates remain in sync
-                        //_.extend(group, updatedProfileFields);
+                        _.extend(group, updatedProfileFields);
 
                         // This will take care of updating the group in existing member libraries and inserting it into new member libraries
                         _touchMembershipLibraries(group, oldLastModified, newMemberIds.slice(), removedMemberIds.slice(), function(err) {

--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -269,7 +269,7 @@ var getMembershipsLibrary = module.exports.getMembershipsLibrary = function(ctx,
                 return callback({'code': 401, 'msg': 'You do not have access to this memberships library'});
             }
 
-            return _getMemberShipsLibrary(ctx, principalId, visibility, start, limit, callback);
+            return _getMembershipsLibrary(ctx, principalId, visibility, start, limit, callback);
         });
     });
 };
@@ -289,7 +289,7 @@ var getMembershipsLibrary = module.exports.getMembershipsLibrary = function(ctx,
  * @param  {String}      callback.nextToken      The value to provide in the `start` parameter to get the next set of results
  * @api private
  */
-var _getMemberShipsLibrary = function(ctx, principalId, visibility, start, limit, callback, _items) {
+var _getMembershipsLibrary = function(ctx, principalId, visibility, start, limit, callback, _items) {
     _items = _items || [];
 
     LibraryAPI.Index.list(PrincipalsConstants.library.MEMBERSHIPS_INDEX_NAME, principalId, visibility, {'start': start, 'limit': limit}, function(err, groupIds, nextToken) {
@@ -316,7 +316,7 @@ var _getMemberShipsLibrary = function(ctx, principalId, visibility, start, limit
             // If we don't have the required number of items yet and there is a next token,
             // we retrieve the next page
             if (_items.length < limit && nextToken) {
-                return _getMemberShipsLibrary(ctx, principalId, visibility, nextToken, limit, callback, _items);
+                return _getMembershipsLibrary(ctx, principalId, visibility, nextToken, limit, callback, _items);
 
             // Otherwise we can return back to the caller
             } else {
@@ -534,7 +534,7 @@ var joinGroup = module.exports.joinGroup = function(ctx, groupId, callback) {
         if (err) {
             return callback(err);
         } else if (hasAnyRole) {
-            return callback({'code': 400, 'msg': 'You are already a member of this group.'});
+            return callback({'code': 400, 'msg': 'You are already a member of this group'});
         }
 
         // Verify the group exists
@@ -542,7 +542,7 @@ var joinGroup = module.exports.joinGroup = function(ctx, groupId, callback) {
             if (err) {
                 return callback(err);
             } else if (!_canJoin(ctx, group, hasAnyRole)) {
-                return callback({'code': 401, 'msg': 'You cannot join this group.'});
+                return callback({'code': 401, 'msg': 'You cannot join this group'});
             }
 
             var changeMembers = {};
@@ -562,13 +562,18 @@ var joinGroup = module.exports.joinGroup = function(ctx, groupId, callback) {
                     // more recently
                     var oldLastModified = group.lastModified;
                     var newLastModified = Date.now().toString();
-                    PrincipalsDAO.updatePrincipal(group.id, {'lastModified': newLastModified}, function(err) {
+                    var updatedProfileFields = {'lastModified': newLastModified};
+                    PrincipalsDAO.updatePrincipal(group.id, updatedProfileFields, function(err) {
                         if (err) {
                             return log().error({
                                 'err': err,
                                 'group': group
                             }, 'An error has occurred while updating the group `lastModified` for member library updates after a group join');
                         }
+
+                        // Apply the updated lastModified timestamp to the group storage object so
+                        // library updates remain in sync
+                        //_.extend(group, updatedProfileFields);
 
                         // This will take care of updating the group in existing member libraries and inserting it into new member libraries
                         _touchMembershipLibraries(group, oldLastModified, newMemberIds.slice(), removedMemberIds.slice(), function(err) {
@@ -983,16 +988,16 @@ var _canManage = function(ctx, groupId, callback) {
  * @api private
  */
 var _touchMembershipLibraries = function(group, oldLastModified, newMemberIds, removedMemberIds, callback) {
-    // Get the ancestors of this group
-    _getAncestors(group, function(err, parentGroups) {
+    // Get the ancestors of this group. Since a user's membership library contains all indirect
+    // group memberships, we need to insert/update/remove all indirect group ancestors
+    _getAncestors(group, function(err, ancestorGroups) {
         if (err) {
             return callback(err);
         }
 
         // Create a set of groups that holds the group we changed and all its parents
-        var changedGroup = _.extend({}, group);
-        changedGroup.oldLastModified = oldLastModified;
-        var groups = parentGroups.concat(changedGroup);
+        var changedGroup = _.extend({}, group, {'oldLastModified': oldLastModified});
+        var groups = ancestorGroups.concat(changedGroup);
 
         // Insert the group (and its ancestors) into the membership libraries of the new members
         _insertMembershipsLibraries(groups, newMemberIds, function(err, explodedInsertedPrincipals) {
@@ -1000,16 +1005,17 @@ var _touchMembershipLibraries = function(group, oldLastModified, newMemberIds, r
                 return callback(err);
             }
 
-            // Remove the group (and its ancestors) from the membership libraries of the removed principals
+            // Remove the group (and its ancestors) from the membership libraries of the removed
+            // principals
             _removeMembershipsLibraries(removedMemberIds, groups, function(err) {
                 if (err) {
                     return callback(err);
                 }
 
-                // Update the membership libraries of all the other members of the changed group to ensure
-                // it shows at the top of their membership library
+                // Update the membership libraries of all the other members of the changed group to
+                // ensure it shows at the top of their membership library
                 if (oldLastModified) {
-                    _updateMembershipsLibraries(changedGroup, explodedInsertedPrincipals, callback);
+                    return _updateMembershipsLibraries(changedGroup, explodedInsertedPrincipals, callback);
                 } else {
                     return callback();
                 }
@@ -1057,7 +1063,8 @@ var _insertMembershipsLibraries = function(groups, newMemberIds, callback) {
                         'group': group
                     }, 'Unable to add a group to a principal\'s membership library');
                 }
-                done();
+
+                return done();
             });
         });
     });

--- a/node_modules/oae-principals/lib/test/util.js
+++ b/node_modules/oae-principals/lib/test/util.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var assert = require('assert');
 
 var ConfigTestsUtil = require('oae-config/lib/test/util');
+var Library = require('oae-library');
 var PrincipalsAPI = require('oae-principals');
 var RestAPI = require('oae-rest');
 var TestsUtil = require('oae-tests/lib/util');
@@ -192,5 +193,278 @@ var uploadAndCropPicture = module.exports.uploadAndCropPicture = function(restCt
             assert.ok(!err);
             return callback(uploadPicturePrincipal, cropPicturePrincipal);
         });
+    });
+};
+
+/**
+ * Attempt to join a group, ensuring it fails with the specified HTTP code
+ *
+ * @param  {RestContext}    userRestCtx     The REST context of the user to try and join the group
+ * @param  {String}         groupId         The id of the group to try and join
+ * @param  {Number}         httpCode        The expected HTTP code of the failure
+ * @param  {Function}       callback        Invoked when the join operation fails as expected
+ * @throws {AssertionError}                 Thrown if the join operation did not fail with the expected code
+ */
+var assertJoinGroupFails = module.exports.assertJoinGroupFails = function(userRestCtx, groupId, httpCode, callback) {
+    RestAPI.Group.joinGroup(userRestCtx, groupId, function(err) {
+        assert.ok(err);
+        assert.strictEqual(err.code, httpCode);
+        return callback();
+    });
+};
+
+/**
+ * Attempt to join a group, ensuring it succeeds. It will also verify standard expected results of
+ * joining a group, such as:
+ *
+ *  * The user gets added to the group members of the group
+ *  * The group gets added to the user's memberships library
+ *  * The group's lastModified property gets updated
+ *
+ * @param  {RestContext}    managerRestCtx  The REST context of a user who is a manager of the group
+ * @param  {RestContext}    userRestCtx     The REST context of the user who is to join the group
+ * @param  {String}         groupId         The id of the group to join
+ * @param  {Function}       callback        Invoked when the group has been joined as expected
+ * @throws {AssertionError}                 Thrown if the join is unsuccessful or the expected results of joining a group don't hold true
+ */
+var assertJoinGroupSucceeds = module.exports.assertJoinGroupSucceeds = function(managerRestCtx, userRestCtx, groupId, callback) {
+    // Get the user joining the group, we will need their id
+    RestAPI.User.getMe(userRestCtx, function(err, me) {
+        assert.ok(!err);
+
+        // Get the group. We will want to make sure its timestamp is updated
+        RestAPI.Group.getGroup(managerRestCtx, groupId, function(err, groupBefore) {
+            assert.ok(!err);
+
+            // Get the group members. We will want to make sure the user in context gets added to
+            // the list of members by adding them into the expected list of members
+            getAllGroupMembers(managerRestCtx, groupId, null, function(membersBefore) {
+                var expectedMemberIds =
+                    _.chain(membersBefore)
+                        .pluck('profile')
+                        .pluck('id')
+                        .value()
+                        .concat(me.id);
+
+                // Get the memberships. We will want to make sure the group gets added to the user's
+                // membership library by adding it to the expected list of memberships
+                getAllMembershipsLibrary(userRestCtx, me.id, null, function(membershipsBefore) {
+                    var expectedMembershipIds =
+                        _.chain(membershipsBefore)
+                            .pluck('id')
+                            .value()
+                            .concat(groupId);
+
+                    // Perform the actual join action, ensuring it reports successful
+                    RestAPI.Group.joinGroup(userRestCtx, groupId, function(err) {
+                        assert.ok(!err);
+
+                        // Joining a group leaves some asynchronous library index updates to happen,
+                        // wait for those to complete
+                        Library.Index.whenUpdatesComplete(function() {
+
+                            // Ensure the user is added to the group members
+                            assertGroupMembersEquals(managerRestCtx, groupId, expectedMemberIds, function() {
+
+                                // Ensure the group is added to the user memberships library
+                                assertMembershipsLibraryEquals(userRestCtx, me.id, expectedMembershipIds, function() {
+
+                                    // Ensure the group lastModified timestamp is updated
+                                    RestAPI.Group.getGroup(managerRestCtx, groupId, function(err, groupAfter) {
+                                        assert.ok(!err);
+                                        assert.ok(groupBefore.lastModified < groupAfter.lastModified);
+                                        return callback();
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+};
+
+/**
+ * Attempt to leave a group, ensuring that the operation fails with the given HTTP code
+ *
+ * @param  {RestContext}    userRestCtx     The REST context of the user who will try to leave the group
+ * @param  {String}         groupId         The id of the group to try and leave
+ * @param  {Number}         httpCode        The expected HTTP code of the failed leave operation
+ * @param  {Function}       callback        Invoked when the leave operation fails as expected
+ * @throws {AssertionError}                 Thrown if the leave operation does not fail as expected
+ */
+var assertLeaveGroupFails = module.exports.assertLeaveGroupFails = function(userRestCtx, groupId, httpCode, callback) {
+    RestAPI.Group.leaveGroup(userRestCtx, groupId, function(err) {
+        assert.ok(err);
+        assert.strictEqual(err.code, httpCode);
+        return callback();
+    });
+};
+
+/**
+ * Attempt to leave a group, ensuring it succeeds. It will also verify standard expected results of
+ * leaving a group, such as:
+ *
+ *  * The user gets removed from the group members of the group
+ *  * The group gets removed from the user's memberships library
+ *  * The group's lastModified property does not get updated
+ *
+ * @param  {RestContext}    managerRestCtx  The REST context of a user who is a manager of the group
+ * @param  {RestContext}    userRestCtx     The REST context of the user who is to join the group
+ * @param  {String}         groupId         The id of the group to join
+ * @param  {Function}       callback        Invoked when the group has been joined as expected
+ * @throws {AssertionError}                 Thrown if the join is unsuccessful or the expected results of joining a group don't hold true
+ */
+var assertLeaveGroupSucceeds = module.exports.assertLeaveGroupSucceeds = function(managerRestCtx, userRestCtx, groupId, callback) {
+    // Get the user leaving the group, we will need their id
+    RestAPI.User.getMe(userRestCtx, function(err, me) {
+        assert.ok(!err);
+
+        // Get the group, so we have a copy of its lastModified field before leaving
+        RestAPI.Group.getGroup(managerRestCtx, groupId, function(err, groupBefore) {
+            assert.ok(!err);
+
+            // Determine the expected members after leaving the group by removing it from the current
+            // set of members
+            getAllGroupMembers(managerRestCtx, groupId, null, function(membersBefore) {
+                var expectedMemberIdsAfter =
+                    _.chain(membersBefore)
+                        .pluck('profile')
+                        .pluck('id')
+                        .filter(function(memberBeforeId) {
+                            return memberBeforeId !== me.id;
+                        })
+                        .value();
+
+                // Determine the expected memberships after leaving the group by removing the group from
+                // the current set of memberships
+                getAllMembershipsLibrary(userRestCtx, me.id, null, function(membershipsBefore) {
+                    var expectedMembershipIdsAfter =
+                        _.chain(membershipsBefore)
+                            .pluck('id')
+                            .filter(function(membershipBeforeId) {
+                                return membershipBeforeId !== groupId;
+                            })
+                            .value();
+
+                    // Perform the actual leave action, ensuring it reports successful
+                    RestAPI.Group.leaveGroup(userRestCtx, groupId, function(err) {
+                        assert.ok(!err);
+
+                        // Ensure the members are what we expect
+                        assertGroupMembersEquals(managerRestCtx, groupId, expectedMemberIdsAfter, function() {
+
+                            // Ensure the memberships are what we expect
+                            assertMembershipsLibraryEquals(userRestCtx, me.id, expectedMembershipIdsAfter, function() {
+
+                                // Get the group after it has been left, ensuring that its lastModified
+                                // date hasn't been updated
+                                RestAPI.Group.getGroup(managerRestCtx, groupId, function(err, groupAfter) {
+                                    assert.ok(!err);
+                                    assert.strictEqual(groupBefore.lastModified, groupAfter.lastModified);
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+};
+
+/**
+ * Ensure that the group members listing of the group is the same as the provided expected member ids
+ *
+ * @param  {RestContext}    restCtx             The REST context of the user with which to check the group members
+ * @param  {String}         groupId             The id of the group whose members to check
+ * @param  {String[]}       expectedMemberIds   The ids of the members we expect to find in the group
+ * @param  {Function}       callback            Invoked when the members have been successfully validated
+ * @throws {AssertionError}                     Thrown if there is an issue getting the members or if they are not as expected
+ */
+var assertGroupMembersEquals = module.exports.assertGroupMembersEquals = function(restCtx, groupId, expectedMemberIds, callback) {
+    getAllGroupMembers(restCtx, groupId, null, function(members) {
+        // Pluck out the member ids, do not care about sorting
+        var actualMemberIds = _.chain(members).pluck('profile').pluck('id').value().sort();
+        assert.deepEqual(actualMemberIds, expectedMemberIds.sort());
+        return callback();
+    });
+};
+
+/**
+ * Ensure that the memberships library of the user is the same as the provided expected group ids
+ *
+ * @param  {RestContext}    restCtx                 The REST context of the user with which to check the memberships library
+ * @param  {String}         groupId                 The id of the user whose memberships library to check
+ * @param  {String[]}       expectedMembershipIds   The ids of the memberships we expect to find in the library
+ * @param  {Function}       callback                Invoked when the memberships have been successfully validated
+ * @throws {AssertionError}                         Thrown if there is an issue getting the memberships or if they are not as expected
+ */
+var assertMembershipsLibraryEquals = module.exports.getAllMembershipsLibrary = function(restCtx, userId, expectedMembershipIds, callback) {
+    getAllMembershipsLibrary(restCtx, userId, null, function(memberships) {
+        // Pluck out the membership ids, do not care about sorting
+        assert.deepEqual(_.pluck(memberships, 'id').sort(), expectedMembershipIds.sort());
+        return callback();
+    });
+};
+
+/**
+ * Get all items in a user's memberships library
+ *
+ * @param  {RestContext}    restCtx                 The context of the user with which to fetch the memberships library
+ * @param  {String}         userId                  The id of the user whose memberships library to fetch
+ * @param  {Object}         [opts]                  Optional flags for fetching the group memberships library
+ * @param  {Number}         [opts.batchSize]        The number of items to fetch per page when fetching the memberships library
+ * @param  {Function}       callback                Standard callback function
+ * @param  {Object[]}       callback.memberships    All membership entries in the memberships library of the user
+ * @param  {Object[]}       callback.responses      All raw responses that were receive when fetching the memberships library page by page
+ */
+var getAllMembershipsLibrary = module.exports.getAllMembershipsLibrary = function(restCtx, userId, opts, callback, _nextToken, _groupMemberships, _responses) {
+    opts = opts || {};
+    opts.batchSize = opts.batchSize || 12;
+    _groupMemberships = _groupMemberships || [];
+    _responses = _responses || [];
+    if (_nextToken === null) {
+        return callback(_groupMemberships, _responses);
+    }
+
+    // Get the current page of membership entries
+    RestAPI.Group.getMembershipsLibrary(restCtx, userId, _nextToken, opts.batchSize, function(err, response) {
+        assert.ok(!err);
+        _responses.concat(response);
+        _groupMemberships = _.union(_groupMemberships, response.results);
+        _nextToken = response.nextToken;
+        return getAllMembershipsLibrary(restCtx, userId, opts, callback, _nextToken, _groupMemberships, _responses);
+    });
+};
+
+/**
+ * Get all items in a group's members list
+ *
+ * @param  {RestContext}    restCtx                 The context of the user with which to fetch the members
+ * @param  {String}         groupId                 The id of the group whose members to fetch
+ * @param  {Object}         [opts]                  Optional flags for fetching the group members
+ * @param  {Number}         [opts.batchSize]        The number of members to fetch per page
+ * @param  {Function}       callback                Standard callback function
+ * @param  {Object[]}       callback.memberships    All members of the group
+ * @param  {Object[]}       callback.responses      All raw responses that were receive when fetching the members page by page
+ */
+var getAllGroupMembers = module.exports.getAllGroupMembers = function(restCtx, groupId, opts, callback, _nextToken, _members, _responses) {
+    opts = opts || {};
+    opts.batchSize = opts.batchSize || 12;
+    _members = _members || [];
+    _responses = _responses || [];
+    if (_nextToken === null) {
+        return callback(_members, _responses);
+    }
+
+    // Get the current page of group members
+    RestAPI.Group.getGroupMembers(restCtx, groupId, _nextToken, opts.batchSize, function(err, response) {
+        assert.ok(!err);
+        _responses.concat(response);
+        _members = _.union(_members, response.results);
+        _nextToken = response.nextToken;
+        return getAllGroupMembers(restCtx, groupId, opts, callback, _nextToken, _members, _responses);
     });
 };

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -810,7 +810,7 @@ describe('Groups', function() {
         it ('verify update non-existent group', function(callback) {
             var groupId = util.format('g:%s:%s', global.oaeTests.tenants.cam.alias, TestsUtil.generateTestGroupId());
             RestAPI.Group.updateGroup(johnRestContext, groupId, {'joinable': 'yes'}, function(err, updatedGroup) {
-                assert.equal(err.code, 404, JSON.stringify(err, null, 4));
+                assert.strictEqual(err.code, 404);
                 assert.ok(!updatedGroup);
                 callback();
             });
@@ -1932,35 +1932,22 @@ describe('Groups', function() {
                         assert.ok(!err);
 
                         // Verify cannot leave group of which I am not a member
-                        RestAPI.Group.leaveGroup(brandenRestContext, group.id, function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 400);
+                        PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, group.id, 400, function() {
 
-                            // Now join the group
-                            RestAPI.Group.joinGroup(brandenRestContext, group.id, function(err) {
-                                assert.ok(!err);
+                            // Now join the group and ensure it was successful
+                            PrincipalsTestUtil.assertJoinGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
 
-                                // Get the group after a join
+                                // Get the group state immediately after join so we can ensure the stability of its lastModified time
                                 RestAPI.Group.getGroup(jackRestContext, group.id, function(err, groupAfterJoin) {
-                                    assert.ok(!err);
-
-                                    // Ensure the lastModified timestamp has updated because of the join
-                                    assert.ok(groupAfterJoin.lastModified > group.lastModified);
 
                                     // Verify not a valid id
-                                    RestAPI.Group.leaveGroup(brandenRestContext, 'not-a-valid-id', function(err) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 400);
+                                    PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, 'not-a-valid-id', 400, function() {
 
                                         // Verify a non-group id
-                                        RestAPI.Group.leaveGroup(brandenRestContext, branden.id, function(err) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 400);
+                                        PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, branden.id, 400, function() {
 
                                             // Verify anonymous user cannot leave
-                                            RestAPI.Group.leaveGroup(anonymousRestContext, group.id, function(err) {
-                                                assert.ok(err);
-                                                assert.equal(err.code, 401);
+                                            PrincipalsTestUtil.assertLeaveGroupFails(anonymousRestContext, group.id, 401, function() {
 
                                                 // Verify branden is still a member
                                                 RestAPI.Group.getGroupMembers(brandenRestContext, group.id, null, 10000, function(err, members) {
@@ -1968,8 +1955,7 @@ describe('Groups', function() {
                                                     assert.equal(members.results.length, 2);
 
                                                     // Verify successful leave
-                                                    RestAPI.Group.leaveGroup(brandenRestContext, group.id, function(err) {
-                                                        assert.ok(!err);
+                                                    PrincipalsTestUtil.assertLeaveGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
 
                                                         RestAPI.Group.getGroup(jackRestContext, group.id, function(err, groupAfterLeave) {
                                                             assert.ok(!err);
@@ -1977,18 +1963,8 @@ describe('Groups', function() {
                                                             // Make sure the lastModified has not changed as a result of a leave
                                                             assert.equal(groupAfterJoin.lastModified, groupAfterLeave.lastModified);
 
-                                                            // Verify only jack is a member
-                                                            RestAPI.Group.getGroupMembers(brandenRestContext, group.id, null, 10000, function(err, members) {
-                                                                assert.ok(!err);
-                                                                assert.equal(members.results.length, 1);
-
-                                                                // Verify that the last manager can't leave
-                                                                RestAPI.Group.leaveGroup(jackRestContext, group.id, function(err) {
-                                                                    assert.ok(err);
-                                                                    assert.equal(err.code, 400);
-                                                                    callback();
-                                                                });
-                                                            });
+                                                            // Verify that the last manager can't leave
+                                                            PrincipalsTestUtil.assertLeaveGroupFails(jackRestContext, group.id, 400, callback);
                                                         });
                                                     });
                                                 });
@@ -2025,64 +2001,45 @@ describe('Groups', function() {
                         assert.ok(!err);
 
                         // Validate invalid group id
-                        RestAPI.Group.joinGroup(brandenRestContext, 'not-a-valid-id', function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 400);
+                        PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, 'not-a-valid-id', 400, function() {
 
                             // Validate non-group group id
-                            RestAPI.Group.joinGroup(brandenRestContext, branden.id, function(err) {
-                                assert.ok(err);
-                                assert.equal(err.code, 400);
+                            PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, branden.id, 400, function() {
 
                                 // Validate non-joinable group
-                                RestAPI.Group.joinGroup(brandenRestContext, group.id, function(err) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
+                                PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, group.id, 401, function() {
 
                                     // Make group joinable
                                     RestAPI.Group.updateGroup(jackRestContext, group.id, {'joinable': 'yes'}, function(err) {
                                         assert.ok(!err);
 
                                         // Join as anonymous and verify it still fails
-                                        RestAPI.Group.joinGroup(anonymousRestContext, group.id, function(err) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 401);
+                                        PrincipalsTestUtil.assertJoinGroupFails(anonymousRestContext, group.id, 401, function() {
 
                                             // Verify we still aren't a member
-                                            RestAPI.Group.getGroupMembers(jackRestContext, group.id, null, 10000, function(err, members) {
-                                                assert.ok(!err);
-                                                assert.equal(members.results.length, 1);
+                                            PrincipalsTestUtil.getAllGroupMembers(jackRestContext, group.id, null, function(members) {
+                                                assert.equal(members.length, 1);
 
                                                 // Join as branden, should finally work
-                                                RestAPI.Group.joinGroup(brandenRestContext, group.id, function(err) {
-                                                    assert.ok(!err);
+                                                PrincipalsTestUtil.assertJoinGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
 
-                                                    // Verify the user was added
-                                                    RestAPI.Group.getGroupMembers(jackRestContext, group.id, null, 10000, function(err, members) {
-                                                        assert.ok(!err);
-                                                        assert.equal(members.results.length, 2);
+                                                    // Verify jack cannot join, he is already manager
+                                                    PrincipalsTestUtil.assertJoinGroupFails(jackRestContext, group.id, 400, function() {
 
-                                                        // Verify jack cannot join, he is already manager
-                                                        RestAPI.Group.joinGroup(jackRestContext, group.id, function(err) {
-                                                            assert.ok(err);
-                                                            assert.equal(err.code, 400);
+                                                        // Verify he was not demoted to member
+                                                        PrincipalsTestUtil.getAllGroupMembers(jackRestContext, group.id, null, function(members) {
+                                                            assert.equal(members.length, 2);
 
-                                                            // Verify he was not demoted to member
-                                                            RestAPI.Group.getGroupMembers(jackRestContext, group.id, null, 10000, function(err, members) {
-                                                                assert.ok(!err);
-                                                                assert.equal(members.results.length, 2);
-
-                                                                var hadJack = false;
-                                                                _.each(members.results, function(result) {
-                                                                    if (result.profile.id === jack.id) {
-                                                                        hadJack = true;
-                                                                        assert.equal(result.role, 'manager');
-                                                                    }
-                                                                });
-
-                                                                assert.ok(hadJack);
-                                                                callback();
+                                                            var hadJack = false;
+                                                            _.each(members, function(result) {
+                                                                if (result.profile.id === jack.id) {
+                                                                    hadJack = true;
+                                                                    assert.equal(result.role, 'manager');
+                                                                }
                                                             });
+
+                                                            assert.ok(hadJack);
+                                                            return callback();
                                                         });
                                                     });
                                                 });
@@ -2324,7 +2281,7 @@ describe('Groups', function() {
                 var principalId = TestsUtil.generateTestUserId(identifier);
                 if (type === 'group') {
                     RestAPI.Group.createGroup(johnRestContext, metadata, metadata, 'public', 'yes', [], [], function(err, groupObj) {
-                        assert.ok(!err, JSON.stringify(err, null, 4));
+                        assert.ok(!err);
                         createdPrincipals[identifier] = groupObj;
                         if (_.keys(createdPrincipals).length === 12) {
                             callback(createdPrincipals);


### PR DESCRIPTION
Addresses #1128

The unit test refactoring I did to try and reproduce this issue properly catches it happening. So regression test is baked into the general leave group tests.