### PR TITLE
URGENT Group Home Page Blank

### DIFF
--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -72,39 +72,45 @@ var getFullGroupProfile = module.exports.getFullGroupProfile = function(ctx, gro
             return callback(err);
         }
 
-        PrincipalsUtil.getPrincipal(ctx, group.createdBy, function(err, createdBy) {
+        // Determine what roles, if any, the current user has on the group
+        _getAllRoles(ctx, groupId, function(err, roles) {
             if (err) {
                 return callback(err);
             }
-            group.createdBy = createdBy;
 
-            // Determine what roles, if any, the current user has on the group
-            _getAllRoles(ctx, groupId, function(err, roles) {
-                if (err) {
-                    return callback(err);
-                }
+            var hasRole = (!_.isEmpty(roles));
+            if (!_canView(ctx, group, hasRole)) {
+                return callback({'code': 401, 'msg': 'You do not have access to this group'});
+            }
 
-                var hasRole = (!_.isEmpty(roles));
-                if (!_canView(ctx, group, hasRole)) {
-                    return callback({'code': 401, 'msg': 'You do not have access to this group'});
-                }
+            // A tenant or global administrator should be marked as a member and a manager
+            var isAdmin =  (ctx.user() && ctx.user().isAdmin(group.tenant.alias));
 
-                // A tenant or global administrator should be marked as a member and a manager
-                var isAdmin =  (ctx.user() && ctx.user().isAdmin(group.tenant.alias));
+            group.isMember = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MEMBER) || _.contains(roles, PrincipalsConstants.roles.MANAGER));
+            group.isManager = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MANAGER));
+            group.canJoin = _canJoin(ctx, group, hasRole);
 
-                group.isMember = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MEMBER) || _.contains(roles, PrincipalsConstants.roles.MANAGER));
-                group.isManager = (isAdmin || _.contains(roles, PrincipalsConstants.roles.MANAGER));
-                group.canJoin = _canJoin(ctx, group, hasRole);
+            if (group.isMember) {
+                // Generate a signature that can be used for push notifications
+                group.signature = Signature.createExpiringResourceSignature(ctx, groupId);
 
-                if (group.isMember) {
-                    // Generate a signature that can be used for push notifications
-                    group.signature = Signature.createExpiringResourceSignature(ctx, groupId);
+            }
 
-                }
+            // Only fetch the group creator if there is one
+            if (group.createdBy) {
+                PrincipalsUtil.getPrincipal(ctx, group.createdBy, function(err, createdBy) {
+                    if (err) {
+                        return callback(err);
+                    }
+                    group.createdBy = createdBy;
 
+                    PrincipalsEmitter.emit(PrincipalsConstants.events.GET_GROUP_PROFILE, ctx, group);
+                    return callback(null, group);
+                });
+            } else {
                 PrincipalsEmitter.emit(PrincipalsConstants.events.GET_GROUP_PROFILE, ctx, group);
                 return callback(null, group);
-            });
+            }
         });
     });
 };

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -20,6 +20,7 @@ var util = require('util');
 
 var AuthzAPI = require('oae-authz');
 var AuthzUtil = require('oae-authz/lib/util');
+var Cassandra = require('oae-util/lib/cassandra');
 var Context = require('oae-context/lib/api').Context;
 var ConfigTestUtil = require('oae-config/lib/test/util');
 var FoldersTestUtil = require('oae-folders/lib/test/util');
@@ -381,7 +382,38 @@ describe('Groups', function() {
                         assert.ok(fetchedGroup.picture.small);
                         assert.ok(fetchedGroup.picture.medium);
                         assert.ok(fetchedGroup.picture.large);
-                        return callback();
+
+                        // Delete the group createdBy user and assert the group can still be retrieved
+                        Cassandra.runQuery('DELETE "createdBy" from "Principals" WHERE "principalId"=?', [fetchedGroup.id], function(err) {
+                            assert.ok(!err);
+
+                            // Get the group profile and verify its model
+                            RestAPI.Group.getGroup(johnRestContext, createdGroup.id, function(err, fetchedGroup) {
+                                assert.ok(!err);
+                                assert.ok(fetchedGroup.isMember);
+                                assert.ok(fetchedGroup.isManager);
+                                assert.equal(fetchedGroup.displayName, 'Group title');
+                                assert.equal(fetchedGroup.description, 'Group description');
+                                assert.equal(fetchedGroup.visibility, 'private');
+                                assert.equal(fetchedGroup.joinable, 'request');
+                                assert.ok(!fetchedGroup.createdBy);
+                                assert.ok(fetchedGroup.created);
+                                assert.equal(fetchedGroup.resourceType, 'group');
+                                assert.equal(createdGroup.profilePath, '/group/' + createdGroup.tenant.alias + '/' + AuthzUtil.getResourceFromId(createdGroup.id).resourceId);
+                                assert.ok(_.isObject(createdGroup.tenant));
+                                assert.equal(_.keys(fetchedGroup.tenant).length, 2);
+                                assert.equal(fetchedGroup.tenant.displayName, global.oaeTests.tenants.cam.displayName);
+                                assert.equal(fetchedGroup.tenant.alias, global.oaeTests.tenants.cam.alias);
+                                assert.ok(!fetchedGroup.picture.smallUri);
+                                assert.ok(!fetchedGroup.picture.mediumUri);
+                                assert.ok(!fetchedGroup.picture.largeUri);
+                                assert.ok(fetchedGroup.picture.small);
+                                assert.ok(fetchedGroup.picture.medium);
+                                assert.ok(fetchedGroup.picture.large);
+
+                                return callback();
+                            });
+                        });
                     });
                 });
             });


### PR DESCRIPTION
I've posted this ticket in the UX area as well, sorry, wasn't sure where to put it.

I've just been alerted to an issue with OAE group ins our main Marist OAE instance.  I've been able to replicate in on my computer (Windows 8.1 FireFox 36.0.1) but have not researched beyond this....

When you go to a Group site you get the outside frame of the page but not the activity feed or navigation.  A good example is: https://marist.oaeproject.org/group/marist/lyJ02SmQp

In addition to normal concerns over such things, we are using OAE for collaboration associated with the LAK conference and folks have critical documents in Groups that we cannot access.  Thus, there is significant concern here at the moment.

I'm going to post this via GitHub as well in a moment.

Josh