### PR TITLE
(Issue 1129) Ensure author can delete own message in a private discussion

### DIFF
--- a/node_modules/oae-discussions/lib/api.authz.js
+++ b/node_modules/oae-discussions/lib/api.authz.js
@@ -255,7 +255,7 @@ var canDeleteDiscussionMessage = module.exports.canDeleteDiscussionMessage = fun
             return callback(null, true);
         }
 
-        // It's not our message or we cannot interact and we are not manager, so we cannot delete
+        // It's not our message or we cannot interact and we are not a manager, so we cannot delete
         // this message
         return callback(null, false);
     });

--- a/node_modules/oae-discussions/lib/api.authz.js
+++ b/node_modules/oae-discussions/lib/api.authz.js
@@ -243,19 +243,21 @@ var canDeleteDiscussionMessage = module.exports.canDeleteDiscussionMessage = fun
         return callback(null, false);
     }
 
-    AuthzAPI.resolveImplicitRole(ctx, discussion.id, discussion.tenant.alias, discussion.visibility, DiscussionsConstants.roles.ALL_PRIORITY, function(err, implicitRole, canInteract) {
+    AuthzAPI.resolveEffectiveRole(ctx, discussion.id, discussion.tenant.alias, discussion.visibility, DiscussionsConstants.roles.ALL_PRIORITY, function(err, effectiveRole, canInteract) {
         if (err) {
             return callback(err);
-        } else if (implicitRole === DiscussionsConstants.roles.MANAGER) {
+        } else if (effectiveRole === DiscussionsConstants.roles.MANAGER) {
             // Managers can always delete messages
             return callback(null, true);
         } else if (canInteract && message.createdBy === user.id) {
-            // The user is still able to interact with this tenant, they can delete their own message
+            // So long as the user is still able to interact with this discussion, they can delete
+            // their own message
             return callback(null, true);
         }
 
-        // It's not our message, or we cannot implicitly interact. We need explicit manager access to delete the message
-        return AuthzAPI.hasRole(user.id, discussion.id, DiscussionsConstants.roles.MANAGER, callback);
+        // It's not our message or we cannot interact and we are not manager, so we cannot delete
+        // this message
+        return callback(null, false);
     });
 };
 

--- a/node_modules/oae-discussions/tests/test-discussions.js
+++ b/node_modules/oae-discussions/tests/test-discussions.js
@@ -2095,7 +2095,7 @@ describe('Discussions', function() {
     });
 
 
-    describe('Posting Messages', function() {
+    describe('Messages', function() {
 
         /**
          * Test that verifies input validation when creating a message
@@ -2668,36 +2668,37 @@ describe('Discussions', function() {
 
             DiscussionsTestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant, publicTenant1, privateTenant, privateTenant1) {
 
-                // Create message structure on the public discussion
-                RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.publicDiscussion.id, 'Message1 parent on public', null, function(err, publicMessage1) {
+                // Add a manager and member to the discussion
+                var updates = {};
+                updates[publicTenant.privateUser.user.id] = 'manager';
+                updates[publicTenant.loggedinUser.user.id] = 'member';
+                RestAPI.Discussions.updateDiscussionMembers(publicTenant.adminRestContext, publicTenant.privateDiscussion.id, updates, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.publicDiscussion.id, 'Message1 reply on public', publicMessage1.created, function(err, replyPublicMessage1) {
+                    // Create message structure on the public discussion
+                    RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, 'Message1 parent on public', null, function(err, publicMessage1) {
                         assert.ok(!err);
 
-                        RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.publicDiscussion.id, 'Message2 parent on public', null, function(err, publicMessage2) {
+                        RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, 'Message1 reply on public', publicMessage1.created, function(err, replyPublicMessage1) {
                             assert.ok(!err);
 
-                            // Add a manager to the discussion
-                            var updates = {};
-                            updates[publicTenant.privateUser.user.id] = 'manager';
-                            RestAPI.Discussions.updateDiscussionMembers(publicTenant.adminRestContext, publicTenant.publicDiscussion.id, updates, function(err) {
+                            RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, 'Message2 parent on public', null, function(err, publicMessage2) {
                                 assert.ok(!err);
 
                                 // Verify anonymous cannot delete a message
-                                RestAPI.Discussions.deleteMessage(publicTenant.anonymousRestContext, publicTenant.publicDiscussion.id, publicMessage1.created, function(err, message) {
+                                RestAPI.Discussions.deleteMessage(publicTenant.anonymousRestContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
                                     assert.ok(!message);
 
                                     // Verify non-manager, non-creator user can't delete a message
-                                    RestAPI.Discussions.deleteMessage(publicTenant.publicUser.restContext, publicTenant.publicDiscussion.id, publicMessage1.created, function(err, message) {
+                                    RestAPI.Discussions.deleteMessage(publicTenant.publicUser.restContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
                                         assert.ok(err);
                                         assert.equal(err.code, 401);
                                         assert.ok(!message);
 
                                         // Verify manager can delete, also verify the parent message is soft-deleted and its model
-                                        RestAPI.Discussions.deleteMessage(publicTenant.privateUser.restContext, publicTenant.publicDiscussion.id, publicMessage1.created, function(err, message) {
+                                        RestAPI.Discussions.deleteMessage(publicTenant.privateUser.restContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
                                             assert.ok(!err);
                                             assert.ok(message);
 
@@ -2714,7 +2715,7 @@ describe('Discussions', function() {
                                             assert.ok(!message.createdBy);
 
                                             // Ensure the deleted message is in the list of messages still, but deleted
-                                            RestAPI.Discussions.getMessages(publicTenant.privateUser.restContext, publicTenant.publicDiscussion.id, null, null, function(err, items) {
+                                            RestAPI.Discussions.getMessages(publicTenant.privateUser.restContext, publicTenant.privateDiscussion.id, null, null, function(err, items) {
                                                 assert.ok(!err);
                                                 assert.ok(items.results.length, 3);
 
@@ -2731,22 +2732,22 @@ describe('Discussions', function() {
                                                 assert.ok(!message.createdBy);
 
                                                 // Delete the rest of the messages to test hard-deletes. This also tests owner can delete
-                                                RestAPI.Discussions.deleteMessage(publicTenant.loggedinUser.restContext, publicTenant.publicDiscussion.id, replyPublicMessage1.created, function(err, message) {
+                                                RestAPI.Discussions.deleteMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, replyPublicMessage1.created, function(err, message) {
                                                     assert.ok(!err);
                                                     assert.ok(!message);
 
                                                     // We re-delete this one, but it should actually do a hard delete this time as there are no children
-                                                    RestAPI.Discussions.deleteMessage(publicTenant.loggedinUser.restContext, publicTenant.publicDiscussion.id, publicMessage1.created, function(err, message) {
+                                                    RestAPI.Discussions.deleteMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
                                                         assert.ok(!err);
                                                         assert.ok(!message);
 
                                                         // Perform a hard-delete on this leaf message. This also tests admin can delete
-                                                        RestAPI.Discussions.deleteMessage(publicTenant.adminRestContext, publicTenant.publicDiscussion.id, publicMessage2.created, function(err, message) {
+                                                        RestAPI.Discussions.deleteMessage(publicTenant.adminRestContext, publicTenant.privateDiscussion.id, publicMessage2.created, function(err, message) {
                                                             assert.ok(!err);
                                                             assert.ok(!message);
 
                                                             // Should be no more messages in the discussion as they should have all been de-indexed by hard deletes
-                                                            RestAPI.Discussions.getMessages(publicTenant.privateUser.restContext, publicTenant.publicDiscussion.id, null, null, function(err, items) {
+                                                            RestAPI.Discussions.getMessages(publicTenant.privateUser.restContext, publicTenant.privateDiscussion.id, null, null, function(err, items) {
                                                                 assert.ok(!err);
                                                                 assert.ok(items);
                                                                 assert.equal(items.results.length, 0);

--- a/node_modules/oae-discussions/tests/test-discussions.js
+++ b/node_modules/oae-discussions/tests/test-discussions.js
@@ -2661,98 +2661,102 @@ describe('Discussions', function() {
             });
         });
 
-        /**
-         * Test that verifies the logic of deleting messages, and the model and permissions for the operation
+        /*!
+         * Ensure that deleting messages works as expected with the given tenant, users and discussion
+         *
+         * @param  {Object}         tenant          The tenant info object for the tenant under which the test occurs
+         * @param  {Object}         managerUser     The user info object (as per DiscussionsTestsUtil#setupMultiTenantPrivacyEntities) for the user who will act as the manager of the discussion
+         * @param  {Object}         memberUser      The user info object (as per DiscussionsTestsUtil#setupMultiTenantPrivacyEntities) for the user who will act as the member of the discussion
+         * @param  {Object}         nonMemberUser   The user info object (as per DiscussionsTestsUtil#setupMultiTenantPrivacyEntities) for the user who will not be explicitly associated to the discussion, but will be authenticated to the tenant
+         * @param  {Discussion}     discussion      The discussion against which to create and delete messages, verifying the expected outcomes
+         * @param  {Function}       callback        Invoked when all assertions have passed
+         * @throws {AssertionError}                 Thrown if any of the assertions failed while creating and deleting messages
          */
-        it('verify deleting messages, model and permissions', function(callback) {
+        var _assertDeleteMessagePermissions = function(tenant, managerUser, memberUser, nonMemberUser, discussion, callback) {
+            // Add the manager and member users to the discussion
+            var updates = {};
+            updates[managerUser.user.id] = 'manager';
+            updates[memberUser.user.id] = 'member';
+            RestAPI.Discussions.updateDiscussionMembers(tenant.adminRestContext, discussion.id, updates, function(err) {
+                assert.ok(!err);
 
-            DiscussionsTestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant, publicTenant1, privateTenant, privateTenant1) {
-
-                // Add a manager and member to the discussion
-                var updates = {};
-                updates[publicTenant.privateUser.user.id] = 'manager';
-                updates[publicTenant.loggedinUser.user.id] = 'member';
-                RestAPI.Discussions.updateDiscussionMembers(publicTenant.adminRestContext, publicTenant.privateDiscussion.id, updates, function(err) {
+                // Create a message structure on the discussion
+                RestAPI.Discussions.createMessage(memberUser.restContext, discussion.id, 'Message1 parent on public', null, function(err, message1) {
                     assert.ok(!err);
 
-                    // Create message structure on the public discussion
-                    RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, 'Message1 parent on public', null, function(err, publicMessage1) {
+                    RestAPI.Discussions.createMessage(memberUser.restContext, discussion.id, 'Message1 reply on public', message1.created, function(err, replyMessage1) {
                         assert.ok(!err);
 
-                        RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, 'Message1 reply on public', publicMessage1.created, function(err, replyPublicMessage1) {
+                        RestAPI.Discussions.createMessage(memberUser.restContext, discussion.id, 'Message2 parent on public', null, function(err, message2) {
                             assert.ok(!err);
 
-                            RestAPI.Discussions.createMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, 'Message2 parent on public', null, function(err, publicMessage2) {
-                                assert.ok(!err);
+                            // Verify that anonymous cannot delete a message
+                            RestAPI.Discussions.deleteMessage(tenant.anonymousRestContext, discussion.id, message1.created, function(err, message) {
+                                assert.ok(err);
+                                assert.equal(err.code, 401);
+                                assert.ok(!message);
 
-                                // Verify anonymous cannot delete a message
-                                RestAPI.Discussions.deleteMessage(publicTenant.anonymousRestContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
+                                // Verify that a non-manager and non-creator user can't delete a message
+                                RestAPI.Discussions.deleteMessage(nonMemberUser.restContext, discussion.id, message1.created, function(err, message) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
                                     assert.ok(!message);
 
-                                    // Verify non-manager, non-creator user can't delete a message
-                                    RestAPI.Discussions.deleteMessage(publicTenant.publicUser.restContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 401);
-                                        assert.ok(!message);
+                                    // Verify that a manager can delete the message, also verify that the parent message is soft-deleted and its resulting model
+                                    RestAPI.Discussions.deleteMessage(managerUser.restContext, discussion.id, message1.created, function(err, message) {
+                                        assert.ok(!err);
+                                        assert.ok(message);
 
-                                        // Verify manager can delete, also verify the parent message is soft-deleted and its model
-                                        RestAPI.Discussions.deleteMessage(publicTenant.privateUser.restContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
+                                        // Ensure the deleted message model
+                                        assert.equal(message.id, message1.id);
+                                        assert.equal(message.messageBoxId, message1.messageBoxId);
+                                        assert.equal(message.threadKey, message1.threadKey);
+                                        assert.equal(message.created, message1.created);
+                                        assert.equal(message.replyTo, message1.replyTo);
+                                        assert.notEqual(parseInt(message.deleted, 10), NaN);
+                                        assert.ok(parseInt(message.deleted, 10) > parseInt(message.created, 10));
+                                        assert.strictEqual(message.level, message1.level);
+                                        assert.ok(!message.body);
+                                        assert.ok(!message.createdBy);
+
+                                        // Ensure the deleted message is in the list of messages still, but deleted
+                                        RestAPI.Discussions.getMessages(managerUser.restContext, discussion.id, null, null, function(err, items) {
                                             assert.ok(!err);
-                                            assert.ok(message);
+                                            assert.ok(items.results.length, 3);
 
-                                            // Ensure the deleted message model
-                                            assert.equal(message.id, publicMessage1.id);
-                                            assert.equal(message.messageBoxId, publicMessage1.messageBoxId);
-                                            assert.equal(message.threadKey, publicMessage1.threadKey);
-                                            assert.equal(message.created, publicMessage1.created);
-                                            assert.equal(message.replyTo, publicMessage1.replyTo);
+                                            var message = items.results[1];
+                                            assert.equal(message.id, message1.id);
+                                            assert.equal(message.messageBoxId, message1.messageBoxId);
+                                            assert.equal(message.threadKey, message1.threadKey);
+                                            assert.equal(message.created, message1.created);
+                                            assert.equal(message.replyTo, message1.replyTo);
                                             assert.notEqual(parseInt(message.deleted, 10), NaN);
                                             assert.ok(parseInt(message.deleted, 10) > parseInt(message.created, 10));
-                                            assert.strictEqual(message.level, publicMessage1.level);
+                                            assert.strictEqual(message.level, message1.level);
                                             assert.ok(!message.body);
                                             assert.ok(!message.createdBy);
 
-                                            // Ensure the deleted message is in the list of messages still, but deleted
-                                            RestAPI.Discussions.getMessages(publicTenant.privateUser.restContext, publicTenant.privateDiscussion.id, null, null, function(err, items) {
+                                            // Delete the rest of the messages to test hard-deletes. This also tests owner can delete
+                                            RestAPI.Discussions.deleteMessage(memberUser.restContext, discussion.id, replyMessage1.created, function(err, message) {
                                                 assert.ok(!err);
-                                                assert.ok(items.results.length, 3);
+                                                assert.ok(!message);
 
-                                                var message = items.results[1];
-                                                assert.equal(message.id, publicMessage1.id);
-                                                assert.equal(message.messageBoxId, publicMessage1.messageBoxId);
-                                                assert.equal(message.threadKey, publicMessage1.threadKey);
-                                                assert.equal(message.created, publicMessage1.created);
-                                                assert.equal(message.replyTo, publicMessage1.replyTo);
-                                                assert.notEqual(parseInt(message.deleted, 10), NaN);
-                                                assert.ok(parseInt(message.deleted, 10) > parseInt(message.created, 10));
-                                                assert.strictEqual(message.level, publicMessage1.level);
-                                                assert.ok(!message.body);
-                                                assert.ok(!message.createdBy);
-
-                                                // Delete the rest of the messages to test hard-deletes. This also tests owner can delete
-                                                RestAPI.Discussions.deleteMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, replyPublicMessage1.created, function(err, message) {
+                                                // We re-delete this one, but it should actually do a hard delete this time as there are no children
+                                                RestAPI.Discussions.deleteMessage(memberUser.restContext, discussion.id, message1.created, function(err, message) {
                                                     assert.ok(!err);
                                                     assert.ok(!message);
 
-                                                    // We re-delete this one, but it should actually do a hard delete this time as there are no children
-                                                    RestAPI.Discussions.deleteMessage(publicTenant.loggedinUser.restContext, publicTenant.privateDiscussion.id, publicMessage1.created, function(err, message) {
+                                                    // Perform a hard-delete on this leaf message. This also tests admin can delete
+                                                    RestAPI.Discussions.deleteMessage(tenant.adminRestContext, discussion.id, message2.created, function(err, message) {
                                                         assert.ok(!err);
                                                         assert.ok(!message);
 
-                                                        // Perform a hard-delete on this leaf message. This also tests admin can delete
-                                                        RestAPI.Discussions.deleteMessage(publicTenant.adminRestContext, publicTenant.privateDiscussion.id, publicMessage2.created, function(err, message) {
+                                                        // There should be no more messages in the discussion as they should have all been de-indexed by hard deletes
+                                                        RestAPI.Discussions.getMessages(managerUser.restContext, discussion.id, null, null, function(err, items) {
                                                             assert.ok(!err);
-                                                            assert.ok(!message);
-
-                                                            // Should be no more messages in the discussion as they should have all been de-indexed by hard deletes
-                                                            RestAPI.Discussions.getMessages(publicTenant.privateUser.restContext, publicTenant.privateDiscussion.id, null, null, function(err, items) {
-                                                                assert.ok(!err);
-                                                                assert.ok(items);
-                                                                assert.equal(items.results.length, 0);
-                                                                return callback();
-                                                            });
+                                                            assert.ok(items);
+                                                            assert.equal(items.results.length, 0);
+                                                            return callback();
                                                         });
                                                     });
                                                 });
@@ -2762,6 +2766,25 @@ describe('Discussions', function() {
                                 });
                             });
                         });
+                    });
+                });
+            });
+        };
+
+        /**
+         * Test that verifies the logic of deleting messages, and the model and permissions for the operation
+         */
+        it('verify deleting discussion messages, model and permissions', function(callback) {
+            DiscussionsTestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant, publicTenant1, privateTenant, privateTenant1) {
+
+                // Ensure permissions for deleting a message of a public discussion
+                _assertDeleteMessagePermissions(publicTenant, publicTenant.privateUser, publicTenant.loggedinUser, publicTenant.publicUser, publicTenant.publicDiscussion, function() {
+
+                    // Ensure permissions for deleting a message of a loggedin discussion
+                    _assertDeleteMessagePermissions(publicTenant, publicTenant.privateUser, publicTenant.loggedinUser, publicTenant.publicUser, publicTenant.loggedinDiscussion, function() {
+
+                        // Ensure permissions for deleting a message of a private discussion
+                        return _assertDeleteMessagePermissions(publicTenant, publicTenant.privateUser, publicTenant.loggedinUser, publicTenant.publicUser, publicTenant.privateDiscussion, callback);
                     });
                 });
             });

--- a/node_modules/oae-folders/lib/authz.js
+++ b/node_modules/oae-folders/lib/authz.js
@@ -407,19 +407,21 @@ var canDeleteFolderMessage = module.exports.canDeleteFolderMessage = function(ct
     }
 
     // Try to determine the implicit role of the current user on the folder
-    AuthzAPI.resolveImplicitRole(ctx, folder.groupId, folder.tenant.alias, folder.visibility, FoldersConstants.roles.ALL_PRIORITY, function(err, implicitRole, canInteract) {
+    AuthzAPI.resolveEffectiveRole(ctx, folder.groupId, folder.tenant.alias, folder.visibility, FoldersConstants.roles.ALL_PRIORITY, function(err, effectiveRole, canInteract) {
         if (err) {
             return callback(err);
-        } else if (implicitRole === FoldersConstants.roles.MANAGER) {
+        } else if (effectiveRole === FoldersConstants.roles.MANAGER) {
             // Managers can always delete messages
             return callback(null, true);
         } else if (canInteract && message.createdBy === user.id) {
-            // The user is still able to interact with this tenant, they can delete their own message
+            // So long as the user is still able to interact with this discussion, they can delete
+            // their own message
             return callback(null, true);
         }
 
-        // It's not our message, or we cannot implicitly interact. We need explicit manager access to delete the message
-        return AuthzAPI.hasRole(user.id, folder.groupId, FoldersConstants.roles.MANAGER, callback);
+        // It's not our message or we cannot interact and we are not manager, so we cannot delete
+        // this message
+        return callback(null, false);
     });
 };
 

--- a/node_modules/oae-folders/lib/authz.js
+++ b/node_modules/oae-folders/lib/authz.js
@@ -419,7 +419,7 @@ var canDeleteFolderMessage = module.exports.canDeleteFolderMessage = function(ct
             return callback(null, true);
         }
 
-        // It's not our message or we cannot interact and we are not manager, so we cannot delete
+        // It's not our message or we cannot interact and we are not a manager, so we cannot delete
         // this message
         return callback(null, false);
     });

--- a/node_modules/oae-folders/tests/test-messages.js
+++ b/node_modules/oae-folders/tests/test-messages.js
@@ -495,7 +495,7 @@ describe('Folders', function() {
 
                             // Unknown folder id
                             FoldersTestUtil.assertDeleteMessageFails(simong.restContext, 'f:foo:bar', message.created, 404, function() {
-                        
+
                                 // Validate invalid timestamp
                                 FoldersTestUtil.assertDeleteMessageFails(simong.restContext, folder.id, 'NaN', 400, function() {
                                     FoldersTestUtil.assertDeleteMessageFails(simong.restContext, folder.id, 'Not a created timestamp', 400, function() {
@@ -521,24 +521,25 @@ describe('Folders', function() {
 
             FoldersTestUtil.setupMultiTenantPrivacyEntities(function(publicTenant, publicTenant1, privateTenant, privateTenant1) {
 
-                // Create message structure on the public folder
-                FoldersTestUtil.assertCreateMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.publicFolder.id, 'Message1 parent on public', null, function(publicMessage1) {
-                    FoldersTestUtil.assertCreateMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.publicFolder.id, 'Message1 reply on public', publicMessage1.created, function(replyPublicMessage1) {
-                        FoldersTestUtil.assertCreateMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.publicFolder.id, 'Message2 parent on public', null, function(publicMessage2) {
+                // Add a manager to the folder
+                var updates = {};
+                updates[publicTenant.privateUser.user.id] = 'manager';
+                updates[publicTenant.loggedinUser.user.id] = 'viewer';
+                FoldersTestUtil.assertUpdateFolderMembersSucceeds(publicTenant.adminRestContext, publicTenant.privateFolder.id, updates, function() {
 
-                            // Add a manager to the folder
-                            var updates = {};
-                            updates[publicTenant.privateUser.user.id] = 'manager';
-                            FoldersTestUtil.assertUpdateFolderMembersSucceeds(publicTenant.adminRestContext, publicTenant.publicFolder.id, updates, function() {
+                    // Create message structure on the public folder
+                    FoldersTestUtil.assertCreateMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.privateFolder.id, 'Message1 parent on public', null, function(publicMessage1) {
+                        FoldersTestUtil.assertCreateMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.privateFolder.id, 'Message1 reply on public', publicMessage1.created, function(replyPublicMessage1) {
+                            FoldersTestUtil.assertCreateMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.privateFolder.id, 'Message2 parent on public', null, function(publicMessage2) {
 
                                 // Verify anonymous cannot delete a message
-                                FoldersTestUtil.assertDeleteMessageFails(publicTenant.anonymousRestContext, publicTenant.publicFolder.id, publicMessage1.created, 401, function() {
+                                FoldersTestUtil.assertDeleteMessageFails(publicTenant.anonymousRestContext, publicTenant.privateFolder.id, publicMessage1.created, 401, function() {
 
                                     // Verify non-manager, non-creator user can't delete a message
-                                    FoldersTestUtil.assertDeleteMessageFails(publicTenant.publicUser.restContext, publicTenant.publicFolder.id, publicMessage1.created, 401, function() {
+                                    FoldersTestUtil.assertDeleteMessageFails(publicTenant.publicUser.restContext, publicTenant.privateFolder.id, publicMessage1.created, 401, function() {
 
                                         // Verify manager can delete, also verify the parent message is soft-deleted and its model
-                                        FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.privateUser.restContext, publicTenant.publicFolder.id, publicMessage1.created, function(message) {
+                                        FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.privateUser.restContext, publicTenant.privateFolder.id, publicMessage1.created, function(message) {
 
                                             // Ensure the deleted message model
                                             assert.equal(message.id, publicMessage1.id);
@@ -553,7 +554,7 @@ describe('Folders', function() {
                                             assert.ok(!message.createdBy);
 
                                             // Ensure the deleted message is still in the list of messages, but marked as deleted
-                                            FoldersTestUtil.assertGetMessagesSucceeds(publicTenant.privateUser.restContext, publicTenant.publicFolder.id, null, null, function(items) {
+                                            FoldersTestUtil.assertGetMessagesSucceeds(publicTenant.privateUser.restContext, publicTenant.privateFolder.id, null, null, function(items) {
                                                 assert.ok(items.results.length, 3);
 
                                                 var message = items.results[1];
@@ -569,19 +570,19 @@ describe('Folders', function() {
                                                 assert.ok(!message.createdBy);
 
                                                 // Delete the rest of the messages to test hard-deletes. This also tests owner can delete
-                                                FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.publicFolder.id, replyPublicMessage1.created, function(message) {
+                                                FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.privateFolder.id, replyPublicMessage1.created, function(message) {
                                                     assert.ok(!message);
 
                                                     // We re-delete this one, but it should actually do a hard delete this time as there are no children
-                                                    FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.publicFolder.id, publicMessage1.created, function(message) {
+                                                    FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.loggedinUser.restContext, publicTenant.privateFolder.id, publicMessage1.created, function(message) {
                                                         assert.ok(!message);
 
                                                         // Perform a hard-delete on this leaf message. This also tests admin can delete
-                                                        FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.adminRestContext, publicTenant.publicFolder.id, publicMessage2.created, function(message) {
+                                                        FoldersTestUtil.assertDeleteMessageSucceeds(publicTenant.adminRestContext, publicTenant.privateFolder.id, publicMessage2.created, function(message) {
                                                             assert.ok(!message);
 
                                                             // Should be no more messages in the folder as they should have all been de-indexed by hard deletes
-                                                            FoldersTestUtil.assertGetMessagesSucceeds(publicTenant.privateUser.restContext, publicTenant.publicFolder.id, null, null, function(items) {
+                                                            FoldersTestUtil.assertGetMessagesSucceeds(publicTenant.privateUser.restContext, publicTenant.privateFolder.id, null, null, function(items) {
                                                                 assert.equal(items.results.length, 0);
                                                                 return callback();
                                                             });


### PR DESCRIPTION
... and folder

At the time of doing the "is creator" check, we didn't have a fully accurate `canInteract` check, only implicit. We need the explicit `canInteract` check at that time, therefore we may as well just do `getEffectiveRole`.