### PR TITLE
Fix tile line-height in iphone emails; Align visibility icon to bottom

### DIFF
--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -152,9 +152,9 @@
         str += '            <tr>';
         str += '                <td valign="bottom">';
         str += '                    <div class="preview-tile-metadata">';
-        str += '                        <table cellpadding="0" cellspacing="0">';
+        str += '                        <table cellpadding="0" cellspacing="0" class="preview-tile-metadata-inner">';
         str += '                            <tr valign="top">';
-        str += '                                <td><h3>';
+        str += '                                <td colspan="2"><h3>';
 
         // We add the link in here again as some mail clients will remove the outer link. We do not link
         // the entity if it's a private user
@@ -164,12 +164,12 @@
             str += '                                <a href="' + shared.ensureAbsoluteLink(entity.profilePath, baseUrl) + '" title="' + util.html.encodeForHTMLAttribute(entity.displayName) + '" target="_blank" class="preview-tile-title wrapped">' + title + '</a>';
         }
         str += '                                </h3></td>';
-        if (entity.resourceType !== 'user') {
-            str += '                            <td><img src="' + shared.ensureAbsoluteLink(icon, baseUrl) + '" alt="' + i18nVisibility + '" class="preview-tile-metadata-visibility" /></td>';
-        }
         str += '                            </tr>';
         str += '                            <tr>';
-        str += '                                <td colspan="2"><small class="preview-tile-metadata-description">' + resourceType + '</small></td>';
+        str += '                                <td class="preview-tile-metadata-description"><small>' + resourceType + '</small></td>';
+        if (entity.resourceType !== 'user') {
+            str += '                            <td class="preview-tile-metadata-visibility"><img src="' + shared.ensureAbsoluteLink(icon, baseUrl) + '" alt="' + i18nVisibility + '"/></td>';
+        }
         str += '                            </tr>';
         str += '                        </table>';
         str += '                    </div>';
@@ -333,7 +333,12 @@
                 width: 520px;
             }
 
-            .preview-tile-container .preview-tile-metadata img.preview-tile-metadata-visibility {
+            .preview-tile-metadata .preview-tile-metadata-inner {
+                width: 100%;
+            }
+
+            .preview-tile-container .preview-tile-metadata .preview-tile-metadata-visibility,
+            .preview-tile-container .preview-tile-metadata .preview-tile-metadata-visibility > img {
                 height: 18px;
                 width: 18px;
             }
@@ -342,7 +347,7 @@
                 display: block;
                 font-size: 14px;
                 font-weight: 600;
-                line-height: 1.4;
+                line-height: 18px;
                 margin: 0;
                 max-width: 135px;
                 width: 130px;
@@ -357,7 +362,7 @@
                 color: <%= skinVariables['tile-title-color'] %>;
             }
 
-            .preview-tile-container .preview-tile-metadata .preview-tile-metadata-description {
+            .preview-tile-container .preview-tile-metadata .preview-tile-metadata-description > small {
                 color: <%= skinVariables['tile-description-color'] %>;
                 text-transform: uppercase;
                 font-size: 13px;

--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -362,6 +362,10 @@
                 color: <%= skinVariables['tile-title-color'] %>;
             }
 
+            .preview-tile-container .preview-tile-metadata .preview-tile-metadata-description {
+                padding-top: 2px;
+            }
+
             .preview-tile-container .preview-tile-metadata .preview-tile-metadata-description > small {
                 color: <%= skinVariables['tile-description-color'] %>;
                 text-transform: uppercase;


### PR DESCRIPTION
Addresses the line-height portion of https://github.com/oaeproject/3akai-ux/issues/3990

This was only visible on iPhone, but it seems using a px line-height works quite a bit better in the Apple Mail app.

I've also moved the visibility icons to the bottom right of the metadata rather than top right. This is consistent with newer designs.

Note that it's tough to see pixel-perfectness with a local build since the icons don't link properly, so I'd like to see this on QA0 after merged and iterate if necessary.