### PR TITLE
Intermittent test failure in folder processing

### DIFF
--- a/node_modules/oae-folders/lib/test/util.js
+++ b/node_modules/oae-folders/lib/test/util.js
@@ -24,6 +24,8 @@ var ContentTestUtil = require('oae-content/lib/test/util');
 var Context = require('oae-context').Context;
 var LibraryAPI = require('oae-library');
 var LibraryTestUtil = require('oae-library/lib/test/util');
+var MQTestUtil = require('oae-util/lib/test/mq-util');
+var PreviewConstants = require('oae-preview-processor/lib/constants');
 var PrincipalsAPI = require('oae-principals');
 var RestAPI = require('oae-rest');
 var SearchTestsUtil = require('oae-search/lib/test/util');
@@ -730,7 +732,7 @@ var assertRemoveFolderFromLibraryFails = module.exports.assertRemoveFolderFromLi
 var assertRemoveFolderFromLibrarySucceeds = module.exports.assertRemoveFolderFromLibrarySucceeds = function(restContext, principalId, folderId, callback) {
     RestAPI.Folders.removeFolderFromLibrary(restContext, principalId, folderId, function(err, result) {
         assert.ok(!err);
-        
+
         // Assert that the folder really was removed
         assertGetFoldersLibrarySucceeds(restContext, principalId, null, null, function(folders) {
             var folder = _.findWhere(folders, {'id': folderId});
@@ -1431,9 +1433,16 @@ var _purgeFoldersLibraries = function(principalIds, callback) {
  * @api private
  */
 var _purgeFolderContentLibrary = function(folderId, callback) {
-    FoldersDAO.getFoldersByIds([folderId], function(err, folders) {
-        assert.ok(!err);
-        return LibraryTestUtil.assertPurgeFreshLibraries(FoldersConstants.library.CONTENT_LIBRARY_INDEX_NAME, [_.first(folders).groupId], callback);
+    // Before proceeding, we wait till the folder has been processed by the preview processor. We do this as the PP
+    // needs the folder's content library to generate a thumbnail and we clear it out a few lines lower. If we weren't
+    // to wait here, the PP might try to generate a thumbnail for a (temporarily) empty folder library. Note that this
+    // shouldn't result in slower (non-PP) tests as the PP won't be bound to the folder generate queue thus
+    // `whenTasksEmpty` will return immediately
+    MQTestUtil.whenTasksEmpty(PreviewConstants.MQ.TASK_GENERATE_FOLDER_PREVIEWS, function() {
+        FoldersDAO.getFoldersByIds([folderId], function(err, folders) {
+            assert.ok(!err);
+            return LibraryTestUtil.assertPurgeFreshLibraries(FoldersConstants.library.CONTENT_LIBRARY_INDEX_NAME, [_.first(folders).groupId], callback);
+        });
     });
 };
 

--- a/node_modules/oae-preview-processor/lib/api.js
+++ b/node_modules/oae-preview-processor/lib/api.js
@@ -125,19 +125,27 @@ var disable = module.exports.disable = function(callback) {
 
         log().info('Unbound the preview processor from the generate previews task queue');
 
-
-        TaskQueue.unbind(PreviewConstants.MQ.TASK_REGENERATE_PREVIEWS, function(err) {
+        TaskQueue.unbind(PreviewConstants.MQ.TASK_GENERATE_FOLDER_PREVIEWS, function(err) {
             if (err) {
-                log().error({'err': err}, 'Could not bind to the regenerate previews queue');
+                log().error({'err': err}, 'Could not unbind from the folder previews queue');
                 return callback(err);
             }
 
-            log().info('Unbound the preview processor from the regenerate previews task queue');
+            log().info('Unbound the preview processor from the folder generate previews task queue');
 
-            // Remove our REST error listener.
-            RestUtil.removeListener('error', _restErrorLister);
+            TaskQueue.unbind(PreviewConstants.MQ.TASK_REGENERATE_PREVIEWS, function(err) {
+                if (err) {
+                    log().error({'err': err}, 'Could not bind to the regenerate previews queue');
+                    return callback(err);
+                }
 
-            return callback();
+                log().info('Unbound the preview processor from the regenerate previews task queue');
+
+                // Remove our REST error listener.
+                RestUtil.removeListener('error', _restErrorLister);
+
+                return callback();
+            });
         });
     });
 };


### PR DESCRIPTION
See https://travis-ci.org/oaeproject/Hilary/builds/54584919

```
  1) Preview processor Preview generation verify folder processing:
     Uncaught AssertionError: "undefined" == true
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-preview-processor/tests/test-previews.js:1583:64
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-folders/lib/test/util.js:440:16
      at Request._callback (/home/travis/build/oaeproject/Hilary/node_modules/oae-rest/lib/util.js:9:8822)
      at Request.self.callback (/home/travis/build/oaeproject/Hilary/node_modules/oae-rest/node_modules/request/request.js:121:22)
      at Request.emit (events.js:98:17)
      at Request.<anonymous> (/home/travis/build/oaeproject/Hilary/node_modules/oae-rest/node_modules/request/request.js:978:14)
      at Request.emit (events.js:117:20)
      at IncomingMessage.<anonymous> (/home/travis/build/oaeproject/Hilary/node_modules/oae-rest/node_modules/request/request.js:929:12)
      at IncomingMessage.emit (events.js:117:20)
      at _stream_readable.js:938:16
```

Note that this is not the same issue as https://github.com/oaeproject/Hilary/issues/1084