### PR TITLE
Made `email` a required field when creating a user

### DIFF
--- a/node_modules/oae-activity/tests/test-activity.js
+++ b/node_modules/oae-activity/tests/test-activity.js
@@ -269,17 +269,15 @@ describe('Activity', function() {
                     assert.ok(!err);
 
                     // Create the user we will use as the activity stream
-                    var jackUsername = TestsUtil.generateTestUserId('jack');
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                         assert.ok(!err);
-                        var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                         // Try to generate an activity for Jack's feed
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                        RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                             assert.ok(!err);
 
                             // Verify no activity is generated, because we don't have any bound workers
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.ok(activityStream.items);
@@ -290,12 +288,12 @@ describe('Activity', function() {
                                     assert.ok(!err);
 
                                     // Generate a 2nd activity for Jack's feed
-                                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                                    RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                                         assert.ok(!err);
 
                                         // Verify both the first activity and the 2nd are collected into the stream, as the first one should have been queued until
                                         // we were finally enabled.
-                                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.ok(activityStream.items);
@@ -307,11 +305,11 @@ describe('Activity', function() {
                                                 assert.ok(!err);
 
                                                 // Create a 3rd activity to verify routing
-                                                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                                                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                                                     assert.ok(!err);
 
                                                     // Verify it was routed: now we should have 3 activities aggregated
-                                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                         assert.ok(!err);
                                                         assert.ok(activityStream);
                                                         assert.ok(activityStream.items);
@@ -339,24 +337,22 @@ describe('Activity', function() {
                 ActivityTestUtil.refreshConfiguration({'activityTtl': 2}, function(err) {
                     assert.ok(!err);
 
-                    var jackUsername = TestsUtil.generateTestUserId('jack');
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                         assert.ok(!err);
-                        var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                         // Try to generate an activity for Jack's feed
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                        RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                             assert.ok(!err);
 
                             // Verify the activity is generated immediately
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.ok(activityStream.items);
                                 assert.equal(activityStream.items.length, 1);
 
                                 // Now wait for the expiry and verify it has disappeared
-                                setTimeout(ActivityTestUtil.collectAndGetActivityStream, 2100, jackCtx, null, null, function(err, activityStream) {
+                                setTimeout(ActivityTestUtil.collectAndGetActivityStream, 2100, jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
                                     assert.ok(activityStream.items);
@@ -466,17 +462,14 @@ describe('Activity', function() {
              * Test that verifies that the default activity transformer will return just the oae:id, oae:tenant and objectType of an entity
              */
             it('verify default activity transformer returns objectType, oae:tenant and oae:id', function(callback) {
-                var username = TestsUtil.generateTestUserId('jack');
                 var testActivityType = TestsUtil.generateTestUserId();
                 var testResourceType = TestsUtil.generateTestUserId();
                 var testResourceId = 'foo:camtest:' + TestsUtil.generateTestUserId();
 
-                var jackUsername = TestsUtil.generateTestUserId('jack');
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    var actorResource = new ActivitySeedResource('user', jack.id);
+                    var actorResource = new ActivitySeedResource('user', jack.user.id);
                     var objectResource = new ActivitySeedResource(testResourceType, testResourceId, {'secret': 'My secret data!'});
                     var seed = new ActivitySeed(testActivityType, Date.now(), 'whistle', actorResource, objectResource);
 
@@ -505,7 +498,7 @@ describe('Activity', function() {
                         propagationCallback(null, [{'type': 'all'}]);
 
                         // Collect the persisted activity, and make sure its transformation contains the id and type, but not the secret
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.equal(activityStream.items.length, 1);
                             assert.ok(activityStream.items[0].object);
@@ -684,13 +677,11 @@ describe('Activity', function() {
              * Test that postActivity validates input properly
              */
             it('verify postActivity validation', function(callback) {
-                var jackUsername = TestsUtil.generateTestUserId('jack');
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // Generate an activity for Jack's feed
-                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         /*!
@@ -706,9 +697,9 @@ describe('Activity', function() {
                                 'verb': 'share',
                                 'published': Date.now()
                             };
-                            var actor = {'resourceType': 'user', 'resourceId': jack.id};
+                            var actor = {'resourceType': 'user', 'resourceId': jack.user.id};
                             var object = {'resourceType': 'content', 'resourceId': link.id};
-                            var target = {'resourceType': 'user', 'resourceId': jack.id};
+                            var target = {'resourceType': 'user', 'resourceId': jack.user.id};
 
                             seed = _.extend(seed, seedOverlay);
 
@@ -806,13 +797,11 @@ describe('Activity', function() {
              * Test that verifies activities stop being posted when it is disabled in the admin console.
              */
             it('verify disabling activity posting', function(callback) {
-                var jackUsername = TestsUtil.generateTestUserId('jack');
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // Generate an activity for Jack's feed
-                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         // Disable activity posting
@@ -820,13 +809,13 @@ describe('Activity', function() {
                             assert.ok(!err);
 
                             // Try and generate an activity, but this should actually not be posted
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, link2) {
+                            RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, link2) {
                                 assert.ok(!err);
 
                                 ConfigTestsUtil.updateConfigAndWait(globalAdminRestContext, null, {'oae-activity/activity/enabled': true}, function(err) {
                                     assert.ok(!err);
 
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         // Verify only one activity and it is not an aggregation
@@ -1416,20 +1405,16 @@ describe('Activity', function() {
          * Test that verifies the tenant information gets associated with each activity entity.
          */
         it('verify activities have tenant information', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
 
-                var jack = _.values(users)[0].user;
-                var jackCtx = _.values(users)[0].restContext;
-                var jane = _.values(users)[1].user;
-
                 // Jack creates a link and shares it with Jane.
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream.items.length > 0);
 
@@ -1463,19 +1448,16 @@ describe('Activity', function() {
          * Test that verifies the tenant information gets associated with each activity entity when they appear in collections.
          */
         it('verify activities with collections have tenant information', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-                var jack = _.values(users)[0].user;
-                var jackCtx = _.values(users)[0].restContext;
-                var jane = _.values(users)[1].user;
-                var jill = _.values(users)[2].user;
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, jill) {
+                assert.ok(!err);
 
                 // Jack creates a link and shares it with Jane and Jill.
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id, jill.id], function(err) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id, jill.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream.items.length > 0);
 
@@ -1511,47 +1493,38 @@ describe('Activity', function() {
          * Test that verifies paging of activity feeds
          */
         it('verify paging of activity feeds', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Generate 2 activities for jack's feed
+                RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    var janeCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                    // Generate 2 activities for jack's feed
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                         assert.ok(!err);
 
-                        RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                        // Get the items, ensure there are 2
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
+                            assert.equal(activityStream.items.length, 2);
 
-                            // Get the items, ensure there are 2
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            var firstId = activityStream.items[0]['oae:activityId'];
+                            var secondId = activityStream.items[1]['oae:activityId'];
+
+                            // Verify when you query with limit=1, you get the first and only the first activity
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, {'limit': 1}, function(err, activityStream) {
                                 assert.ok(!err);
-                                assert.equal(activityStream.items.length, 2);
+                                assert.equal(activityStream.items.length, 1);
+                                assert.equal(activityStream.items[0]['oae:activityId'], firstId);
+                                assert.equal(activityStream.nextToken, firstId);
 
-                                var firstId = activityStream.items[0]['oae:activityId'];
-                                var secondId = activityStream.items[1]['oae:activityId'];
-
-                                // Verify when you query with limit=1, you get the first and only the first activity
-                                ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, {'limit': 1}, function(err, activityStream) {
+                                // Verify when you query with the firstId as the start point, you get just the second activity
+                                ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, {'start': firstId}, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.equal(activityStream.items.length, 1);
-                                    assert.equal(activityStream.items[0]['oae:activityId'], firstId);
-                                    assert.equal(activityStream.nextToken, firstId);
-
-                                    // Verify when you query with the firstId as the start point, you get just the second activity
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, {'start': firstId}, function(err, activityStream) {
-                                        assert.ok(!err);
-                                        assert.equal(activityStream.items.length, 1);
-                                        assert.equal(activityStream.items[0]['oae:activityId'], secondId);
-                                        assert.ok(!activityStream.nextToken);
-                                        callback();
-                                    });
+                                    assert.equal(activityStream.items[0]['oae:activityId'], secondId);
+                                    assert.ok(!activityStream.nextToken);
+                                    return callback();
                                 });
                             });
                         });
@@ -1679,23 +1652,20 @@ describe('Activity', function() {
          * rather than continuing to aggregate in the previous activity.
          */
         it('verify aggregation idle expiry time', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Set the aggregate expiry time to 1 second. This should give us enough time to aggregate 2 activities, wait for expiry, then create a 3rd to verify it does not aggregate.
             ActivityTestUtil.refreshConfiguration({'aggregateIdleExpiry': 1}, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
+                    RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
                         assert.ok(!err);
 
-                        RestAPI.Content.createLink(jackCtx, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
+                        RestAPI.Content.createLink(jack.restContext, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
                             assert.ok(!err);
 
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
                                 // Verify both creates are aggregated into 1 activity
@@ -1718,11 +1688,11 @@ describe('Activity', function() {
                                 assert.ok(hasB);
 
                                 // Let the aggregation timeout expire and create a new link
-                                setTimeout(RestAPI.Content.createLink, 1100, jackCtx, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
+                                setTimeout(RestAPI.Content.createLink, 1100, jack.restContext, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
                                     assert.ok(!err);
 
                                     // Re-collect and verify that the aggregate expired, thus making the link a new activity, not an aggregate
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         // Now validate the activity stream contents
@@ -1762,33 +1732,30 @@ describe('Activity', function() {
          * does not fall idle.
          */
         it('verify aggregation max expiry time', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Set the aggregate max time to 1s and the idle time higher to 5s, this is to rule out the possibility of idle expiry messing up this test
             ActivityTestUtil.refreshConfiguration({'aggregateIdleExpiry': 5, 'aggregateMaxExpiry': 1}, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // This is when the createLink aggregate is born
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
+                    RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
                         assert.ok(!err);
 
                         // Drop an aggregate in. The when collected the aggregate is 600ms old
-                        setTimeout(RestAPI.Content.createLink, 600, jackCtx, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
+                        setTimeout(RestAPI.Content.createLink, 600, jack.restContext, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
                             assert.ok(!err);
 
                             // Collect, then wait for expiry
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
                                 // When this content item is created, it should have crossed max expiry, causing this content create activity to be delivered individually
-                                setTimeout(RestAPI.Content.createLink, 1500, jackCtx, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
+                                setTimeout(RestAPI.Content.createLink, 1500, jack.restContext, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
                                     assert.ok(!err);
 
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         // Now validate the activity stream contents
@@ -1829,27 +1796,24 @@ describe('Activity', function() {
          * Test that verifies that when the aggregateIdleExpiry expires, the aggregate data disappears from storage.
          */
         it('verify aggregated data is automatically deleted after the idle expiry time', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Set the aggregate max time to 1s, if we add aggregate data then wait this period of time, queries to the DAO should show that this data has
             // been automatically cleaned out
             ActivityTestUtil.refreshConfiguration({'aggregateIdleExpiry': 1, 'aggregateMaxExpiry': 5}, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // Create a link then collect, which creates the aggregates
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         // Drop an aggregate in. This is when the aggregate should be initially persisted, so should expire 1s from this time
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
 
                             // Verify that the DAO reports the aggregate status is indeed there
-                            var aggregateKey = util.format('content-create#%s#activity#user:%s##__null__', jack.id, jack.id);
+                            var aggregateKey = util.format('content-create#%s#activity#user:%s##__null__', jack.user.id, jack.user.id);
 
                             ActivityDAO.getAggregateStatus([aggregateKey], function(err, aggregateStatus) {
                                 assert.ok(!err);
@@ -1860,7 +1824,7 @@ describe('Activity', function() {
                                 ActivityDAO.getAggregatedEntities([aggregateKey], function(err, aggregatedEntities) {
                                     assert.ok(!err);
                                     assert.ok(aggregatedEntities[aggregateKey]);
-                                    assert.ok(aggregatedEntities[aggregateKey]['actors']['user:' + jack.id]);
+                                    assert.ok(aggregatedEntities[aggregateKey]['actors']['user:' + jack.user.id]);
                                     assert.ok(aggregatedEntities[aggregateKey]['objects']['content:' + link.id]);
 
                                     // Wait the max expiry (1s) to let them disappear and verify there is no status

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -1371,42 +1371,6 @@ describe('Activity Email', function() {
     });
 
     /**
-     * Test that verifies if a user within a batch does not have an email address, it does not stop
-     * emails from being sent to other users in the same batch
-     */
-    it('verify user without email does not stop email from being sent to other users', function(callback) {
-        TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-            assert.ok(!err);
-
-            // Sort the user ids as the users are collected for emailing in this arbitrary ordering
-            var userIds = _.keys(users).sort();
-            var firstUser = users[userIds[0]];
-            var secondUser = users[userIds[1]];
-            var thirdUser = users[userIds[2]];
-
-            // Clear the email for the third user so we have a user that has no email address
-            RestAPI.User.updateUser(thirdUser.restContext, thirdUser.user.id, {'email': 'notavalidemail'}, function(err, updatedThirdUser) {
-                assert.ok(!err);
-                assert.strictEqual(updatedThirdUser.email, 'notavalidemail');
-
-                // The first user in the list triggers an email notification for the second and third user in the list
-                RestAPI.Content.createLink(firstUser.restContext, 'test content', 'Google', 'public', 'http://www.google.ca', [], [thirdUser.user.id, secondUser.user.id], [], function(err, link) {
-                    assert.ok(!err);
-
-                    // Collect the emails for the target users
-                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
-                        // Ensure we have 1 message. `thirdUser` does not get one because they do
-                        // not have an email addres. However that should not stop `secondUser` from
-                        // getting an email
-                        assert.strictEqual(messages.length, 1);
-                        return callback();
-                    });
-                });
-            });
-        });
-    });
-
-    /**
      * Test that verifies a private user does not appear in a link in an activity email
      */
     it('verify private users are not displayed with links', function(callback) {

--- a/node_modules/oae-activity/tests/test-notifications.js
+++ b/node_modules/oae-activity/tests/test-notifications.js
@@ -364,9 +364,9 @@ describe('Notifications', function() {
                 assert.ok(!err);
 
                 // Give mrvisser and nico an email address
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, {'email': 'mrvisser@example.com', 'emailPreference': 'immediate'}, function(err) {
+                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, {'emailPreference': 'immediate'}, function(err) {
                     assert.ok(!err);
-                    RestAPI.User.updateUser(nico.restContext, nico.user.id, {'email': 'nico@example.com', 'emailPreference': 'immediate'}, function(err) {
+                    RestAPI.User.updateUser(nico.restContext, nico.user.id, {'emailPreference': 'immediate'}, function(err) {
                         assert.ok(!err);
 
                         // Create a piece of content and make nico and mrvisser managers. They should each get an e-mail
@@ -376,8 +376,8 @@ describe('Notifications', function() {
                             // Assert that both nico and mrvisser received an e-mail, but noone else
                             EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
                                 assert.equal(messages.length, 2);
-                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[0].to[0].address));
-                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[1].to[0].address));
+                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[0].to[0].address));
+                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[1].to[0].address));
                                 assert.notEqual(messages[0].to, messages[1].to);
 
                                 // Simulate an unexpected loop and try to route the same activity seed multiple times
@@ -394,8 +394,8 @@ describe('Notifications', function() {
                                             // Assert that only 1 mail got sent to both nico and mrvisser
                                             EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
                                                 assert.equal(messages.length, 2);
-                                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[0].to[0].address));
-                                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[1].to[0].address));
+                                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[0].to[0].address));
+                                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[1].to[0].address));
                                                 assert.notEqual(messages[0].to, messages[1].to[0].address);
                                                 return callback();
                                             });

--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -163,9 +163,9 @@ var localUsernameExists = module.exports.localUsernameExists = function(ctx, ten
  * @param  {String}     username                The unique username for the global administrator
  * @param  {String}     password                The password for the global administrator
  * @param  {String}     displayName             The display name for the global administrator
- * @param  {String}     email                   The email address for the global administrator
  * @param  {String}     [opts]                  Optional user profile parameters
  * @param  {String}     [opts.locale]           The locale for the global administrator
+ * @param  {String}     [opts.email]            The email address for the global administrator
  * @param  {string}     [opts.emailPreference]  The email preference for the global administrator
  * @param  {String}     [opts.publicAlias]      The name to show when the global administrator is inaccessible to a user
  * @param  {Function}   callback                Standard callback function
@@ -174,7 +174,7 @@ var localUsernameExists = module.exports.localUsernameExists = function(ctx, ten
  * @param  {String}     callback.loginId        The *flattened* loginId for this user
  * @param  {Boolean}    callback.created        `true` if a global administrator was created with the provided username, `false` otherwise
  */
-var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = function(ctx, username, password, displayName, email, opts, callback) {
+var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = function(ctx, username, password, displayName, opts, callback) {
     opts = opts || {};
 
     var validator = new Validator();
@@ -184,8 +184,6 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
     validator.check(password, {'code': 400, 'msg': 'You must provide a password'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
-    validator.check(email, {'code': 400, 'msg': 'You must provide an email address'}).notEmpty();
-    validator.check(email, {'code': 400, 'msg': 'A valid email address must be provided'}).isEmail();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
@@ -194,7 +192,7 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
     opts.visibility = AuthzConstants.visibility.PRIVATE;
 
     var providerProperties = {'password': password};
-    getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, username, providerProperties, displayName, email, opts, function(err, user, loginId, created) {
+    getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, username, providerProperties, displayName, opts, function(err, user, loginId, created) {
         if (err) {
             return callback(err);
         } else if (!created) {
@@ -229,28 +227,24 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
  * @param  {String}       authProvider              The authentication provider of the login id
  * @param  {String}       externalId                The desired externalId/username for this user
  * @param  {String}       displayName               The display name for the user
- * @param  {String}       email                     The email address for the user
  * @param  {String}       [opts]                    Optional user profile parameters
  * @param  {String}       [opts.locale]             The locale for the user
  * @param  {String}       [opts.email]              The email address for the user
  * @param  {String}       [opts.emailPreference]    The email preference for the user
  * @param  {String}       [opts.visibility]         The visibility of the user. One of: @see AuthzConstants.visibility
  * @param  {String}       [opts.publicAlias]        The name to show when the user is inaccessible to a user
- * @param  {String}       [opts.emailPreference]    The email preference for the user. One of: @see PrincipalsConstants.emailPreference
  * @param  {Function}     callback                  Standard callback function
  * @param  {Object}       callback.err              An error that occurred, if any
  * @param  {User}         callback.user             The user that was fetched or created
  * @param  {String}       callback.loginId          The *flattened* loginId for this user
  * @param  {Boolean}      callback.created          `true` if the user was created, `false` otherwise
  */
-var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvider, externalId, providerProperties, displayName, email, opts, callback) {
+var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvider, externalId, providerProperties, displayName, opts, callback) {
     opts = opts || {};
 
     var validator = new Validator();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
-    validator.check(email, {'code': 400, 'msg': 'You must provide an email address'}).notEmpty();
-    validator.check(email, {'code': 400, 'msg': 'A valid email address must be provided'}).isEmail();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
@@ -262,7 +256,7 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvide
         return callback(validator.getFirstError());
     }
 
-    _getOrCreateUser(ctx, loginId, displayName, email, opts, callback);
+    _getOrCreateUser(ctx, loginId, displayName, opts, callback);
 };
 
 /**
@@ -271,7 +265,6 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvide
  * @param  {Context}    ctx                 Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId             The login id to use to fetch or create the user
  * @param  {String}     displayName         The display name for the user
- * @param  {String}     email               The email address for the user
  * @param  {Object}     [opts]              Optional user profile parameters
  * @param  {Function}   callback            Standard callback function
  * @param  {Object}     callback.err        An error that occurred, if any
@@ -280,7 +273,7 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvide
  * @param  {Boolean}    callback.created    `true` if the user was created, `false` otherwise
  * @api private
  */
-var _getOrCreateUser = function(ctx, loginId, displayName, email, opts, callback) {
+var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
     opts = opts || {};
 
     _getUserIdFromLoginId(loginId, function(err, userId) {
@@ -295,7 +288,7 @@ var _getOrCreateUser = function(ctx, loginId, displayName, email, opts, callback
                 'opts': opts
             }, 'Auto-creating a user on login');
 
-            createUser(ctx, loginId, displayName, email, opts, function(err, user) {
+            createUser(ctx, loginId, displayName, opts, function(err, user) {
                 if (err) {
                     return callback(err);
                 }
@@ -320,8 +313,8 @@ var _getOrCreateUser = function(ctx, loginId, displayName, email, opts, callback
  * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId                     The login id that will be associated with the tenant administrator so they may log in
  * @param  {String}     displayName                 The display name for the tenant administrator
- * @param  {String}     email                       The email address for the tenant administrator
  * @param  {Object}     [opts]                      Optional user profile parameters
+ * @param  {String}     [opts.email]                The email address for the user
  * @param  {String}     [opts.emailPreference]      The email preference for the tenant administrator. One of: @see PrincipalsConstants.emailPreference
  * @param  {String}     [opts.locale]               The locale for the tenant administrator
  * @param  {String}     [opts.publicAlias]          The name to show when the tenant administrator is inaccessible to a user
@@ -329,7 +322,7 @@ var _getOrCreateUser = function(ctx, loginId, displayName, email, opts, callback
  * @param  {Object}     callback.err                An error that occurred, if any
  * @param  {User}       callback.user               The created tenant administrator
  */
-var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx, loginId, displayName, email, opts, callback) {
+var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx, loginId, displayName, opts, callback) {
     opts = opts || {};
 
     var validator = new Validator();
@@ -354,7 +347,7 @@ var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx,
     opts.visibility = AuthzConstants.visibility.PRIVATE;
 
     // Create the user object with their login id
-    _createUser(ctx, loginId, displayName, email, opts, function(err, user) {
+    _createUser(ctx, loginId, displayName, opts, function(err, user) {
         if (err) {
             return callback(err);
         }
@@ -376,10 +369,10 @@ var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx,
  * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId                     The login id that will be associated with the user so they may log in
  * @param  {String}     displayName                 The display name for the user
- * @param  {String}     email                       The email address for the user
  * @param  {Object}     [opts]                      Optional user profile parameters
  * @param  {Boolean}    [opts.acceptedTC]           Whether or not the user has accepted the Terms and Conditions
  * @param  {String}     [opts.locale]               The locale for the user
+ * @param  {String}     [opts.email]                The email address for the user
  * @param  {String}     [opts.emailPreference]      The email preference for the user. One of: @see PrincipalsConstants.emailPreference
  * @param  {String}     [opts.visibility]           The visibility of the user. One of: @see AuthzConstants.visibility
  * @param  {String}     [opts.publicAlias]          The name to show when the user is inaccessible to a user
@@ -387,11 +380,10 @@ var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx,
  * @param  {Object}     callback.err                An error that occurred, if any
  * @param  {User}       callback.user               The created user
  */
-var createUser = module.exports.createUser = function(ctx, loginId, displayName, email, opts, callback) {
+var createUser = module.exports.createUser = function(ctx, loginId, displayName, opts, callback) {
     var validator = new Validator();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
-    validator.check(email, {'code': 400, 'msg': 'A valid email address must be provided'}).isEmail();
     _validateLoginIdForPersistence(validator, loginId);
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
@@ -411,7 +403,7 @@ var createUser = module.exports.createUser = function(ctx, loginId, displayName,
         return callback({'code': 401, 'msg': 'Only global administrators may create users on a tenant that is not the current'});
     }
 
-    _createUser(ctx, loginId, displayName, email, opts, callback);
+    _createUser(ctx, loginId, displayName, opts, callback);
 };
 
 /**
@@ -421,7 +413,6 @@ var createUser = module.exports.createUser = function(ctx, loginId, displayName,
  * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId                     The login id that will be associated with the user so they may log in
  * @param  {String}     displayName                 The display name for the user
- * @param  {String}     email                       The email address for the user
  * @param  {Object}     [opts]                      Optional user profile parameters
  * @param  {Boolean}    [opts.acceptedTC]           Whether or not the user has accepted the Terms and Conditions
  * @param  {String}     [opts.locale]               The locale for the user
@@ -434,7 +425,7 @@ var createUser = module.exports.createUser = function(ctx, loginId, displayName,
  * @param  {User}       callback.user               The created user
  * @api private
  */
-var _createUser = function(ctx, loginId, displayName, email, opts, callback) {
+var _createUser = function(ctx, loginId, displayName, opts, callback) {
     // Lock on externalId to make sure we're not already making an account for this user
     var lockKey = loginId.externalId;
     Locking.acquire(lockKey, 15, function(err, lockToken) {
@@ -456,10 +447,10 @@ var _createUser = function(ctx, loginId, displayName, email, opts, callback) {
             }
 
             // Create the user and immediately associate the login id
-            PrincipalsAPI.createUser(ctx, loginId.tenantAlias, displayName, email, opts, function(err, user) {
+            PrincipalsAPI.createUser(ctx, loginId.tenantAlias, displayName, opts, function(err, user) {
                 if (err) {
                     Locking.release(lockKey, lockToken, function() {
-                        callback(err);
+                        return callback(err);
                     });
                     return;
                 }

--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -163,9 +163,9 @@ var localUsernameExists = module.exports.localUsernameExists = function(ctx, ten
  * @param  {String}     username                The unique username for the global administrator
  * @param  {String}     password                The password for the global administrator
  * @param  {String}     displayName             The display name for the global administrator
+ * @param  {String}     email                   The email address for the global administrator
  * @param  {String}     [opts]                  Optional user profile parameters
  * @param  {String}     [opts.locale]           The locale for the global administrator
- * @param  {String}     [opts.email]            The email address for the global administrator
  * @param  {string}     [opts.emailPreference]  The email preference for the global administrator
  * @param  {String}     [opts.publicAlias]      The name to show when the global administrator is inaccessible to a user
  * @param  {Function}   callback                Standard callback function
@@ -174,7 +174,7 @@ var localUsernameExists = module.exports.localUsernameExists = function(ctx, ten
  * @param  {String}     callback.loginId        The *flattened* loginId for this user
  * @param  {Boolean}    callback.created        `true` if a global administrator was created with the provided username, `false` otherwise
  */
-var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = function(ctx, username, password, displayName, opts, callback) {
+var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = function(ctx, username, password, displayName, email, opts, callback) {
     opts = opts || {};
 
     var validator = new Validator();
@@ -184,6 +184,8 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
     validator.check(password, {'code': 400, 'msg': 'You must provide a password'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
+    validator.check(email, {'code': 400, 'msg': 'You must provide an email address'}).notEmpty();
+    validator.check(email, {'code': 400, 'msg': 'A valid email address must be provided'}).isEmail();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
@@ -192,7 +194,7 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
     opts.visibility = AuthzConstants.visibility.PRIVATE;
 
     var providerProperties = {'password': password};
-    getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, username, providerProperties, displayName, opts, function(err, user, loginId, created) {
+    getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, username, providerProperties, displayName, email, opts, function(err, user, loginId, created) {
         if (err) {
             return callback(err);
         } else if (!created) {
@@ -204,9 +206,9 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
         PrincipalsAPI.setGlobalAdmin(ctx, user.id, true, function(err) {
             if (err) {
                 return callback(err);
+            } else if (created) {
+                log().info({'user': user, 'username': username}, 'Global Admin account created');
             }
-
-            log().info({'user': user, 'username': username}, 'Global Admin account created');
 
             // Fetch the user again to get the updated version of the user
             PrincipalsAPI.getUser(ctx, user.id, function(err, user) {
@@ -227,6 +229,7 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
  * @param  {String}       authProvider              The authentication provider of the login id
  * @param  {String}       externalId                The desired externalId/username for this user
  * @param  {String}       displayName               The display name for the user
+ * @param  {String}       email                     The email address for the user
  * @param  {String}       [opts]                    Optional user profile parameters
  * @param  {String}       [opts.locale]             The locale for the user
  * @param  {String}       [opts.email]              The email address for the user
@@ -240,10 +243,14 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
  * @param  {String}       callback.loginId          The *flattened* loginId for this user
  * @param  {Boolean}      callback.created          `true` if the user was created, `false` otherwise
  */
-var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvider, externalId, providerProperties, displayName, opts, callback) {
+var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvider, externalId, providerProperties, displayName, email, opts, callback) {
+    opts = opts || {};
+
     var validator = new Validator();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
+    validator.check(email, {'code': 400, 'msg': 'You must provide an email address'}).notEmpty();
+    validator.check(email, {'code': 400, 'msg': 'A valid email address must be provided'}).isEmail();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
@@ -255,7 +262,7 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvide
         return callback(validator.getFirstError());
     }
 
-    _getOrCreateUser(ctx, loginId, displayName, opts, callback);
+    _getOrCreateUser(ctx, loginId, displayName, email, opts, callback);
 };
 
 /**
@@ -264,6 +271,7 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvide
  * @param  {Context}    ctx                 Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId             The login id to use to fetch or create the user
  * @param  {String}     displayName         The display name for the user
+ * @param  {String}     email               The email address for the user
  * @param  {Object}     [opts]              Optional user profile parameters
  * @param  {Function}   callback            Standard callback function
  * @param  {Object}     callback.err        An error that occurred, if any
@@ -272,7 +280,9 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvide
  * @param  {Boolean}    callback.created    `true` if the user was created, `false` otherwise
  * @api private
  */
-var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
+var _getOrCreateUser = function(ctx, loginId, displayName, email, opts, callback) {
+    opts = opts || {};
+
     _getUserIdFromLoginId(loginId, function(err, userId) {
         if (err && err.code !== 404) {
             return callback(err);
@@ -285,18 +295,17 @@ var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
                 'opts': opts
             }, 'Auto-creating a user on login');
 
-            createUser(ctx, loginId, displayName, opts, function(err, user) {
+            createUser(ctx, loginId, displayName, email, opts, function(err, user) {
                 if (err) {
-                    return (err);
+                    return callback(err);
                 }
-
                 return callback(null, user, _flattenLoginId(loginId), true);
             });
         } else {
             // The user existed, simply fetch their profile
             PrincipalsAPI.getUser(ctx, userId, function(err, user) {
                 if (err) {
-                    return (err);
+                    return callback(err);
                 }
 
                 return callback(null, user, _flattenLoginId(loginId), false);
@@ -311,8 +320,8 @@ var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
  * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId                     The login id that will be associated with the tenant administrator so they may log in
  * @param  {String}     displayName                 The display name for the tenant administrator
+ * @param  {String}     email                       The email address for the tenant administrator
  * @param  {Object}     [opts]                      Optional user profile parameters
- * @param  {String}     [opts.email]                The email address for the tenant administrator
  * @param  {String}     [opts.emailPreference]      The email preference for the tenant administrator. One of: @see PrincipalsConstants.emailPreference
  * @param  {String}     [opts.locale]               The locale for the tenant administrator
  * @param  {String}     [opts.publicAlias]          The name to show when the tenant administrator is inaccessible to a user
@@ -320,7 +329,7 @@ var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
  * @param  {Object}     callback.err                An error that occurred, if any
  * @param  {User}       callback.user               The created tenant administrator
  */
-var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx, loginId, displayName, opts, callback) {
+var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx, loginId, displayName, email, opts, callback) {
     opts = opts || {};
 
     var validator = new Validator();
@@ -345,7 +354,7 @@ var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx,
     opts.visibility = AuthzConstants.visibility.PRIVATE;
 
     // Create the user object with their login id
-    _createUser(ctx, loginId, displayName, opts, function(err, user) {
+    _createUser(ctx, loginId, displayName, email, opts, function(err, user) {
         if (err) {
             return callback(err);
         }
@@ -367,10 +376,10 @@ var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx,
  * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId                     The login id that will be associated with the user so they may log in
  * @param  {String}     displayName                 The display name for the user
+ * @param  {String}     email                       The email address for the user
  * @param  {Object}     [opts]                      Optional user profile parameters
  * @param  {Boolean}    [opts.acceptedTC]           Whether or not the user has accepted the Terms and Conditions
  * @param  {String}     [opts.locale]               The locale for the user
- * @param  {String}     [opts.email]                The email address for the user
  * @param  {String}     [opts.emailPreference]      The email preference for the user. One of: @see PrincipalsConstants.emailPreference
  * @param  {String}     [opts.visibility]           The visibility of the user. One of: @see AuthzConstants.visibility
  * @param  {String}     [opts.publicAlias]          The name to show when the user is inaccessible to a user
@@ -378,10 +387,11 @@ var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx,
  * @param  {Object}     callback.err                An error that occurred, if any
  * @param  {User}       callback.user               The created user
  */
-var createUser = module.exports.createUser = function(ctx, loginId, displayName, opts, callback) {
+var createUser = module.exports.createUser = function(ctx, loginId, displayName, email, opts, callback) {
     var validator = new Validator();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
+    validator.check(email, {'code': 400, 'msg': 'A valid email address must be provided'}).isEmail();
     _validateLoginIdForPersistence(validator, loginId);
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
@@ -401,7 +411,7 @@ var createUser = module.exports.createUser = function(ctx, loginId, displayName,
         return callback({'code': 401, 'msg': 'Only global administrators may create users on a tenant that is not the current'});
     }
 
-    _createUser(ctx, loginId, displayName, opts, callback);
+    _createUser(ctx, loginId, displayName, email, opts, callback);
 };
 
 /**
@@ -411,6 +421,7 @@ var createUser = module.exports.createUser = function(ctx, loginId, displayName,
  * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
  * @param  {LoginId}    loginId                     The login id that will be associated with the user so they may log in
  * @param  {String}     displayName                 The display name for the user
+ * @param  {String}     email                       The email address for the user
  * @param  {Object}     [opts]                      Optional user profile parameters
  * @param  {Boolean}    [opts.acceptedTC]           Whether or not the user has accepted the Terms and Conditions
  * @param  {String}     [opts.locale]               The locale for the user
@@ -423,7 +434,7 @@ var createUser = module.exports.createUser = function(ctx, loginId, displayName,
  * @param  {User}       callback.user               The created user
  * @api private
  */
-var _createUser = function(ctx, loginId, displayName, opts, callback) {
+var _createUser = function(ctx, loginId, displayName, email, opts, callback) {
     // Lock on externalId to make sure we're not already making an account for this user
     var lockKey = loginId.externalId;
     Locking.acquire(lockKey, 15, function(err, lockToken) {
@@ -445,7 +456,7 @@ var _createUser = function(ctx, loginId, displayName, opts, callback) {
             }
 
             // Create the user and immediately associate the login id
-            PrincipalsAPI.createUser(ctx, loginId.tenantAlias, displayName, opts, function(err, user) {
+            PrincipalsAPI.createUser(ctx, loginId.tenantAlias, displayName, email, opts, function(err, user) {
                 if (err) {
                     Locking.release(lockKey, lockToken, function() {
                         callback(err);

--- a/node_modules/oae-authentication/lib/strategies/cas/init.js
+++ b/node_modules/oae-authentication/lib/strategies/cas/init.js
@@ -70,7 +70,6 @@ module.exports = function() {
 
             var username = casResponse.user;
             var displayName = casResponse.user;
-            var email = null;
             var opts = {};
 
             // If the CAS server returned attributes we try to map them to OAE profile parameters
@@ -84,14 +83,12 @@ module.exports = function() {
                 // Set the optional profile parameters
                 AuthenticationUtil.setProfileParameter(opts, 'email', mapEmail, casResponse.attributes);
                 AuthenticationUtil.setProfileParameter(opts, 'locale', mapLocale, casResponse.attributes);
-                email = opts.email;
-                // TODO: Implement the "no email when using SSO"-flow
             }
 
             var context = new Context(tenant, null);
 
             // This `done` callback sends into the `self.verify` call inside `strategy.js` of the CAS strategy directory
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.CAS, username, null, displayName, opts.email, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.CAS, username, null, displayName, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/cas/init.js
+++ b/node_modules/oae-authentication/lib/strategies/cas/init.js
@@ -70,6 +70,7 @@ module.exports = function() {
 
             var username = casResponse.user;
             var displayName = casResponse.user;
+            var email = null;
             var opts = {};
 
             // If the CAS server returned attributes we try to map them to OAE profile parameters
@@ -83,12 +84,14 @@ module.exports = function() {
                 // Set the optional profile parameters
                 AuthenticationUtil.setProfileParameter(opts, 'email', mapEmail, casResponse.attributes);
                 AuthenticationUtil.setProfileParameter(opts, 'locale', mapLocale, casResponse.attributes);
+                email = opts.email;
+                // TODO: Implement the "no email when using SSO"-flow
             }
 
             var context = new Context(tenant, null);
 
             // This `done` callback sends into the `self.verify` call inside `strategy.js` of the CAS strategy directory
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.CAS, username, null, displayName, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.CAS, username, null, displayName, opts.email, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/facebook/init.js
+++ b/node_modules/oae-authentication/lib/strategies/facebook/init.js
@@ -61,13 +61,14 @@ module.exports = function() {
                 opts.mediumPictureUri = 'remote:' + picture.data.url;
             }
 
-            // Not all facebook users have an e-mail address.
+            // TODO: Implement the "no email when using SSO"-flow
+            var email = null;
             if (profile.emails.length > 0 && profile.emails[0].value) {
-                opts.email = profile.emails[0].value;
+                email = profile.emails[0].value;
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.FACEBOOK, externalId, null, displayName, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.FACEBOOK, externalId, null, displayName, email, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/facebook/init.js
+++ b/node_modules/oae-authentication/lib/strategies/facebook/init.js
@@ -61,14 +61,12 @@ module.exports = function() {
                 opts.mediumPictureUri = 'remote:' + picture.data.url;
             }
 
-            // TODO: Implement the "no email when using SSO"-flow
-            var email = null;
             if (profile.emails.length > 0 && profile.emails[0].value) {
-                email = profile.emails[0].value;
+                opts.email = profile.emails[0].value;
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.FACEBOOK, externalId, null, displayName, email, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.FACEBOOK, externalId, null, displayName, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/google/init.js
+++ b/node_modules/oae-authentication/lib/strategies/google/init.js
@@ -89,7 +89,9 @@ module.exports = function() {
 
             // The locale returned by google only specifies the language, but not the region which
             // isn't very useful
-            var opts = {};
+            var opts = {
+                'email': email
+            };
             var picture = profile['_json'].picture;
             if (picture) {
                 opts.smallPictureUri = 'remote:' + picture;
@@ -97,7 +99,7 @@ module.exports = function() {
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.GOOGLE, externalId, null, displayName, email, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.GOOGLE, externalId, null, displayName, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/google/init.js
+++ b/node_modules/oae-authentication/lib/strategies/google/init.js
@@ -89,9 +89,7 @@ module.exports = function() {
 
             // The locale returned by google only specifies the language, but not the region which
             // isn't very useful
-            var opts = {
-                'email': email
-            };
+            var opts = {};
             var picture = profile['_json'].picture;
             if (picture) {
                 opts.smallPictureUri = 'remote:' + picture;
@@ -99,7 +97,7 @@ module.exports = function() {
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.GOOGLE, externalId, null, displayName, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.GOOGLE, externalId, null, displayName, email, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/ldap/init.js
+++ b/node_modules/oae-authentication/lib/strategies/ldap/init.js
@@ -75,15 +75,17 @@ module.exports = function() {
             var externalId = profile[mapExternalId];
             var displayName = profile[mapDisplayName];
             var opts = {};
+            var email = null;
+            // TODO: Implement the "no email when using SSO"-flow
             if (mapEmail) {
-                opts.email = profile[mapEmail];
+                email = profile[mapEmail];
             }
             if (mapLocale) {
                 opts.locale = profile[mapLocale];
             }
 
             var ctx = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LDAP, externalId, null, displayName, opts, done);
+            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LDAP, externalId, null, displayName, email, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/ldap/init.js
+++ b/node_modules/oae-authentication/lib/strategies/ldap/init.js
@@ -75,17 +75,15 @@ module.exports = function() {
             var externalId = profile[mapExternalId];
             var displayName = profile[mapDisplayName];
             var opts = {};
-            var email = null;
-            // TODO: Implement the "no email when using SSO"-flow
             if (mapEmail) {
-                email = profile[mapEmail];
+                opts.email = profile[mapEmail];
             }
             if (mapLocale) {
                 opts.locale = profile[mapLocale];
             }
 
             var ctx = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LDAP, externalId, null, displayName, email, opts, done);
+            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LDAP, externalId, null, displayName, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/shibboleth/init.js
+++ b/node_modules/oae-authentication/lib/strategies/shibboleth/init.js
@@ -83,8 +83,7 @@ module.exports = function(config) {
 
             // Get an email address from the provided headers. We fall back to `eppn` which may not always
             // contain a valid email address
-            // TODO: Implement the "no email when using SSO"-flow
-            var email = _getBestAttributeValue(tenant.alias, 'mapEmail', headers, headers['eppn']);
+            opts.email = _getBestAttributeValue(tenant.alias, 'mapEmail', headers, headers['eppn']);
 
             // Get a locale, if any
             var locale = _getBestAttributeValue(tenant.alias, 'mapLocale', headers, headers['locale']);
@@ -95,7 +94,7 @@ module.exports = function(config) {
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.SHIBBOLETH, externalId, null, displayName, email, opts, function(err, user, loginId, created) {
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.SHIBBOLETH, externalId, null, displayName, opts, function(err, user, loginId, created) {
                 if (err) {
                     return callback(err);
 

--- a/node_modules/oae-authentication/lib/strategies/shibboleth/init.js
+++ b/node_modules/oae-authentication/lib/strategies/shibboleth/init.js
@@ -82,17 +82,9 @@ module.exports = function(config) {
             var opts = {};
 
             // Get an email address from the provided headers. We fall back to `eppn` which may not always
-            // contain a valid email address. We only set the `email` value if a valid email has been provided
+            // contain a valid email address
+            // TODO: Implement the "no email when using SSO"-flow
             var email = _getBestAttributeValue(tenant.alias, 'mapEmail', headers, headers['eppn']);
-            if (email) {
-                var validator = new Validator();
-                validator.check(email, {'code': 400, 'msg': 'Invalid email'}).isEmail();
-                if (!validator.hasErrors()) {
-                    opts['email'] = email;
-                } else {
-                    log().warn({'email': email, 'externalId': externalId, 'tenant': tenant.alias}, 'A user signed in via Shib with an invalid email address');
-                }
-            }
 
             // Get a locale, if any
             var locale = _getBestAttributeValue(tenant.alias, 'mapLocale', headers, headers['locale']);
@@ -103,7 +95,7 @@ module.exports = function(config) {
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.SHIBBOLETH, externalId, null, displayName, opts, function(err, user, loginId, created) {
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.SHIBBOLETH, externalId, null, displayName, email, opts, function(err, user, loginId, created) {
                 if (err) {
                     return callback(err);
 

--- a/node_modules/oae-authentication/lib/strategies/twitter/init.js
+++ b/node_modules/oae-authentication/lib/strategies/twitter/init.js
@@ -57,8 +57,10 @@ module.exports = function() {
             // Use the Twitter handle to register this user.
             // Unfortunately Twitter doesn't hand out the e-mail address.
             // @see https://dev.twitter.com/discussions/4019
+            // TODO: Implement the "no email when using SSO"-flow
             var username = profile.username;
             var displayName = profile.displayName;
+            var email = null;
             var opts = {};
             var picture = profile['_json']['profile_image_url_https'];
             if (picture) {
@@ -70,7 +72,7 @@ module.exports = function() {
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.TWITTER, username, null, displayName, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.TWITTER, username, null, displayName, email, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/lib/strategies/twitter/init.js
+++ b/node_modules/oae-authentication/lib/strategies/twitter/init.js
@@ -57,10 +57,8 @@ module.exports = function() {
             // Use the Twitter handle to register this user.
             // Unfortunately Twitter doesn't hand out the e-mail address.
             // @see https://dev.twitter.com/discussions/4019
-            // TODO: Implement the "no email when using SSO"-flow
             var username = profile.username;
             var displayName = profile.displayName;
-            var email = null;
             var opts = {};
             var picture = profile['_json']['profile_image_url_https'];
             if (picture) {
@@ -72,7 +70,7 @@ module.exports = function() {
             }
 
             var context = new Context(tenant, null);
-            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.TWITTER, username, null, displayName, email, opts, done);
+            AuthenticationAPI.getOrCreateUser(context, AuthenticationConstants.providers.TWITTER, username, null, displayName, opts, done);
         });
         return passportStrategy;
     };

--- a/node_modules/oae-authentication/tests/test-auth-local.js
+++ b/node_modules/oae-authentication/tests/test-auth-local.js
@@ -24,6 +24,7 @@ var TestsUtil = require('oae-tests');
 
 var AuthenticationAPI = require('oae-authentication');
 var AuthenticationConstants = require('oae-authentication/lib/constants').AuthenticationConstants;
+var AuthenticationTestUtil = require('oae-authentication/lib/test/util');
 var LoginId = require('oae-authentication/lib/model').LoginId;
 
 describe('Authentication', function() {
@@ -57,14 +58,7 @@ describe('Authentication', function() {
      * Ensure that all tests will start with local authentication enabled, even if tests that disable it fail
      */
     afterEach(function(callback) {
-        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-authentication/local/enabled': true}, function(err) {
-            assert.ok(!err);
-        });
-
-        // When the strategies have refreshed, then continue
-        AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-            callback();
-        });
+        return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(camAdminRestContext,  null, {'oae-authentication/local/enabled': true}, callback);
     });
 
 
@@ -75,48 +69,45 @@ describe('Authentication', function() {
          */
         it('verify local authentication', function(callback) {
             // Create a test user
-            var userId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                assert.ok(createdUser);
-                var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
 
                 // Log the user out first, to make sure that the cookie jar for the user is empty
-                RestAPI.Authentication.logout(userRestContext, function(err, body, response) {
+                RestAPI.Authentication.logout(user.restContext, function(err, body, response) {
                     assert.ok(!err);
                     assert.equal(response.statusCode, 302);
                     assert.equal(response.headers.location, '/');
 
                     // Login without a user id
-                    RestAPI.Authentication.login(userRestContext, null, 'password', function(err) {
+                    RestAPI.Authentication.login(user.restContext, null, 'password', function(err) {
                         assert.ok(err);
 
                         // Log in with the wrong password
-                        RestAPI.Authentication.login(userRestContext, userId, 'wrong-password', function(err) {
+                        RestAPI.Authentication.login(user.restContext, user.restContext.username, 'wrong-password', function(err) {
                             assert.ok(err);
 
                             // Log in with the correct password
-                            RestAPI.Authentication.login(userRestContext, userId, 'password', function(err) {
+                            RestAPI.Authentication.login(user.restContext, user.restContext.username, 'password', function(err) {
                                 assert.ok(!err);
 
                                 // Verify that we are actually logged in
-                                RestAPI.User.getMe(userRestContext, function(err, meObj) {
+                                RestAPI.User.getMe(user.restContext, function(err, meObj) {
                                     assert.ok(!err);
                                     assert.ok(meObj);
-                                    assert.equal(meObj.id, createdUser.id);
+                                    assert.equal(meObj.id, user.user.id);
 
                                     // Logout
-                                    RestAPI.Authentication.logout(userRestContext, function(err, body, response) {
+                                    RestAPI.Authentication.logout(user.restContext, function(err, body, response) {
                                         assert.ok(!err);
                                         assert.equal(response.statusCode, 302);
                                         assert.equal(response.headers.location, '/');
 
                                         // Verify that we are now logged out
-                                        RestAPI.User.getMe(userRestContext, function(err, meObj) {
+                                        RestAPI.User.getMe(user.restContext, function(err, meObj) {
                                             assert.ok(!err);
                                             assert.ok(meObj);
                                             assert.equal(meObj.anon, true);
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -151,17 +142,19 @@ describe('Authentication', function() {
                     var err = err1 || err2;
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 }
             };
 
             // Create a test user
             var userId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            var email2 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', email1, {}, function(err, createdUser) {
                 err1 = err;
                 checkComplete();
             });
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', email2, {}, function(err, createdUser) {
                 err2 = err;
                 checkComplete();
             });
@@ -180,7 +173,7 @@ describe('Authentication', function() {
                 RestAPI.Authentication.login(anonymousCamRestContext, 'u:cam:non-existing-user', 'password', function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -190,19 +183,18 @@ describe('Authentication', function() {
          */
         it('verify tenant login separation', function(callback) {
             // Create a test user
-            var userId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                assert.ok(createdUser);
-                var anymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
 
                 // Verify that we cannot login on tenant B
-                RestAPI.Authentication.login(anonymousGtRestContext, userId, 'password', function(err) {
+                var anonymousGtRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host);
+                RestAPI.Authentication.login(anonymousGtRestContext, user.restContext.username, 'password', function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Verify that we can login on tenant A
-                    RestAPI.Authentication.login(anymousRestContext, userId, 'password', function(err) {
+                    var anonymousCamRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+                    RestAPI.Authentication.login(anonymousCamRestContext, user.restContext.username, 'password', function(err) {
                         assert.ok(!err);
                         return callback();
                     });
@@ -216,23 +208,21 @@ describe('Authentication', function() {
          */
         it('verify disable local authentication', function(callback) {
             // Create a user and associated anonymous context they we'll use to verify local login
-            var jackUsername = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackRestCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Sanity check login with the rest context
-                RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                RestAPI.User.getMe(jack.restContext, function(err, me) {
                     assert.ok(!err);
-                    assert.equal(me.id, jack.id);
+                    assert.equal(me.id, jack.user.id);
 
                     // Log it out and sanity check we're anonymous again
-                    RestAPI.Authentication.logout(jackRestCtx, function(err, body, response) {
+                    RestAPI.Authentication.logout(jack.restContext, function(err, body, response) {
                         assert.ok(!err);
                         assert.equal(response.statusCode, 302);
                         assert.equal(response.headers.location, '/');
 
-                        RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                        RestAPI.User.getMe(jack.restContext, function(err, me) {
                             assert.ok(!err);
                             assert.strictEqual(me.anon, true);
 
@@ -245,13 +235,13 @@ describe('Authentication', function() {
                             AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
 
                                 // Verify local authentication fails
-                                RestAPI.Authentication.login(jackRestCtx, jackUsername, 'password', function(err, body, response) {
+                                RestAPI.Authentication.login(jack.restContext, jack.restContext.username, 'password', function(err, body, response) {
                                     assert.ok(!err);
                                     assert.equal(response.statusCode, 302);
                                     assert.equal(response.headers.location, '/?authentication=disabled');
 
                                     // Ensure the user is still anonymous
-                                    RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                                    RestAPI.User.getMe(jack.restContext, function(err, me) {
                                         assert.ok(!err);
                                         assert.strictEqual(me.anon, true);
 
@@ -264,13 +254,13 @@ describe('Authentication', function() {
                                         AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
 
                                             // Verify authentication succeeds now
-                                            RestAPI.Authentication.login(jackRestCtx, jackUsername, 'password', function(err) {
+                                            RestAPI.Authentication.login(jack.restContext, jack.restContext.username, 'password', function(err) {
                                                 assert.ok(!err);
 
-                                                RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                                                RestAPI.User.getMe(jack.restContext, function(err, me) {
                                                     assert.ok(!err);
-                                                    assert.equal(me.id, jack.id);
-                                                    callback();
+                                                    assert.equal(me.id, jack.user.id);
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -343,7 +333,7 @@ describe('Authentication', function() {
                         // Log the global admin back in so the cookie jar can be restored
                         RestAPI.Authentication.login(globalAdminRestContext, globalAdminRestContext.username, globalAdminRestContext.userPassword, function(err) {
                             assert.ok(!err);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -358,49 +348,39 @@ describe('Authentication', function() {
          */
         it('verify change password', function(callback) {
             // Create a test user
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Test User', null, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA, userB) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
                 // Try changing the password with a wrong old password
-                RestAPI.Authentication.changePassword(testUserRestContext, userObj.id, 'wrong-password', 'totally-new-password', function(err) {
+                RestAPI.Authentication.changePassword(userA.restContext, userA.user.id, 'wrong-password', 'totally-new-password', function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Try changing the password with the correct old password
-                    RestAPI.Authentication.changePassword(testUserRestContext, userObj.id, 'password', 'totally-new-password', function(err) {
+                    RestAPI.Authentication.changePassword(userA.restContext, userA.user.id, 'password', 'totally-new-password', function(err) {
                         assert.ok(!err);
-                        testUserRestContext.userPassword = 'totally-new-password';
+                        userA.restContext.userPassword = 'totally-new-password';
 
                         // Try changing someone else's password
-                        RestAPI.User.createUser(camAdminRestContext, usernameB, 'password', 'Test User', null, function(err, otherUserObj) {
-                            assert.ok(!err);
-                            assert.ok(otherUserObj);
-                            RestAPI.Authentication.changePassword(testUserRestContext, otherUserObj.id, 'password', 'totally-new-password', function(err) {
+                        RestAPI.Authentication.changePassword(userA.restContext, userB.user.id, 'password', 'totally-new-password', function(err) {
+                            assert.ok(err);
+                            assert.equal(err.code, 401);
+
+                            // Try logging in with the wrong password
+                            RestAPI.Authentication.login(anonymousCamRestContext, userA.restContext.username, 'password', function(err) {
                                 assert.ok(err);
                                 assert.equal(err.code, 401);
 
-                                var anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
-
                                 // Try logging in with the wrong password
-                                RestAPI.Authentication.login(anonymousRestContext, usernameA, 'password', function(err) {
+                                var anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+                                RestAPI.Authentication.login(anonymousRestContext, userA.restContext.username, 'password', function(err) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
 
                                     // Try logging in with the new password
-                                    RestAPI.Authentication.login(anonymousRestContext, usernameA, 'totally-new-password', function(err) {
+                                    RestAPI.Authentication.login(anonymousRestContext, userA.restContext.username, 'totally-new-password', function(err) {
                                         assert.ok(!err);
-
-                                        // Log out again
-                                        RestAPI.Authentication.logout(testUserRestContext, function(err, body, response) {
-                                            assert.ok(!err);
-                                            assert.equal(response.statusCode, 302);
-                                            assert.equal(response.headers.location, '/');
-                                            return callback();
-                                        });
+                                        return callback();
                                     });
                                 });
                             });
@@ -415,17 +395,15 @@ describe('Authentication', function() {
          */
         it('verify admin change password', function(callback) {
             // Create a test user
-            var testUserId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, testUserId, 'password', 'Test User', null, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                assert.ok(userObj);
 
                 // Try to change the password as the anonymous user
-                RestAPI.Authentication.changePassword(anonymousCamRestContext, userObj.id, 'password', 'totally-new-password', function(err) {
+                RestAPI.Authentication.changePassword(anonymousCamRestContext, user.user.id, 'password', 'totally-new-password', function(err) {
                     assert.ok(err);
 
                     // Try to change the password as the tenant admin
-                    RestAPI.Authentication.changePassword(camAdminRestContext, userObj.id, 'password', 'totally-new-password', function(err) {
+                    RestAPI.Authentication.changePassword(camAdminRestContext, user.user.id, 'password', 'totally-new-password', function(err) {
                         assert.ok(!err);
 
                         // make a broken password change request as admin
@@ -435,9 +413,10 @@ describe('Authentication', function() {
 
                             // Try changing passwords for a user with no local strategy
                             var twitterTestUserId = TestsUtil.generateTestUserId();
+                            var email = TestsUtil.generateTestEmailAddress();
                             var ctx = new Context(global.oaeTests.tenants.cam);
                             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, twitterTestUserId);
-                            AuthenticationAPI.createUser(ctx, loginId, 'Twitter User', undefined, function(err, userObj) {
+                            AuthenticationAPI.createUser(ctx, loginId, 'Twitter User', email, {}, function(err, userObj) {
                                 assert.ok(!err);
                                 assert.ok(userObj);
 
@@ -445,7 +424,7 @@ describe('Authentication', function() {
                                     assert.ok(err);
                                     assert.equal(err.code, 400);
 
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });
@@ -498,7 +477,7 @@ describe('Authentication', function() {
                                             assert.ok(err);
                                             assert.equal(err.code, 400);
 
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -524,7 +503,8 @@ describe('Authentication', function() {
                 assert.equal(err.code, 404);
 
                 // Create a user with this login id
-                RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, createdUser) {
+                var email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                     assert.ok(!err);
                     assert.ok(createdUser);
 
@@ -552,7 +532,8 @@ describe('Authentication', function() {
                                         assert.equal(err.code, 404);
 
                                         // Create a user with this login id
-                                        RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'Test User', {'visibility': 'public'}, function(err, createdUser) {
+                                        var email = TestsUtil.generateTestEmailAddress();
+                                        RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'Test User', email, {'visibility': 'public'}, function(err, createdUser) {
                                             assert.ok(!err);
                                             assert.ok(createdUser);
 
@@ -603,7 +584,7 @@ describe('Authentication', function() {
                 // Verify that the existence cannot be checked when an empty string username is provided
                 RestAPI.Authentication.exists(anonymousCamRestContext, '', function(err) {
                     assert.ok(err);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -616,21 +597,22 @@ describe('Authentication', function() {
          * API as this would normally be called by Facebook, Twitter, etc. authentication
          */
         it('verify getOrCreateUser', function(callback) {
-            var userId = TestsUtil.generateTestUserId();
+            var externalId = TestsUtil.generateTestUserId();
             var ctx = new Context(global.oaeTests.tenants.cam);
+            var email = TestsUtil.generateTestEmailAddress();
 
-            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, userId, null, 'Nicolaas Matthijs', null, function(err, userObj, loginId, created) {
+            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Nicolaas Matthijs', email, {}, function(err, userObj, loginId, created) {
                 assert.ok(!err);
                 assert.ok(userObj);
                 assert.strictEqual(created, true);
 
                 // Get the user again through the same function
-                AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, userId, null, 'Branden Visser', null, function(err, userObj, loginId, created) {
+                AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Branden Visser', email, {}, function(err, userObj, loginId, created) {
                     assert.ok(!err);
                     assert.ok(userObj);
                     assert.equal(userObj.displayName, 'Nicolaas Matthijs');
                     assert.strictEqual(created, false);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -643,24 +625,26 @@ describe('Authentication', function() {
          */
         it('verify create without login id', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            AuthenticationAPI.createUser(ctx, undefined, 'Branden Visser', undefined, function(err, userObj) {
+            var email = TestsUtil.generateTestEmailAddress();
+            AuthenticationAPI.createUser(ctx, undefined, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
         /**
-         * Test that verifies that a user cannot be created without a tenant
+         * Test that verifies that a user cannot be created without a tenant alias
          */
-        it('verify create without tenant id', function(callback) {
+        it('verify create without tenant alias', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -670,11 +654,12 @@ describe('Authentication', function() {
         it('verify create without provider', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, undefined, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -683,11 +668,12 @@ describe('Authentication', function() {
          */
         it('verify create without external id', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, undefined, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -698,23 +684,46 @@ describe('Authentication', function() {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Test with `undefined` display name
-            AuthenticationAPI.createUser(ctx, loginId, undefined, null, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, undefined, email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
 
                 // Test with `null` display name
-                AuthenticationAPI.createUser(ctx, loginId, null, null, function(err, userObj) {
+                AuthenticationAPI.createUser(ctx, loginId, null, email, {}, function(err, userObj) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
                     // Test with empty string display name
-                    AuthenticationAPI.createUser(ctx, loginId, '', null, function(err, userObj) {
+                    AuthenticationAPI.createUser(ctx, loginId, '', email, {}, function(err, userObj) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
-                        callback();
+                        return callback();
                     });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that a user cannot be created with an invalid email address
+         */
+        it('verify create with invalid email address', function(callback) {
+            var ctx = new Context(global.oaeTests.tenants.cam);
+            var username = TestsUtil.generateTestUserId();
+            var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
+
+            // Test with no email address
+            AuthenticationAPI.createUser(ctx, loginId, 'Test', null, {}, function(err, userObj) {
+                assert.ok(err);
+                assert.equal(err.code, 400);
+
+                // Test with an invalid email address
+                AuthenticationAPI.createUser(ctx, loginId, 'Test', 'not an email address', {}, function(err, userObj) {
+                    assert.ok(err);
+                    assert.equal(err.code, 400);
+                    return callback();
                 });
             });
         });
@@ -725,11 +734,12 @@ describe('Authentication', function() {
         it('verify create local without password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username);
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -739,11 +749,12 @@ describe('Authentication', function() {
         it('verify create local with short password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -752,10 +763,11 @@ describe('Authentication', function() {
          */
         it('verify create user with local loginId', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
+            var email = TestsUtil.generateTestEmailAddress();
             var username = TestsUtil.generateTestUserId();
             var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(!err);
                 assert.ok(userObj);
 
@@ -780,12 +792,13 @@ describe('Authentication', function() {
         it('verify create user with non-local loginId', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, {
                 'username': username,
                 'userPassword': 'password'
             });
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, username);
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(!err);
                 assert.ok(userObj);
 
@@ -793,7 +806,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, username, function(err, userId) {
                     assert.ok(!err);
                     assert.equal(userId, userObj.id);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -804,6 +817,7 @@ describe('Authentication', function() {
         it('verify creating a user fails if the local login id is already taken', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, {
                 'username': username,
                 'userPassword': 'password'
@@ -811,11 +825,11 @@ describe('Authentication', function() {
 
             // Create the user with the login id
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
                 assert.ok(!err);
 
                 // Ensure we get an error when trying to create a user with the same login id
-                AuthenticationAPI.createUser(ctx, loginId, 'Evil Branden Visser', undefined, function(err) {
+                AuthenticationAPI.createUser(ctx, loginId, 'Evil Branden Visser', email, {}, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
@@ -840,18 +854,18 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Cam Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL',
                 'acceptedTC': 'true'
             };
 
             // Ensure the profile parameters are accurate when creating a tenant administrator as a global administrator
-            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, opts, function(err, user) {
+            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, email, opts, function(err, user) {
                 assert.ok(!err);
                 assert.equal(user.displayName, displayName);
-                assert.equal(user.email, opts.email);
+                assert.equal(user.email, email);
                 assert.equal(user.locale, opts.locale);
                 assert.equal(user.publicAlias, opts.publicAlias);
                 assert.equal(user.visibility, 'private');
@@ -860,7 +874,7 @@ describe('Authentication', function() {
                 RestAPI.User.getUser(globalAdminRestContext, user.id, function(err, user) {
                     assert.ok(!err);
                     assert.equal(user.displayName, displayName);
-                    assert.equal(user.email, opts.email);
+                    assert.equal(user.email, email);
                     assert.equal(user.locale, opts.locale);
                     assert.equal(user.publicAlias, opts.publicAlias);
                     assert.equal(user.visibility, 'private');
@@ -869,10 +883,11 @@ describe('Authentication', function() {
 
                     // Ensure the profile parameters are accurate when creating a new tenant administrator as a tenant administrator
                     username = TestsUtil.generateTestUserId();
-                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, opts, function(err, user) {
+                    email = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, email, opts, function(err, user) {
                         assert.ok(!err);
                         assert.equal(user.displayName, displayName);
-                        assert.equal(user.email, opts.email);
+                        assert.equal(user.email, email);
                         assert.equal(user.locale, opts.locale);
                         assert.equal(user.publicAlias, opts.publicAlias);
                         assert.equal(user.visibility, 'private');
@@ -881,7 +896,7 @@ describe('Authentication', function() {
                         RestAPI.User.getUser(camAdminRestContext, user.id, function(err, user) {
                             assert.ok(!err);
                             assert.equal(user.displayName, displayName);
-                            assert.equal(user.email, opts.email);
+                            assert.equal(user.email, email);
                             assert.equal(user.locale, opts.locale);
                             assert.equal(user.publicAlias, opts.publicAlias);
                             assert.equal(user.visibility, 'private');
@@ -900,27 +915,28 @@ describe('Authentication', function() {
          */
         it('verify authorization of creating a tenant admin user on a tenant', function(callback) {
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, mrvisser) {
                 assert.ok(!err);
 
                 // Ensure anonymous global tenant user cannot create a tenant admin
-                RestAPI.User.createTenantAdminUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                RestAPI.User.createTenantAdminUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Ensure anonymous user tenant user cannot create a tenant admin on a tenant
-                    RestAPI.User.createTenantAdminUserOnTenant(anonymousCamRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                    RestAPI.User.createTenantAdminUserOnTenant(anonymousCamRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 404);
 
                         // Ensure regular user tenant user cannot create a tenant admin on a tenant
-                        RestAPI.User.createTenantAdminUserOnTenant(mrvisser.restContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                        RestAPI.User.createTenantAdminUserOnTenant(mrvisser.restContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 404);
 
                             // Sanity check global admin can create a tenant administrator on another tenant
-                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                                 assert.ok(!err);
 
                                 return callback();
@@ -936,22 +952,23 @@ describe('Authentication', function() {
          */
         it('verify authorization of creating a tenant admin user on the current tenant', function(callback) {
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, mrvisser) {
                 assert.ok(!err);
 
                 // Ensure anonymous users cannot create tenant admins
-                RestAPI.User.createTenantAdminUser(anonymousCamRestContext, username, 'password', 'displayName', null, function(err, user) {
+                RestAPI.User.createTenantAdminUser(anonymousCamRestContext, username, 'password', 'displayName', email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Ensure regular users cannot create tenant admins
-                    RestAPI.User.createTenantAdminUser(mrvisser.restContext, username, 'password', 'displayName', null, function(err, user) {
+                    RestAPI.User.createTenantAdminUser(mrvisser.restContext, username, 'password', 'displayName', email, {}, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 401);
 
                         // Sanity check a tenant administrator can create a new tenant administrator on the tenant
-                        RestAPI.User.createTenantAdminUser(camAdminRestContext, username, 'password', 'displayName', null, function(err, user) {
+                        RestAPI.User.createTenantAdminUser(camAdminRestContext, username, 'password', 'displayName', email, {}, function(err, user) {
                             assert.ok(!err);
 
                             return callback();
@@ -968,15 +985,15 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Cam Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL',
                 'acceptedTC': 'true'
             };
 
             // Ensure a tenant alias is required
-            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, null, username, password, displayName, opts, function(err, user) {
+            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, null, username, password, displayName, email, opts, function(err, user) {
                 assert.ok(err);
 
                 // Note that this technically hits the "update user" endpoint with user id "createTenantAdmin". The mistake can be so subtle in
@@ -984,30 +1001,40 @@ describe('Authentication', function() {
                 assert.equal(err.code, 400);
 
                 // Ensure a username is required
-                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, null, password, displayName, opts, function(err, user) {
+                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, null, password, displayName, email, opts, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
                     // Ensure a password is required
-                    RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, null, displayName, opts, function(err, user) {
+                    RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, null, displayName, email, opts, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
 
                         // Ensure a displayName is required
-                        RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, null, opts, function(err, user) {
+                        RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, null, email, opts, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
 
-                            // Ensure target tenant cannot be the global admin tenant
-                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, 'admin', username, password, displayName, opts, function(err, user) {
+                            // Ensure a valid email is required
+                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, null, opts, function(err, user) {
                                 assert.ok(err);
                                 assert.equal(err.code, 400);
+                                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, 'Not an email', opts, function(err, user) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 400);
 
-                                // Sanity check we can create one with these parameters
-                                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, opts, function(err, user) {
-                                    assert.ok(!err);
+                                    // Ensure target tenant cannot be the global admin tenant
+                                    RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, 'admin', username, password, displayName, email, opts, function(err, user) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 400);
 
-                                    return callback();
+                                        // Sanity check we can create one with these parameters
+                                        RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, email, opts, function(err, user) {
+                                            assert.ok(!err);
+
+                                            return callback();
+                                        });
+                                    });
                                 });
                             });
                         });
@@ -1023,38 +1050,48 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Cam Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL',
                 'acceptedTC': 'true'
             };
 
             // Ensure a username is required
-            RestAPI.User.createTenantAdminUser(camAdminRestContext, null, password, displayName, opts, function(err, user) {
+            RestAPI.User.createTenantAdminUser(camAdminRestContext, null, password, displayName, email, opts, function(err, user) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
 
                 // Ensure a password is required
-                RestAPI.User.createTenantAdminUser(camAdminRestContext, username, null, displayName, opts, function(err, user) {
+                RestAPI.User.createTenantAdminUser(camAdminRestContext, username, null, displayName, email, opts, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
                     // Ensure a displayName is required
-                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, null, opts, function(err, user) {
+                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, null, email, opts, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
 
-                        // Ensure target tenant cannot be the global admin tenant by requesting with the global administrator
-                        RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, opts, function(err, user) {
+                        // Ensure a valid email is required
+                        RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, null, opts, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
+                            RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, 'Not an email', opts, function(err, user) {
+                                assert.ok(err);
+                                assert.equal(err.code, 400);
 
-                            // Sanity check we can create one with these parameters
-                            RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, opts, function(err, user) {
-                                assert.ok(!err);
+                                // Ensure target tenant cannot be the global admin tenant by requesting with the global administrator
+                                RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, email, opts, function(err, user) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 400);
 
-                                return callback();
+                                    // Sanity check we can create one with these parameters
+                                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, email, opts, function(err, user) {
+                                        assert.ok(!err);
+
+                                        return callback();
+                                    });
+                                });
                             });
                         });
                     });
@@ -1072,16 +1109,16 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Global Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL'
             };
 
-            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, password, displayName, opts, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, password, displayName, email, opts, function(err, user) {
                 assert.ok(!err);
                 assert.equal(user.displayName, displayName);
-                assert.equal(user.email, opts.email);
+                assert.equal(user.email, email);
                 assert.equal(user.locale, opts.locale);
                 assert.equal(user.publicAlias, opts.publicAlias);
                 assert.equal(user.visibility, 'private');
@@ -1089,7 +1126,7 @@ describe('Authentication', function() {
                 RestAPI.User.getUser(globalAdminRestContext, user.id, function(err, user) {
                     assert.ok(!err);
                     assert.equal(user.displayName, displayName);
-                    assert.equal(user.email, opts.email);
+                    assert.equal(user.email, email);
                     assert.equal(user.locale, opts.locale);
                     assert.equal(user.publicAlias, opts.publicAlias);
                     assert.equal(user.visibility, 'private');
@@ -1105,10 +1142,11 @@ describe('Authentication', function() {
          */
         it('verify authorization of creating a global admin user', function(callback) {
             var userId = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Ensure anonymous on cam tenant cannot create a global admin user. We expect a 404 because the endpoint is
             // only mounted on the global tenant
-            RestAPI.User.createGlobalAdminUser(anonymousCamRestContext, userId, userId, userId, null, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(anonymousCamRestContext, userId, userId, userId, email, {}, function(err, user) {
                 assert.ok(err);
 
                 // Note that this technically hits the "update user" endpoint with user id "createGlobalAdmin". The mistake can be so subtle in
@@ -1117,14 +1155,14 @@ describe('Authentication', function() {
                 assert.ok(!user);
 
                 // Ensure anonymous on global admin tenant cannot create a global admin user
-                RestAPI.User.createGlobalAdminUser(anonymousGlobalRestContext, userId, userId, userId, null, function(err, user) {
+                RestAPI.User.createGlobalAdminUser(anonymousGlobalRestContext, userId, userId, userId, email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
                     assert.ok(!user);
 
                     // Ensure tenant admin on cam tenant cannot create a global admin user. We expect a 404 because the endpoint is
                     // only mounted on the global tenant
-                    RestAPI.User.createGlobalAdminUser(camAdminRestContext, userId, userId, userId, null, function(err, user) {
+                    RestAPI.User.createGlobalAdminUser(camAdminRestContext, userId, userId, userId, email, {}, function(err, user) {
                         assert.ok(err);
 
                         // Note that this technically hits the "update user" endpoint with user id "createGlobalAdmin". The mistake can be so subtle in
@@ -1145,7 +1183,7 @@ describe('Authentication', function() {
                                 assert.ok(me.anon);
 
                                 // Sanity check that we can create the user and authenticate its context
-                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, null, function(err, user) {
+                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, email, {}, function(err, user) {
                                     assert.ok(!err);
                                     assert.ok(user);
                                     assert.equal(user.displayName, userId);
@@ -1173,55 +1211,75 @@ describe('Authentication', function() {
          */
         it('verify validation of creating a global admin user', function(callback) {
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Ensure you cannot create a global admin user without a username
-            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, null, username, username, null, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, null, username, username, email, {}, function(err, user) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 assert.ok(!user);
 
                 // Ensure you cannot create a global admin user without a password
-                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, null, username, null, function(err, user) {
+                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, null, username, email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
                     assert.ok(!user);
 
                     // Ensure you cannot create a global admin user with a password that is too short
-                    RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, 'a', username, null, function(err, user) {
+                    RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, 'a', username, email, {}, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
                         assert.ok(!user);
 
                         // Ensure you cannot create a global admin user without a displayName
-                        RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, null, function(err, user) {
+                        RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, email, {}, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
                             assert.ok(!user);
 
-                            // Ensure the global admin still cannot be authenticated
-                            var testGlobalUserRestContext = TestsUtil.createGlobalRestContext();
-
-                            // Ensure that the credentials do not authenticate a value global administrator
-                            RestAPI.Authentication.login(testGlobalUserRestContext, username, username, function(err) {
+                            // Ensure you cannot create a global admin user without a valid email address
+                            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, null, {}, function(err, user) {
                                 assert.ok(err);
-                                assert.equal(err.code, 401);
+                                assert.equal(err.code, 400);
+                                assert.ok(!user);
+                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, 'not an email', {}, function(err, user) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 400);
+                                    assert.ok(!user);
 
-                                // Verify the context was not authenticated
-                                RestAPI.User.getMe(testGlobalUserRestContext, function(err, me) {
-                                    assert.ok(!err);
-                                    assert.ok(me.anon);
+                                    // Ensure the global admin still cannot be authenticated
+                                    var testGlobalUserRestContext = TestsUtil.createGlobalRestContext();
 
-                                    // Sanity check the user can be created through the REST endpoints
-                                    RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, null, function(err, user) {
-                                        assert.ok(!err);
-                                        assert.ok(user);
+                                    // Ensure that the credentials do not authenticate a value global administrator
+                                    RestAPI.Authentication.login(testGlobalUserRestContext, username, username, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
 
-                                        // Ensure when we try and create one with the same loginId, we get a 400 error
-                                        RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, null, function(err, secondUser) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 400);
+                                        // Verify the context was not authenticated
+                                        RestAPI.User.getMe(testGlobalUserRestContext, function(err, me) {
+                                            assert.ok(!err);
+                                            assert.ok(me.anon);
 
-                                            return callback();
+                                            // Sanity check the user can be created through the REST endpoints
+                                            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, email, {}, function(err, user) {
+                                                assert.ok(!err);
+                                                assert.ok(user);
+
+                                                // Ensure when we try and create one with the same loginId, we get a 400 error
+                                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, email, {}, function(err, secondUser) {
+                                                    assert.ok(err);
+                                                    assert.equal(err.code, 400);
+
+                                                    // Ensure when we try and create one with the same email address, we get a 400 error
+                                                    username = TestsUtil.generateTestUserId();
+                                                    RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, email, {}, function(err, secondUser) {
+                                                        assert.ok(err);
+                                                        assert.equal(err.code, 400);
+
+                                                        return callback();
+                                                    });
+                                                });
+                                            });
                                         });
                                     });
                                 });
@@ -1237,9 +1295,10 @@ describe('Authentication', function() {
          */
         it('verify creating global admin user results in a user that has global admin user privileges', function(callback) {
             var userId = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Create a global admin user
-            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, null, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, email, {}, function(err, user) {
                 assert.ok(!err);
 
                 // Log them in
@@ -1269,17 +1328,15 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a login id
          */
         it('verify associate without loginId', function(callback) {
-            var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                var userId = TestsUtil.generateTestUserId();
-                ctx = new Context(global.oaeTests.tenants.cam, user);
 
                 // Associate a login id to the user, with no login id
-                AuthenticationAPI.associateLoginId(ctx, undefined, user.id, function(err) {
+                var ctx = new Context(global.oaeTests.tenants.cam, user.user);
+                AuthenticationAPI.associateLoginId(ctx, undefined, user.user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1288,18 +1345,16 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a tenant
          */
         it('verify associate without tenant', function(callback) {
-            var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                var userId = TestsUtil.generateTestUserId();
-                ctx = new Context(global.oaeTests.tenants.cam, user);
-                var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, userId, {'password': 'password'});
 
                 // Associate a login id to the user, with no tenant
-                AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
+                var ctx = new Context(global.oaeTests.tenants.cam, user.user);
+                var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, user.user.id, {'password': 'password'});
+                AuthenticationAPI.associateLoginId(ctx, loginId, user.user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1308,18 +1363,16 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a login provider
          */
         it('verify associate without provider', function(callback) {
-            var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                var userId = TestsUtil.generateTestUserId();
-                ctx = new Context(global.oaeTests.tenants.cam, user);
-                var loginId = new LoginId(ctx.tenant().alias, undefined, userId, {'password': 'password'});
 
                 // Associate a login id to the user, with no login provider
+                var ctx = new Context(global.oaeTests.tenants.cam, user.user);
+                var loginId = new LoginId(ctx.tenant().alias, undefined, user.user.id, {'password': 'password'});
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1328,8 +1381,9 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without an external id
          */
         it('verify associate without external id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1339,7 +1393,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1348,8 +1402,9 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a user id
          */
         it('verify associate without user id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1359,7 +1414,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, undefined, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1369,7 +1424,8 @@ describe('Authentication', function() {
          */
         it('verify associate local without password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1379,7 +1435,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1389,7 +1445,8 @@ describe('Authentication', function() {
          */
         it('verify associate local with short password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1399,7 +1456,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1409,7 +1466,8 @@ describe('Authentication', function() {
          */
         it('verify associate login id to self', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1423,7 +1481,7 @@ describe('Authentication', function() {
                     AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, userId, function(err, userId) {
                         assert.ok(!err);
                         assert.equal(user.id, userId);
-                        callback();
+                        return callback();
                     });
                 });
             });
@@ -1434,7 +1492,8 @@ describe('Authentication', function() {
          */
         it('verify associate multiple login ids to self', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
                 var twitterId = TestsUtil.generateTestUserId() + ':withcolon';
@@ -1457,7 +1516,7 @@ describe('Authentication', function() {
                             AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, twitterId, function(err, userId) {
                                 assert.ok(!err);
                                 assert.equal(user.id, userId);
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -1469,8 +1528,9 @@ describe('Authentication', function() {
          * Test that verifies that an admin user can associate a login id to a user id
          */
         it('verify admin associate login id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
 
@@ -1482,7 +1542,7 @@ describe('Authentication', function() {
                     AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, userId, function(err, userId) {
                         assert.ok(!err);
                         assert.equal(user.id, userId);
-                        callback();
+                        return callback();
                     });
                 });
             });
@@ -1492,12 +1552,14 @@ describe('Authentication', function() {
          * Test that verifies that a user cannot associate a login id to someone else's user id
          */
         it('verify another user cannot associate login id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, mrvisser) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, mrvisser) {
                 assert.ok(!err);
                 var mrvisserUsername = TestsUtil.generateTestUserId() + ':withcolon';
 
-                PrincipalsAPI.createUser(ctx, null, 'Bert Pareyn', undefined, function(err, bert) {
+                email = TestsUtil.generateTestEmailAddress();
+                PrincipalsAPI.createUser(ctx, null, 'Bert Pareyn', email, {}, function(err, bert) {
                     assert.ok(!err);
                     var bertCtx = new Context(global.oaeTests.tenants.cam, bert);
 
@@ -1511,7 +1573,7 @@ describe('Authentication', function() {
                             assert.ok(err);
                             assert.equal(err.code, 404);
                             assert.ok(!mrvisserId);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1522,8 +1584,9 @@ describe('Authentication', function() {
          * Test that verifies that a user can only be mapped to 1 login id per login provider
          */
         it('verify cannot associate multiple login ids of same type', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
                 var userId2 = TestsUtil.generateTestUserId() + ':withcolon';
@@ -1548,7 +1611,7 @@ describe('Authentication', function() {
                                 assert.ok(err);
                                 assert.equal(err.code, 404);
                                 assert.ok(!userId);
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -1563,12 +1626,14 @@ describe('Authentication', function() {
             var adminCtx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
             var mrvisserUsername = TestsUtil.generateTestUserId() + ':withcolon';
             var mrvisserLoginId = new LoginId(global.oaeTests.tenants.cam.alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername);
+            var mrvisserEmail = TestsUtil.generateTestEmailAddress();
             var bertUsername = TestsUtil.generateTestUserId() + ':withcolon';
             var bertLoginId = new LoginId(global.oaeTests.tenants.cam.alias, AuthenticationConstants.providers.LOCAL, bertUsername, {'password': 'password'});
-            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', undefined, function(err, mrvisser) {
+            var bertEmail = TestsUtil.generateTestEmailAddress();
+            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', mrvisserEmail, {}, function(err, mrvisser) {
                 assert.ok(!err);
 
-                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', undefined, function(err, bert) {
+                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', bertEmail, {}, function(err, bert) {
                     assert.ok(!err);
 
                     AuthenticationAPI.associateLoginId(adminCtx, new LoginId(adminCtx.tenant().alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername), bert.id, function(err) {
@@ -1577,7 +1642,7 @@ describe('Authentication', function() {
                         AuthenticationAPI.getUserIdFromLoginId(adminCtx.tenant().alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername, function(err, userId) {
                             assert.ok(!err);
                             assert.equal(userId, bert.id);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1593,7 +1658,7 @@ describe('Authentication', function() {
                 assert.ok(err);
                 assert.equal(err.code, 404);
                 assert.ok(!userId);
-                callback();
+                return callback();
             });
         });
 
@@ -1605,12 +1670,14 @@ describe('Authentication', function() {
             var adminCtx = TestsUtil.createTenantAdminContext(tenant);
             var mrvisserUsername = TestsUtil.generateTestUserId();
             var mrvisserLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername);
+            var mrvisserEmail = TestsUtil.generateTestEmailAddress();
             var bertUsername = TestsUtil.generateTestUserId();
             var bertLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, bertUsername, {'password': 'password'});
-            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', undefined, function(err, mrvisser) {
+            var bertEmail = TestsUtil.generateTestEmailAddress();
+            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', mrvisserEmail, {}, function(err, mrvisser) {
                 assert.ok(!err);
 
-                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', undefined, function(err, bert) {
+                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', bertEmail, {}, function(err, bert) {
                     assert.ok(!err);
                     var bertCtx = new Context(tenant, bert);
 
@@ -1621,7 +1688,7 @@ describe('Authentication', function() {
                         AuthenticationAPI.getUserIdFromLoginId(tenant.alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername, function(err, userId) {
                             assert.ok(!err);
                             assert.equal(userId, mrvisser.id);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1635,7 +1702,7 @@ describe('Authentication', function() {
             AuthenticationAPI.getUserIdFromLoginId(tenant.alias, AuthenticationConstants.providers.TWITTER, '', function(err, userId) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
     });
@@ -1663,7 +1730,7 @@ describe('Authentication', function() {
                 assert.ok(tenant);
                 assert.ok(tenant.alias);
                 assert.equal(tenant.alias, global.oaeTests.tenants.cam.alias);
-                callback();
+                return callback();
             });
 
             // Refresh and propagate to the event binding above

--- a/node_modules/oae-authentication/tests/test-auth-local.js
+++ b/node_modules/oae-authentication/tests/test-auth-local.js
@@ -416,7 +416,7 @@ describe('Authentication', function() {
                             var email = TestsUtil.generateTestEmailAddress();
                             var ctx = new Context(global.oaeTests.tenants.cam);
                             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, twitterTestUserId);
-                            AuthenticationAPI.createUser(ctx, loginId, 'Twitter User', email, {}, function(err, userObj) {
+                            AuthenticationAPI.createUser(ctx, loginId, 'Twitter User', {'email': email}, function(err, userObj) {
                                 assert.ok(!err);
                                 assert.ok(userObj);
 
@@ -601,13 +601,13 @@ describe('Authentication', function() {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var email = TestsUtil.generateTestEmailAddress();
 
-            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Nicolaas Matthijs', email, {}, function(err, userObj, loginId, created) {
+            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Nicolaas Matthijs', {'email': email}, function(err, userObj, loginId, created) {
                 assert.ok(!err);
                 assert.ok(userObj);
                 assert.strictEqual(created, true);
 
                 // Get the user again through the same function
-                AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Branden Visser', email, {}, function(err, userObj, loginId, created) {
+                AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Branden Visser', {'email': email}, function(err, userObj, loginId, created) {
                     assert.ok(!err);
                     assert.ok(userObj);
                     assert.equal(userObj.displayName, 'Nicolaas Matthijs');
@@ -626,7 +626,7 @@ describe('Authentication', function() {
         it('verify create without login id', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var email = TestsUtil.generateTestEmailAddress();
-            AuthenticationAPI.createUser(ctx, undefined, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, undefined, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 return callback();
@@ -641,7 +641,7 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 return callback();
@@ -656,7 +656,7 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, undefined, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 return callback();
@@ -670,7 +670,7 @@ describe('Authentication', function() {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, undefined, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 return callback();
@@ -687,17 +687,17 @@ describe('Authentication', function() {
             var email = TestsUtil.generateTestEmailAddress();
 
             // Test with `undefined` display name
-            AuthenticationAPI.createUser(ctx, loginId, undefined, email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, undefined, {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
 
                 // Test with `null` display name
-                AuthenticationAPI.createUser(ctx, loginId, null, email, {}, function(err, userObj) {
+                AuthenticationAPI.createUser(ctx, loginId, null, {'email': email}, function(err, userObj) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
                     // Test with empty string display name
-                    AuthenticationAPI.createUser(ctx, loginId, '', email, {}, function(err, userObj) {
+                    AuthenticationAPI.createUser(ctx, loginId, '', {'email': email}, function(err, userObj) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
                         return callback();
@@ -714,17 +714,11 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
 
-            // Test with no email address
-            AuthenticationAPI.createUser(ctx, loginId, 'Test', null, {}, function(err, userObj) {
+            // Test with an invalid email address
+            AuthenticationAPI.createUser(ctx, loginId, 'Test', {'email': 'not an email address'}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-
-                // Test with an invalid email address
-                AuthenticationAPI.createUser(ctx, loginId, 'Test', 'not an email address', {}, function(err, userObj) {
-                    assert.ok(err);
-                    assert.equal(err.code, 400);
-                    return callback();
-                });
+                return callback();
             });
         });
 
@@ -736,7 +730,7 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username);
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 return callback();
@@ -751,7 +745,7 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 return callback();
@@ -767,7 +761,7 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(!err);
                 assert.ok(userObj);
 
@@ -798,7 +792,7 @@ describe('Authentication', function() {
                 'userPassword': 'password'
             });
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, username);
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(!err);
                 assert.ok(userObj);
 
@@ -825,11 +819,11 @@ describe('Authentication', function() {
 
             // Create the user with the login id
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', email, {}, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(!err);
 
                 // Ensure we get an error when trying to create a user with the same login id
-                AuthenticationAPI.createUser(ctx, loginId, 'Evil Branden Visser', email, {}, function(err) {
+                AuthenticationAPI.createUser(ctx, loginId, 'Evil Branden Visser', {'email': email}, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
@@ -1383,7 +1377,7 @@ describe('Authentication', function() {
         it('verify associate without external id', function(callback) {
             var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1404,7 +1398,7 @@ describe('Authentication', function() {
         it('verify associate without user id', function(callback) {
             var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1425,7 +1419,7 @@ describe('Authentication', function() {
         it('verify associate local without password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var email = TestsUtil.generateTestEmailAddress();
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1446,7 +1440,7 @@ describe('Authentication', function() {
         it('verify associate local with short password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var email = TestsUtil.generateTestEmailAddress();
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1467,7 +1461,7 @@ describe('Authentication', function() {
         it('verify associate login id to self', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var email = TestsUtil.generateTestEmailAddress();
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1493,7 +1487,7 @@ describe('Authentication', function() {
         it('verify associate multiple login ids to self', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var email = TestsUtil.generateTestEmailAddress();
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
                 var twitterId = TestsUtil.generateTestUserId() + ':withcolon';
@@ -1530,7 +1524,7 @@ describe('Authentication', function() {
         it('verify admin associate login id', function(callback) {
             var email = TestsUtil.generateTestEmailAddress();
             var ctx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
 
@@ -1554,12 +1548,12 @@ describe('Authentication', function() {
         it('verify another user cannot associate login id', function(callback) {
             var email = TestsUtil.generateTestEmailAddress();
             var ctx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, mrvisser) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, mrvisser) {
                 assert.ok(!err);
                 var mrvisserUsername = TestsUtil.generateTestUserId() + ':withcolon';
 
                 email = TestsUtil.generateTestEmailAddress();
-                PrincipalsAPI.createUser(ctx, null, 'Bert Pareyn', email, {}, function(err, bert) {
+                PrincipalsAPI.createUser(ctx, null, 'Bert Pareyn', {'email': email}, function(err, bert) {
                     assert.ok(!err);
                     var bertCtx = new Context(global.oaeTests.tenants.cam, bert);
 
@@ -1586,7 +1580,7 @@ describe('Authentication', function() {
         it('verify cannot associate multiple login ids of same type', function(callback) {
             var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', email, {}, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
                 var userId2 = TestsUtil.generateTestUserId() + ':withcolon';
@@ -1630,10 +1624,10 @@ describe('Authentication', function() {
             var bertUsername = TestsUtil.generateTestUserId() + ':withcolon';
             var bertLoginId = new LoginId(global.oaeTests.tenants.cam.alias, AuthenticationConstants.providers.LOCAL, bertUsername, {'password': 'password'});
             var bertEmail = TestsUtil.generateTestEmailAddress();
-            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', mrvisserEmail, {}, function(err, mrvisser) {
+            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', {'email': mrvisserEmail}, function(err, mrvisser) {
                 assert.ok(!err);
 
-                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', bertEmail, {}, function(err, bert) {
+                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', {'email': bertEmail}, function(err, bert) {
                     assert.ok(!err);
 
                     AuthenticationAPI.associateLoginId(adminCtx, new LoginId(adminCtx.tenant().alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername), bert.id, function(err) {
@@ -1674,10 +1668,10 @@ describe('Authentication', function() {
             var bertUsername = TestsUtil.generateTestUserId();
             var bertLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, bertUsername, {'password': 'password'});
             var bertEmail = TestsUtil.generateTestEmailAddress();
-            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', mrvisserEmail, {}, function(err, mrvisser) {
+            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', {'email': mrvisserEmail}, function(err, mrvisser) {
                 assert.ok(!err);
 
-                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', bertEmail, {}, function(err, bert) {
+                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', {'email': bertEmail}, function(err, bert) {
                     assert.ok(!err);
                     var bertCtx = new Context(tenant, bert);
 

--- a/node_modules/oae-authentication/tests/test-auth-local.js
+++ b/node_modules/oae-authentication/tests/test-auth-local.js
@@ -1244,7 +1244,7 @@ describe('Authentication', function() {
                                     // Ensure the global admin still cannot be authenticated
                                     var testGlobalUserRestContext = TestsUtil.createGlobalRestContext();
 
-                                    // Ensure that the credentials do not authenticate a value global administrator
+                                    // Ensure that the credentials do not authenticate a valid global administrator
                                     RestAPI.Authentication.login(testGlobalUserRestContext, username, username, function(err) {
                                         assert.ok(err);
                                         assert.equal(err.code, 401);

--- a/node_modules/oae-authentication/tests/test-cookies.js
+++ b/node_modules/oae-authentication/tests/test-cookies.js
@@ -153,7 +153,8 @@ describe('Authentication', function() {
 
             // Create a test user
             var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, createdUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                 assert.ok(!err);
                 var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 

--- a/node_modules/oae-authentication/tests/test-external-strategies.js
+++ b/node_modules/oae-authentication/tests/test-external-strategies.js
@@ -67,23 +67,14 @@ describe('Authentication', function() {
         // Enable strategy
         var configUpdate = {};
         configUpdate['oae-authentication/' + strategyName + '/enabled'] = true;
-        ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-            assert.ok(!err);
-        });
-
-        // Wait until the authentication api has finished refreshing its strategies
-        AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+        AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
             // The strategy has been enabled, perform some assertions
             enabledCallback(function() {
+
                 // Reset strategy to cached status
                 configUpdate['oae-authentication/' + strategyName + '/enabled'] = strategyStatus;
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                    assert.ok(!err);
-                });
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-                    return resetCallback();
-                });
+                return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, resetCallback);
             });
         });
     };
@@ -114,12 +105,7 @@ describe('Authentication', function() {
                 // Now disable it
                 var configUpdate = {};
                 configUpdate['oae-authentication/' + strategyName + '/enabled'] = false;
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, 'localhost', configUpdate, function() {
-                    assert.ok(!err);
-                });
-
-                // Wait until the authentication api has finished refreshing its strategies
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+                AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                     // A disabled endpoint should return a 401.
                     request(options, function (err, response, body) {
@@ -382,6 +368,7 @@ describe('Authentication', function() {
         // A string that can be used with our mocked CAS server that will return a succesfull response
         var validTicket = null;
         var externalId = null;
+        var email = null;
 
         /**
          * Function that will start up a mocked CAS server. The url will be configured for the `localhost` tenant
@@ -394,6 +381,7 @@ describe('Authentication', function() {
 
                 validTicket = 'ticket-' + _.random(0, 10000);
                 externalId = 'sg555@' + _.random(0, 10000);
+                email = TestsUtil.generateTestEmailAddress();
                 app.get('/cas/serviceValidate', function(req, res) {
                     if (req.query.ticket === validTicket) {
                         var successXml = '<cas:serviceResponse>';
@@ -401,7 +389,7 @@ describe('Authentication', function() {
                         successXml += '<cas:user>' + externalId + '</cas:user>';
                         successXml += '<cas:attributes>';
                         successXml += '  <cas:displayName>Simon</cas:displayName>';
-                        successXml += '  <cas:email>simon@test.com</cas:email>';
+                        successXml += '  <cas:email>' + email + '</cas:email>';
                         successXml += '</cas:attributes>';
                         successXml += '</cas:authenticationSuccess>';
                         successXml += '</cas:serviceResponse>';
@@ -417,14 +405,7 @@ describe('Authentication', function() {
                 configUpdate['oae-authentication/cas/loginPath'] = '/login';
                 configUpdate['oae-authentication/cas/mapDisplayName'] = '{displayName}';
                 configUpdate['oae-authentication/cas/mapEmail'] = '{email}';
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                    assert.ok(!err);
-                });
-
-                // Wait until the authentication api has finished refreshing its strategies
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-                    return callback();
-                });
+                return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, callback);
             });
         });
 
@@ -473,8 +454,7 @@ describe('Authentication', function() {
 
                     // Configure the login path
                     var configUpdate = {'oae-authentication/cas/loginPath': '/login/something/foo'};
-                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                        assert.ok(!err);
+                    AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                         // The CAS redirect should now redirect to the new login url
                         RestAPI.Authentication.casRedirect(restContext, function(err, body, response) {
@@ -526,10 +506,7 @@ describe('Authentication', function() {
             // By configuring the CAS url to something non existant, we will trigger an error in the validation step
             var configUpdate = {};
             configUpdate['oae-authentication/cas/url'] = 'http://nothing.here.local';
-            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                assert.ok(!err);
-            });
-            AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+            AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                 _enableStrategy('cas', function(done) {
                     // Trigger a ticket validation error by attempting to log in
@@ -563,7 +540,7 @@ describe('Authentication', function() {
                         assert.ok(!err);
                         assert.ok(!me.anon);
                         assert.strictEqual(me.displayName, 'Simon');
-                        assert.strictEqual(me.email, 'simon@test.com');
+                        assert.strictEqual(me.email, email);
                         assert.strictEqual(me.authenticationStrategy, 'cas');
 
                         return done();
@@ -581,13 +558,7 @@ describe('Authentication', function() {
                 // Misconfigure some attributes
                 var configUpdate = {};
                 configUpdate['oae-authentication/cas/mapDisplayName'] = '}displayname{';
-                configUpdate['oae-authentication/cas/mapEmail'] = '{oh lawdy}';
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                    assert.ok(!err);
-                });
-
-                // Wait until the authentication api has finished refreshing its strategies
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+                AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                     // Log in with our CAS server, authentication should succeed
                     var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.localhost.host);
@@ -606,8 +577,6 @@ describe('Authentication', function() {
                             // Nothing can be replaced from the attribute template, so we use it as-is
                             assert.strictEqual(me.displayName, '}displayname{');
 
-                            // The email should not be configured
-                            assert.ok(!me.email);
                             return done();
                         });
                     });
@@ -622,10 +591,8 @@ describe('Authentication', function() {
         it('verify CAS logout', function(callback) {
             var configUpdate = {};
             configUpdate['oae-authentication/cas/logoutUrl'] = 'http://localhost:' + port + '/cas/logout';
-            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                assert.ok(!err);
-            });
-            AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+            AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
+
                 _enableStrategy('cas', function(done) {
                     // Log in with our CAS server
                     var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.localhost.host);
@@ -673,14 +640,7 @@ describe('Authentication', function() {
             // Setup the Shibboleth strategy (but do not enable it just yet)
             var configUpdate = {};
             configUpdate['oae-authentication/shibboleth/idpEntityID'] = 'https://idp.example.com/shibboleth';
-            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                assert.ok(!err);
-            });
-
-            // Wait until the authentication api has finished refreshing its strategies
-            AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-                return callback();
-            });
+            return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, callback);
         });
 
         /**
@@ -811,6 +771,7 @@ describe('Authentication', function() {
                 // Initiate the Shibboleth auth flow
                 _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
 
+                    var email = TestsUtil.generateTestEmailAddress();
                     var attributes = {
                         // Fake a session ID to log in
                         'shib-session-id': Math.random(),
@@ -826,7 +787,7 @@ describe('Authentication', function() {
 
                         // Pass along some attributes
                         'displayname': 'Simon',
-                        'email': 'simon@test.com',
+                        'email': email,
                         'locale': 'en_UK'
                     };
 
@@ -839,7 +800,53 @@ describe('Authentication', function() {
                             assert.ok(!me.anon);
                             assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                             assert.strictEqual(me.displayName, 'Simon');
-                            assert.strictEqual(me.email, 'simon@test.com');
+                            assert.strictEqual(me.email, email);
+                            assert.strictEqual(me.locale, 'en_UK');
+                            return done();
+                        });
+                    });
+                });
+            }, callback);
+        });
+
+        /**
+         * Test that verifies that the remote_user attribute is used when no displayName attributes are specified
+         */
+        it('verify the remote_user attribute is used when no displayName attributes are specified', function(callback) {
+            _enableStrategy('shibboleth', function(done) {
+
+                // Initiate the Shibboleth auth flow
+                _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
+
+                    var email = TestsUtil.generateTestEmailAddress();
+                    var attributes = {
+                        // Fake a session ID to log in
+                        'shib-session-id': Math.random(),
+
+                        // Fake some data about the IdP
+                        'persistent-id': 'https://idp.example.com/shibboleth#https://sp.example.com/shibboleth#' + Math.random(),
+                        'identityProvider': 'https://idp.example.com/shibboleth',
+                        'affiliation': 'Digital Services',
+                        'unscopedAffiliation': 'OAE Team',
+
+                        // Generate an external id
+                        'remote_user': 'simon' + Math.random(),
+
+                        // Pass along some attributes, but don't specify a display name attribute
+                        'email': email,
+                        'locale': 'en_UK'
+                    };
+
+                    // Perform the callback part of the authentication flow
+                    _callbackShibbolethAuthFlow(tenantRestContext, spRestContext, attributes, '/content/bla', function() {
+
+                        // Assert we're logged in and the attributes were correctly persisted
+                        RestAPI.User.getMe(tenantRestContext, function(err, me) {
+                            assert.ok(!err);
+                            assert.ok(!me.anon);
+                            assert.strictEqual(me.authenticationStrategy, 'shibboleth');
+                            assert.strictEqual(me.displayName, attributes.remote_user);
+                            assert.strictEqual(me.email, email);
                             assert.strictEqual(me.locale, 'en_UK');
                             return done();
                         });
@@ -969,12 +976,7 @@ describe('Authentication', function() {
                     // Configure the attribute priority list so it tries an `employee-numer`
                     var configUpdate = {};
                     configUpdate['oae-authentication/shibboleth/externalIdAttributes'] = 'irrelevant-attribute employee-number eppn persistent-id targeted-id';
-                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                        assert.ok(!err);
-                    });
-
-                    // Wait until the authentication api has finished refreshing its strategies
-                    AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+                    AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                         // Initiate the Shibboleth auth flow
                         _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
@@ -1153,38 +1155,8 @@ describe('Authentication', function() {
         });
 
         /**
-         * Test that verifies that an invalid eppn attribute is not used as an email address
+         * TODO: Test that verifies that an invalid email triggers the "no email when using SSO" flow
          */
-        it('verify an invalid eppn attribute is not used as an email address', function(callback) {
-            _enableStrategy('shibboleth', function(done) {
-                _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
-                    var attributes = {
-                        'shib-session-id': _.random(10000),
-                        'persistent-id': 'https://idp.example.com/shibboleth#https://sp.example.com/shibboleth#' + Math.random(),
-                        'identityProvider': 'https://idp.example.com/shibboleth',
-                        'affiliation': 'Digital Services',
-                        'unscopedAffiliation': 'OAE Team',
-                        'remote_user': 'simon' + _.random(10000),
-
-                        // Use an invalid `email` attribute. This should not be stored against the user
-                        'displayname': 'Simon',
-                        'email': 'Simon@backend@oae@apereo.org',
-                        'locale': 'en_UK'
-                    };
-                    _callbackShibbolethAuthFlow(tenantRestContext, spRestContext, attributes, '/content/bla', function() {
-                        RestAPI.User.getMe(tenantRestContext, function(err, me) {
-                            assert.ok(!err);
-                            assert.ok(!me.anon);
-                            assert.strictEqual(me.authenticationStrategy, 'shibboleth');
-                            assert.strictEqual(me.displayName, 'Simon');
-                            assert.ok(!me.email);
-                            assert.strictEqual(me.locale, 'en_UK');
-                            return done();
-                        });
-                    });
-                });
-            }, callback);
-        });
 
         /**
          * Test that verifies that the locale field can be configured as a priority list

--- a/node_modules/oae-config/tests/test-config.js
+++ b/node_modules/oae-config/tests/test-config.js
@@ -52,10 +52,10 @@ describe('Configuration', function() {
         // Fill up the global admin rest context
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
         // Fill up the rest context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            callback();
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+            assert.ok(!err);
+            johnRestContext = john.restContext;
+            return callback();
         });
     });
 

--- a/node_modules/oae-content/tests/test-activity.js
+++ b/node_modules/oae-content/tests/test-activity.js
@@ -27,6 +27,7 @@ var EmailTestsUtil = require('oae-email/lib/test/util');
 var FollowingTestsUtil = require('oae-following/lib/test/util');
 var log = require('oae-logger').logger('test-activity');
 var PreviewConstants = require('oae-preview-processor/lib/constants');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var RestUtil = require('oae-rest/lib/util');
@@ -2073,79 +2074,64 @@ describe('Content Activity', function() {
          * scrubbed.
          */
         it('verify content-comment email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, mrvisser, simong, nicolaas) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-                var nicolaas = _.values(users)[2];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    RestAPI.Content.createLink(mrvisser.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
-                        RestAPI.Content.createLink(mrvisser.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                        RestAPI.Content.createComment(simong.restContext, link.id, '<b>Nice link.</b>\n\nWould click again', null, function(err, simongComment) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createComment(simong.restContext, link.id, '<b>Nice link.</b>\n\nWould click again', null, function(err, simongComment) {
-                                assert.ok(!err);
+                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                // There should be exactly one message, the one sent to mrvisser (manager of content item receives content-comment notification)
+                                assert.equal(messages.length, 1);
 
-                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
-                                    // There should be exactly one message, the one sent to mrvisser (manager of content item receives content-comment notification)
-                                    assert.equal(messages.length, 1);
+                                var stringEmail = JSON.stringify(messages[0], null, 2);
+                                var message = messages[0];
 
-                                    var stringEmail = JSON.stringify(messages[0], null, 2);
-                                    var message = messages[0];
+                                // Sanity check that the message is to mrvisser
+                                assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                    // Sanity check that the message is to mrvisser
-                                    assert.equal(message.to[0].address, mrvisser.user.email);
+                                // Ensure that the subject of the email contains the poster's name
+                                assert.notEqual(message.subject.indexOf('swappedFromPublicAlias'), -1);
 
-                                    // Ensure that the subject of the email contains the poster's name
-                                    assert.notEqual(message.subject.indexOf('swappedFromPublicAlias'), -1);
+                                // Ensure some data expected to be in the email is there
+                                assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
+                                assert.notEqual(stringEmail.indexOf(link.displayName), -1);
 
-                                    // Ensure some data expected to be in the email is there
-                                    assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
-                                    assert.notEqual(stringEmail.indexOf(link.displayName), -1);
+                                // Ensure simong's private info is *nowhere* to be found
+                                assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                                assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                                assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                    // Ensure simong's private info is *nowhere* to be found
-                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
+                                // The message probably contains the public alias, though
+                                assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
 
-                                    // The message probably contains the public alias, though
-                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+                                // The message should have escaped the HTML content in the original message
+                                assert.strictEqual(stringEmail.indexOf('<b>Nice link.</b>'), -1);
 
-                                    // The message should have escaped the HTML content in the original message
-                                    assert.strictEqual(stringEmail.indexOf('<b>Nice link.</b>'), -1);
+                                // The new line characters should've been converted into paragraphs
+                                assert.notEqual(stringEmail.indexOf('Would click again</p>'), -1);
 
-                                    // The new line characters should've been converted into paragraphs
-                                    assert.notEqual(stringEmail.indexOf('Would click again</p>'), -1);
+                                // Post a comment as nicolaas and ensure the recent commenter, simong receives an email about it
+                                RestAPI.Content.createComment(nicolaas.restContext, link.id, 'It 404d', null, function(err, nicolaasComment) {
+                                    assert.ok(!err);
 
-                                    // Post a comment as nicolaas and ensure the recent commenter, simong receives an email about it
-                                    RestAPI.Content.createComment(nicolaas.restContext, link.id, 'It 404d', null, function(err, nicolaasComment) {
-                                        assert.ok(!err);
+                                    EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                                        // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
+                                        assert.equal(emails.length, 2);
 
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                            // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
-                                            assert.equal(emails.length, 2);
-
-                                            var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
-                                            assert.ok(_.contains(emailAddresses, simong.user.email));
-                                            assert.ok(_.contains(emailAddresses, mrvisser.user.email));
-                                            return callback();
-                                        });
+                                        var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
+                                        assert.ok(_.contains(emailAddresses, simong.user.email));
+                                        assert.ok(_.contains(emailAddresses, mrvisser.user.email));
+                                        return callback();
                                     });
                                 });
                             });
@@ -2160,58 +2146,44 @@ describe('Content Activity', function() {
          * appropriately scrubbed.
          */
         it('verify content-create email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
+                    RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [mrvisser.user.id], [], function(err, link) {
                         assert.ok(!err);
 
-                        // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
-                        RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [mrvisser.user.id], [], function(err, link) {
-                            assert.ok(!err);
+                        // Mrvisser should get an email, with simong's information scrubbed
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            // There should be exactly one message, the one sent to mrvisser
+                            assert.equal(messages.length, 1);
 
-                            // Mrvisser should get an email, with simong's information scrubbed
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
-                                // There should be exactly one message, the one sent to mrvisser
-                                assert.equal(messages.length, 1);
+                            var stringEmail = JSON.stringify(messages[0]);
+                            var message = messages[0];
 
-                                var stringEmail = JSON.stringify(messages[0]);
-                                var message = messages[0];
+                            // Sanity check that the message is to mrvisser
+                            assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                // Sanity check that the message is to mrvisser
-                                assert.equal(message.to[0].address, mrvisser.user.email);
+                            // Ensure some data expected to be in the email is there
+                            assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
+                            assert.notEqual(stringEmail.indexOf(link.displayName), -1);
 
-                                // Ensure some data expected to be in the email is there
-                                assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
-                                assert.notEqual(stringEmail.indexOf(link.displayName), -1);
+                            // Ensure simong's private info is *nowhere* to be found
+                            assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                // Ensure simong's private info is *nowhere* to be found
-                                assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                assert.equal(stringEmail.indexOf(simong.user.locale), -1);
+                            // The message probably contains the public alias, though
+                            assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
 
-                                // The message probably contains the public alias, though
-                                assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-
-                                return callback();
-                            });
+                            return callback();
                         });
                     });
                 });
@@ -2223,63 +2195,49 @@ describe('Content Activity', function() {
          * appropriately scrubbed.
          */
         it('verify content-share email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
+                    RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
-                        // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
-                        RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
-                            assert.ok(!err);
+                        // Collect the createLink activity
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                            // Collect the createLink activity
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            RestAPI.Content.shareContent(simong.restContext, link.id, [mrvisser.user.id], function(err) {
+                                assert.ok(!err);
 
-                                RestAPI.Content.shareContent(simong.restContext, link.id, [mrvisser.user.id], function(err) {
-                                    assert.ok(!err);
+                                // Mrvisser should get an email, with simong's information scrubbed
+                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                    // There should be exactly one message, the one sent to mrvisser
+                                    assert.equal(messages.length, 1);
 
-                                    // Mrvisser should get an email, with simong's information scrubbed
-                                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
-                                        // There should be exactly one message, the one sent to mrvisser
-                                        assert.equal(messages.length, 1);
+                                    var stringEmail = JSON.stringify(messages[0]);
+                                    var message = messages[0];
 
-                                        var stringEmail = JSON.stringify(messages[0]);
-                                        var message = messages[0];
+                                    // Sanity check that the message is to mrvisser
+                                    assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                        // Sanity check that the message is to mrvisser
-                                        assert.equal(message.to[0].address, mrvisser.user.email);
+                                    // Ensure some data expected to be in the email is there
+                                    assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
+                                    assert.notEqual(stringEmail.indexOf(link.displayName), -1);
 
-                                        // Ensure some data expected to be in the email is there
-                                        assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
-                                        assert.notEqual(stringEmail.indexOf(link.displayName), -1);
+                                    // Ensure simong's private info is *nowhere* to be found
+                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                        // Ensure simong's private info is *nowhere* to be found
-                                        assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.locale), -1);
-
-                                        // The message probably contains the public alias, though
-                                        assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-                                        return callback();
-                                    });
+                                    // The message probably contains the public alias, though
+                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-content/tests/test-activity.js
+++ b/node_modules/oae-content/tests/test-activity.js
@@ -176,76 +176,63 @@ describe('Content Activity', function() {
          * Test that verifies a content resource routes activities to its members when created, updated and shared
          */
         it('verify routing to content members', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var managerGroupMemberUsername = TestsUtil.generateTestUserId('managerGroupMember');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, managerGroupMember) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create the group that will be a viewer of the content
+                RestAPI.Group.createGroup(camAdminRestContext, 'Viewer Group displayName', 'Viewer Group Description', 'public', 'no', [], [], function(err, viewerGroup) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, managerGroupMemberUsername, 'password', 'Jane', null, function(err, managerGroupMember) {
+                    // Create a group that will be a manager of the content
+                    RestAPI.Group.createGroup(camAdminRestContext, 'Manager Group displayName', 'Manager Group Description',  'public', 'no', [], [], function(err, managerGroup) {
                         assert.ok(!err);
 
-                        // Create the group that will be a viewer of the content
-                        RestAPI.Group.createGroup(camAdminRestContext, 'Viewer Group displayName', 'Viewer Group Description', 'public', 'no', [], [], function(err, viewerGroup) {
+                        // managerGroupMember should be a member of the manager group to verify indirect group member routing
+                        var membership = {};
+                        membership[managerGroupMember.user.id] = 'manager';
+                        RestAPI.Group.setGroupMembers(camAdminRestContext, managerGroup.id, membership, function(err) {
                             assert.ok(!err);
 
-                            // Create a group that will be a manager of the content
-                            RestAPI.Group.createGroup(camAdminRestContext, 'Manager Group displayName', 'Manager Group Description',  'public', 'no', [], [], function(err, managerGroup) {
+                            // Create a content item with manager group and viewer group as members.
+                            RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [managerGroup.id], [viewerGroup.id], [], function(err, link) {
                                 assert.ok(!err);
 
-                                // managerGroupMember should be a member of the manager group to verify indirect group member routing
-                                var membership = {};
-                                membership[managerGroupMember.id] = 'manager';
-                                RestAPI.Group.setGroupMembers(camAdminRestContext, managerGroup.id, membership, function(err) {
+                                // Share the content item with jane
+                                RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                                     assert.ok(!err);
 
-                                    // Create a content item with manager group and viewer group as members.
-                                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [managerGroup.id], [viewerGroup.id], [], function(err, link) {
+                                    // Update the content item
+                                    RestAPI.Content.updateContent(jack.restContext, link.id, {'description': 'Super awesome link'}, function(err) {
                                         assert.ok(!err);
 
-                                        // Share the content item with jane
-                                        RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                                        // Verify Jack got the create, share and update as he was the actor for all of them
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                             assert.ok(!err);
+                                            assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
+                                            assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.user.id));
+                                            assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
 
-                                            // Update the content item
-                                            RestAPI.Content.updateContent(jackCtx, link.id, {'description': 'Super awesome link'}, function(err) {
+                                            // Verify the manager group received the create, share and update as they are a content member
+                                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroup.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
+                                                assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
+                                                assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.user.id));
+                                                assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
 
-                                                // Verify Jack got the create, share and update as he was the actor for all of them
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                                // Verify the viewer group received only the create and update. only managers care about the sharing of the "object"
+                                                ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, viewerGroup.id, null, function(err, activityStream) {
                                                     assert.ok(!err);
                                                     assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                    assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.id));
+                                                    assert.ok(!_getActivity(activityStream, 'content-share', 'target', jane.user.id));
                                                     assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
 
-                                                    // Verify the manager group received the create, share and update as they are a content member
-                                                    ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroup.id, null, function(err, activityStream) {
+                                                    // Verify the manager group *member* got the same activities as the manager group, as they are a member
+                                                    ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroupMember.user.id, null, function(err, activityStream) {
                                                         assert.ok(!err);
                                                         assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                        assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.id));
+                                                        assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.user.id));
                                                         assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
-
-                                                        // Verify the viewer group received only the create and update. only managers care about the sharing of the "object"
-                                                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, viewerGroup.id, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                            assert.ok(!_getActivity(activityStream, 'content-share', 'target', jane.id));
-                                                            assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
-
-                                                            // Verify the manager group *member* got the same activities as the manager group, as they are a member
-                                                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroupMember.id, null, function(err, activityStream) {
-                                                                assert.ok(!err);
-                                                                assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                                assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.id));
-                                                                assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
-                                                                callback();
-                                                            });
-                                                        });
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -264,8 +251,7 @@ describe('Content Activity', function() {
          * when non-manager), the content item is still propagated to the route appropriately.
          */
         it('verify content propagation to non-route activity feeds', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
 
                 // Create a private content item
@@ -275,10 +261,10 @@ describe('Content Activity', function() {
                     // Share the content item with Jack. Jack will get the activity in his feed because he is the target, but he will not be in
                     // the routes of the content item because he is not a manager. Despite this, we need to verify that Jack has the full content
                     // item propagated to him as he does have access to it.
-                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.id], function(err) {
+                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream);
 
@@ -288,7 +274,7 @@ describe('Content Activity', function() {
                             assert.equal(object['oae:resourceSubType'], 'link');
                             assert.equal(object['oae:profilePath'], '/content/' + link.tenant.alias + '/' + AuthzUtil.getResourceFromId(link.id).resourceId);
                             assert.equal(object['displayName'], 'Google');
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -299,10 +285,8 @@ describe('Content Activity', function() {
          * Test that verifies a comment activity is routed to recent commenters of a content item.
          */
         it('verify comment activity is routed to the recent commenters of a content item', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-                var simong = _.values(users)[0];
-                var mrvisser = _.values(users)[1];
-                var bert = _.values(users)[2];
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, simong, mrvisser, bert) {
+                assert.ok(!err);
 
                 // Create a content item to be commented on
                 RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
@@ -336,10 +320,8 @@ describe('Content Activity', function() {
          * access to the content item (e.g., it becomes private after they commented).
          */
         it('verify a comment activity is not routed to a recent commenter if they no longer have access to the content item', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-                var simong = _.values(users)[0];
-                var mrvisser = _.values(users)[1];
-                var bert = _.values(users)[2];
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, simong, mrvisser, bert) {
+                assert.ok(!err);
 
                 // Create a content item to be commented on, bert is a member
                 RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [bert.user.id], [], function(err, link) {
@@ -744,17 +726,15 @@ describe('Content Activity', function() {
                 assert.ok(entity['id'].indexOf(contentId) !== -1);
             };
 
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Generate an activity with the content
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Verify model with no preview state
-                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                         assert.ok(!err);
                         var entity = activityStream.items[0].object;
                         _assertStandardLinkModel(entity, link.id);
@@ -775,7 +755,7 @@ describe('Content Activity', function() {
                                     assert.ok(!err);
 
                                     // Verify that the preview does not display
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         var entity = activityStream.items[0].object;
@@ -788,7 +768,7 @@ describe('Content Activity', function() {
                                             assert.ok(!err);
 
                                             // Verify that the preview still does not display
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
 
                                                 var entity = activityStream.items[0].object;
@@ -801,7 +781,7 @@ describe('Content Activity', function() {
                                                     assert.ok(!err);
 
                                                     // Verify that the previews are returned in the activity
-                                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                                         assert.ok(!err);
 
                                                         var entity = activityStream.items[0].object;
@@ -863,26 +843,24 @@ describe('Content Activity', function() {
          * Test that verifies the properties of a comment entity
          */
         it('verify the comment entity model contains the correct comment information', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Generate an activity with the content
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Create 3 comments, including one reply. We want to make sure the context is properly aggregated in these comments as their activities are delivered.
-                    RestAPI.Content.createComment(jackCtx, link.id, 'Comment A', null, function(err, commentA) {
+                    RestAPI.Content.createComment(jack.restContext, link.id, 'Comment A', null, function(err, commentA) {
                         assert.ok(!err);
 
-                        RestAPI.Content.createComment(jackCtx, link.id, 'Comment B', null, function(err, commentB) {
+                        RestAPI.Content.createComment(jack.restContext, link.id, 'Comment B', null, function(err, commentB) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createComment(jackCtx, link.id, 'Reply Comment A', commentA.created, function(err, replyCommentA) {
+                            RestAPI.Content.createComment(jack.restContext, link.id, 'Reply Comment A', commentA.created, function(err, replyCommentA) {
                                 assert.ok(!err);
 
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -947,7 +925,7 @@ describe('Content Activity', function() {
                                     assert.ok(hadCommentB);
                                     assert.ok(hadReplyCommentA);
 
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });
@@ -1030,19 +1008,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-create and content-update activity are generated when a content item is created and updated.
          */
         it('verify content-create and content-update activities are posted when content is created and updated', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Generate an activity with the content
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
-                    RestAPI.Content.updateContent(jackCtx, link.id, {'description': 'Super awesome link'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, link.id, {'description': 'Super awesome link'}, function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var createActivity = _getActivity(activityStream, 'content-create', 'object', link.id);
                             var updateActivity = _getActivity(activityStream, 'content-update', 'object', link.id);
@@ -1050,7 +1026,7 @@ describe('Content Activity', function() {
                             assert.equal(createActivity.verb, 'create');
                             assert.ok(updateActivity);
                             assert.equal(updateActivity.verb, 'update');
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1061,19 +1037,17 @@ describe('Content Activity', function() {
          * Test to verify the revision id gets updated in the activity when a new revision is posted
          */
         it('verify content-update activities have updated previews', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.Content.createFile(jackCtx, 'name', 'description', 'public', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
+                RestAPI.Content.createFile(jack.restContext, 'name', 'description', 'public', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Create a new revision
-                    RestAPI.Content.updateFileBody(jackCtx, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
+                    RestAPI.Content.updateFileBody(jack.restContext, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var createActivity = _getActivity(activityStream, 'content-create', 'object', content.id);
 
@@ -1081,7 +1055,7 @@ describe('Content Activity', function() {
                             assert.ok(createActivity);
                             assert.ok(updateActivity);
                             assert.notEqual(createActivity.object['oae:revisionId'], updateActivity.object['oae:revisionId']);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1092,18 +1066,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-share activity is generated when a content item is shared.
          */
         it('verify a content-share activity is generated when a content item is shared', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
 
                 RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Try and generate a share activity
-                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.id], function(err) {
+                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var shareActivity = _getActivity(activityStream, 'content-share', 'object', link.id);
                             assert.ok(shareActivity);
@@ -1147,22 +1120,20 @@ describe('Content Activity', function() {
          * Test that verifies that a content-revision activity is generated when a content item's body has been updated / uploaded.
          */
         it('verify a content-revision activity is generated when a content item\'s body has been updated', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a revisable content item
-                RestAPI.Content.createFile(jackCtx, 'Test Content 1', 'Test content description 1', 'private', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
+                RestAPI.Content.createFile(jack.restContext, 'Test Content 1', 'Test content description 1', 'private', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
                     assert.ok(!err);
                     assert.ok(content);
 
                     // Create a new version
-                    RestAPI.Content.updateFileBody(jackCtx, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
+                    RestAPI.Content.updateFileBody(jack.restContext, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
                         assert.ok(!err);
 
                         // Verify the revision activity was created for jack
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var revisionActivity = _getActivity(activityStream, 'content-revision', 'object', content.id);
                             assert.ok(revisionActivity);
@@ -1182,19 +1153,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-add-to-library activity is generated when a user adds a content item to their own library
          */
         it('verify a content-add-to-library activity is generated when a user adds a content item to their own library', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Jack adds the content item to his own library
-                    RestAPI.Content.shareContent(jackCtx, link.id, [jack.id], function(err) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jack.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var addActivity = _getActivity(activityStream, 'content-add-to-library', 'object', link.id);
                             assert.ok(addActivity);
@@ -1210,19 +1179,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-update-visibility activity is generated when a content's visibility is updated
          */
         it('verify a content-update-visibility activity is generated when a content item\'s visibility is updated', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [jack.id], [], function(err, link) {
+                RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [jack.user.id], [], function(err, link) {
                     assert.ok(!err);
 
                     // Jack adds the content item to his own library
                     RestAPI.Content.updateContent(camAdminRestContext, link.id, {'visibility': 'private'}, function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var updateVisibilityActivity = _getActivity(activityStream, 'content-update-visibility', 'object', link.id);
                             assert.ok(updateVisibilityActivity);
@@ -1246,28 +1213,24 @@ describe('Content Activity', function() {
          * aggregated into a collection.
          */
         it('verify content-create activities are pivoted by actor', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Create a Yahoo link
-                    RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
                         // Verify the activities were aggregated into one, pivoted by actor
-                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream);
                             assert.equal(activityStream.items.length, 1);
 
-                            var aggregate = _getActivity(activityStream, 'content-create', 'actor', jack.id);
+                            var aggregate = _getActivity(activityStream, 'content-create', 'actor', jack.user.id);
                             assert.ok(aggregate.object);
                             assert.ok(aggregate.object['oae:collection']);
                             assert.equal(aggregate.object['oae:collection'].length, 2);
@@ -1292,39 +1255,35 @@ describe('Content Activity', function() {
          * deleted properly
          */
         it('verify when a content-create activity is redelivered, it deletes the previous one', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Force a collection of activities so that the individual activity is delivered
-                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                         assert.ok(!err);
                         assert.ok(activityStream);
                         assert.ok(activityStream.items.length, 1);
 
                         // Create a Yahoo link
-                        RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                             assert.ok(!err);
 
                             // Collect again and ensure we still only have one activity
-                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.ok(activityStream.items.length, 1);
 
                                 // Rinse and repeat once to ensure that the aggregates are removed properly as well
-                                RestAPI.Content.createLink(jackCtx, 'Apereo!', 'Apereo!', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                RestAPI.Content.createLink(jack.restContext, 'Apereo!', 'Apereo!', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                     assert.ok(!err);
 
                                     // Collect again and ensure we still only have one activity
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
                                         assert.ok(activityStream);
                                         assert.ok(activityStream.items.length, 1);
@@ -1497,23 +1456,19 @@ describe('Content Activity', function() {
          * Test that verifies when a content item is updated multiple times, the actors that updated it are aggregated into a collection.
          */
         it('verify content-update activities are pivoted by object', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Update the content once as jack
-                    RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'The Google'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'The Google'}, function(err) {
                         assert.ok(!err);
 
                         // Update it a second time as jack, we use this to make sure we don't get duplicates in the aggregation
-                        RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'Google'}, function(err) {
+                        RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'Google'}, function(err) {
                             assert.ok(!err);
 
                             // Update it with a different user, this should be a second entry in the collection
@@ -1521,7 +1476,7 @@ describe('Content Activity', function() {
                                 assert.ok(!err);
 
                                 // Verify we get the 2 actors in the stream
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -1546,31 +1501,27 @@ describe('Content Activity', function() {
          * timestamp.
          */
         it('verify duplicate content-update activities are re-released with a more recent date, with no aggregations', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Update the content once as jack
-                    RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'The Google'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'The Google'}, function(err) {
                         assert.ok(!err);
 
                         // Add something to the activity feed that happened later than the previous update
-                        RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                             assert.ok(!err);
 
                             // Update it a second time as jack, we use this to make sure we don't get duplicates in the aggregation, and ensure the update jumps ahead of the last create activity in the feed
-                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'Google'}, function(err) {
+                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'Google'}, function(err) {
                                 assert.ok(!err);
 
                                 // Verify that the activity is still a non-aggregated activity, it just jumped to the front of the feed
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -1580,35 +1531,35 @@ describe('Content Activity', function() {
                                     // Ensures that the actor is not a collection, but still an individual entity
                                     var activity = activityStream.items[0];
                                     assert.equal(activity['oae:activityType'], 'content-update');
-                                    assert.ok(activity.actor['oae:id'], jack.id);
-                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                    assert.ok(activity.actor['oae:id'], jack.user.id);
+                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' +  AuthzUtil.getResourceFromId(googleLink.id).resourceId);
 
                                     // Send a new activity into the feed so it is the most recent
-                                    RestAPI.Content.createLink(jackCtx, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                    RestAPI.Content.createLink(jack.restContext, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                         assert.ok(!err);
 
                                         // Force a collection so that the most recent activity is in the feed
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.equal(activityStream.items.length, 2);
 
                                             // Jump the update activity to the top again
-                                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'Google'}, function(err) {
+                                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'Google'}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Verify update activity is at the top and still an individual activity
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                     assert.ok(activityStream);
                                                     assert.equal(activityStream.items.length, 2);
 
                                                     // content-update activity should be the first in the list, it should still be a single activity
                                                     var activity = activityStream.items[0];
                                                     assert.equal(activity['oae:activityType'], 'content-update');
-                                                    assert.equal(activity.actor['oae:id'], jack.id);
-                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                                    assert.equal(activity.actor['oae:id'], jack.user.id);
+                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' +  AuthzUtil.getResourceFromId(googleLink.id).resourceId);
                                                     callback();
@@ -1639,31 +1590,27 @@ describe('Content Activity', function() {
          * activity feed. Instead, the activity should be updated and reposted as a recent item.
          */
         it('verify duplicate content-update-visibility activities are not duplicated in the feed', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Update the content once as jack
-                    RestAPI.Content.updateContent(jackCtx, googleLink.id, {'visibility': 'loggedin'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'visibility': 'loggedin'}, function(err) {
                         assert.ok(!err);
 
                         // Add something to the activity feed that happened later than the previous update
-                        RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                             assert.ok(!err);
 
                             // Update it a second time as jack, we use this to make sure we don't get duplicates in the aggregation, and ensure the update jumps ahead of the last create activity in the feed
-                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'visibility': 'private'}, function(err) {
+                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'visibility': 'private'}, function(err) {
                                 assert.ok(!err);
 
                                 // Verify that the activity is still a non-aggregated activity, it just jumped to the front of the feed
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -1673,35 +1620,35 @@ describe('Content Activity', function() {
                                     // Ensures that the actor is not a collection, but still an individual entity
                                     var activity = activityStream.items[0];
                                     assert.equal(activity['oae:activityType'], 'content-update-visibility');
-                                    assert.ok(activity.actor['oae:id'], jack.id);
-                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                    assert.ok(activity.actor['oae:id'], jack.user.id);
+                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' +  AuthzUtil.getResourceFromId(googleLink.id).resourceId);
 
                                     // Send a new activity into the feed so it is the most recent
-                                    RestAPI.Content.createLink(jackCtx, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                    RestAPI.Content.createLink(jack.restContext, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                         assert.ok(!err);
 
                                         // Force a collection so that the most recent activity is in the feed
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.equal(activityStream.items.length, 2);
 
                                             // Jump the update activity to the top again
-                                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'visibility': 'public'}, function(err) {
+                                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'visibility': 'public'}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Verify update activity is at the top and still an individual activity
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                     assert.ok(activityStream);
                                                     assert.equal(activityStream.items.length, 2);
 
                                                     // content-update activity should be the first in the list, it should still be a single activity
                                                     var activity = activityStream.items[0];
                                                     assert.equal(activity['oae:activityType'], 'content-update-visibility');
-                                                    assert.equal(activity.actor['oae:id'], jack.id);
-                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                                    assert.equal(activity.actor['oae:id'], jack.user.id);
+                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' + AuthzUtil.getResourceFromId(googleLink.id).resourceId);
                                                     callback();
@@ -1732,19 +1679,15 @@ describe('Content Activity', function() {
          * for display.
          */
         it('verify that content-comment activity aggregates both actor and object entities while pivoting on target', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Post a content as jack
-                    RestAPI.Content.createComment(jackCtx, link.id, 'Test Comment A', null, function(err) {
+                    RestAPI.Content.createComment(jack.restContext, link.id, 'Test Comment A', null, function(err) {
                         assert.ok(!err);
 
                         // Post a comment as the cambridge admin, we have now aggregated a 2nd comment posting on the same content item
@@ -1752,7 +1695,7 @@ describe('Content Activity', function() {
                             assert.ok(!err);
 
                             // Verify that both actors (camadmin and jack) and both objects (both comments) are available in the activity
-                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.equal(activityStream.items.length, 2);
@@ -1770,11 +1713,11 @@ describe('Content Activity', function() {
                                 assert.equal(activity.target['oae:id'], link.id);
 
                                 // Post a 3rd comment as a user who has posted already
-                                RestAPI.Content.createComment(jackCtx, link.id, 'Test Comment C', null, function(err) {
+                                RestAPI.Content.createComment(jack.restContext, link.id, 'Test Comment C', null, function(err) {
                                     assert.ok(!err);
 
                                     // Verify that the 3rd comment is aggregated into the object collection of the activity, however the actor collection has only the 2 unique actors
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
                                         assert.ok(activityStream);
                                         assert.equal(activityStream.items.length, 2);
@@ -1817,87 +1760,76 @@ describe('Content Activity', function() {
          * activity feed.
          */
         it('verify duplicate content-share activities do not result in redundant activities', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    var janeCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                    // Create a google link
-                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    // Share with jack, creates one activity item in cam admin's feed
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                         assert.ok(!err);
 
-                        // Share with jack, creates one activity item in cam admin's feed
-                        RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                        var removeJane = {};
+                        removeJane[jane.user.id] = false;
+
+                        // Remove jane so we can duplicate the content share after
+                        RestAPI.Content.updateMembers(jack.restContext, link.id, removeJane, function(err) {
                             assert.ok(!err);
 
-                            var removeJane = {};
-                            removeJane[jane.id] = false;
-
-                            // Remove jane so we can duplicate the content share after
-                            RestAPI.Content.updateMembers(jackCtx, link.id, removeJane, function(err) {
+                            // Create some noise in the feed to ensure that the second share content will jump to the top
+                            RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.google.ca', [], [], [], function(err, yahooLink) {
                                 assert.ok(!err);
 
-                                // Create some noise in the feed to ensure that the second share content will jump to the top
-                                RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.google.ca', [], [], [], function(err, yahooLink) {
+                                // Now re-add Jane
+                                RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                                     assert.ok(!err);
 
-                                    // Now re-add Jane
-                                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                                    // Verify that jack only has only one activity in his feed representing the content-share
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
+                                        assert.ok(activityStream);
+                                        assert.equal(activityStream.items.length, 2);
 
-                                        // Verify that jack only has only one activity in his feed representing the content-share
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        // The first activity should be the content share, and it should not be an aggregation
+                                        var activity = activityStream.items[0];
+                                        assert.equal(activity['oae:activityType'], 'content-share');
+                                        assert.equal(activity.actor['oae:id'], jack.user.id);
+                                        assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
+                                        assert.equal(activity.object['oae:id'], link.id);
+                                        assert.equal(activity.object['oae:profilePath'], '/content/' + link.tenant.alias + '/' + AuthzUtil.getResourceFromId(link.id).resourceId);
+                                        assert.equal(activity.target['oae:id'], jane.user.id);
+                                        assert.equal(activity.target['oae:profilePath'], '/user/' + jane.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jane.user.id).resourceId);
+
+                                        // Repeat once more to ensure we don't duplicate when the aggregate is already active
+                                        RestAPI.Content.updateMembers(jack.restContext, link.id, removeJane, function(err) {
                                             assert.ok(!err);
-                                            assert.ok(activityStream);
-                                            assert.equal(activityStream.items.length, 2);
 
-                                            // The first activity should be the content share, and it should not be an aggregation
-                                            var activity = activityStream.items[0];
-                                            assert.equal(activity['oae:activityType'], 'content-share');
-                                            assert.equal(activity.actor['oae:id'], jack.id);
-                                            assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
-                                            assert.equal(activity.object['oae:id'], link.id);
-                                            assert.equal(activity.object['oae:profilePath'], '/content/' + link.tenant.alias + '/' + AuthzUtil.getResourceFromId(link.id).resourceId);
-                                            assert.equal(activity.target['oae:id'], jane.id);
-                                            assert.equal(activity.target['oae:profilePath'], '/user/' + jane.tenant.alias + '/' + AuthzUtil.getResourceFromId(jane.id).resourceId);
-
-                                            // Repeat once more to ensure we don't duplicate when the aggregate is already active
-                                            RestAPI.Content.updateMembers(jackCtx, link.id, removeJane, function(err) {
+                                            // Create some noise in the feed to ensure that the third share content will jump to the top
+                                            RestAPI.Content.createLink(jack.restContext, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                                 assert.ok(!err);
 
-                                                // Create some noise in the feed to ensure that the third share content will jump to the top
-                                                RestAPI.Content.createLink(jackCtx, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                                // Re-share with Jane for the 3rd time
+                                                RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                                                     assert.ok(!err);
 
-                                                    // Re-share with Jane for the 3rd time
-                                                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                                                    // Verify that jack still has only one activity in his feed representing the content-share
+                                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                         assert.ok(!err);
+                                                        assert.ok(activityStream);
+                                                        assert.equal(activityStream.items.length, 2);
 
-                                                        // Verify that jack still has only one activity in his feed representing the content-share
-                                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.ok(activityStream);
-                                                            assert.equal(activityStream.items.length, 2);
-
-                                                            // The first activity should be the content share, and it should still not be an aggregation
-                                                            var activity = activityStream.items[0];
-                                                            assert.equal(activity['oae:activityType'], 'content-share');
-                                                            assert.equal(activity.actor['oae:id'], jack.id);
-                                                            assert.equal(activity.actor['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
-                                                            assert.equal(activity.object['oae:id'], link.id);
-                                                            assert.equal(activity.object['oae:profilePath'], '/content/camtest/' + AuthzUtil.getResourceFromId(link.id).resourceId);
-                                                            assert.equal(activity.target['oae:id'], jane.id);
-                                                            assert.equal(activity.target['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jane.id).resourceId);
-                                                            callback();
-                                                        });
+                                                        // The first activity should be the content share, and it should still not be an aggregation
+                                                        var activity = activityStream.items[0];
+                                                        assert.equal(activity['oae:activityType'], 'content-share');
+                                                        assert.equal(activity.actor['oae:id'], jack.user.id);
+                                                        assert.equal(activity.actor['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
+                                                        assert.equal(activity.object['oae:id'], link.id);
+                                                        assert.equal(activity.object['oae:profilePath'], '/content/camtest/' + AuthzUtil.getResourceFromId(link.id).resourceId);
+                                                        assert.equal(activity.target['oae:id'], jane.user.id);
+                                                        assert.equal(activity.target['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jane.user.id).resourceId);
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -1916,40 +1848,82 @@ describe('Content Activity', function() {
          * from the activity bucket.
          */
         it('verify content-share activities aggregate and are branched properly when all collected at once', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                        // Share google link with jane and branden
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id, branden.user.id], function(err) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                            // Share Yahoo link with jane only
+                            RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                 assert.ok(!err);
 
-                                // Share google link with jane and branden
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id, branden.id], function(err) {
+                                // Verify that the share activities aggregated in both pivot points
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
+                                    assert.ok(!err);
+                                    assert.ok(activityStream);
+                                    assert.equal(activityStream.items.length, 3);
+
+                                    // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
+                                    var activity = activityStream.items[0];
+                                    assert.ok(activity.object['oae:collection']);
+                                    assert.equal(activity.object['oae:collection'].length, 2);
+
+                                    // 2. actor+object aggregate should have: jack+google+(jane,branden)
+                                    activity = activityStream.items[1];
+                                    assert.ok(activity.target['oae:collection']);
+                                    assert.equal(activity.target['oae:collection'].length, 2);
+
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies an activity with two aggregates will create 2 aggregate activities correctly when one single activity
+         * currently exists in the activity stream.
+         */
+        it('verify content-share activities aggregate and are branched properly when collected after first share', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
+                assert.ok(!err);
+
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                    assert.ok(!err);
+
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        assert.ok(!err);
+
+                        // Share google link with jane
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id], function(err) {
+                            assert.ok(!err);
+
+                            // Perform a collection to activate some aggregates ahead of time
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
+                                assert.ok(!err);
+
+                                // Share google now with branden, should aggregate with the previous
+                                RestAPI.Content.shareContent(jack.restContext, googleLink.id, [branden.user.id], function(err) {
                                     assert.ok(!err);
 
                                     // Share Yahoo link with jane only
-                                    RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
+                                    RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                         assert.ok(!err);
 
                                         // Verify that the share activities aggregated in both pivot points
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.equal(activityStream.items.length, 3);
@@ -1964,81 +1938,7 @@ describe('Content Activity', function() {
                                             assert.ok(activity.target['oae:collection']);
                                             assert.equal(activity.target['oae:collection'].length, 2);
 
-                                            callback();
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-
-        /**
-         * Test that verifies an activity with two aggregates will create 2 aggregate activities correctly when one single activity
-         * currently exists in the activity stream.
-         */
-        it('verify content-share activities aggregate and are branched properly when collected after first share', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
-
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
-                    assert.ok(!err);
-
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
-                        assert.ok(!err);
-
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
-                            assert.ok(!err);
-
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
-                                assert.ok(!err);
-
-                                // Share google link with jane
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id], function(err) {
-                                    assert.ok(!err);
-
-                                    // Perform a collection to activate some aggregates ahead of time
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                        assert.ok(!err);
-
-                                        // Share google now with branden, should aggregate with the previous
-                                        RestAPI.Content.shareContent(jackCtx, googleLink.id, [branden.id], function(err) {
-                                            assert.ok(!err);
-
-                                            // Share Yahoo link with jane only
-                                            RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
-                                                assert.ok(!err);
-
-                                                // Verify that the share activities aggregated in both pivot points
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                    assert.ok(!err);
-                                                    assert.ok(activityStream);
-                                                    assert.equal(activityStream.items.length, 3);
-
-                                                    // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
-                                                    var activity = activityStream.items[0];
-                                                    assert.ok(activity.object['oae:collection']);
-                                                    assert.equal(activity.object['oae:collection'].length, 2);
-
-                                                    // 2. actor+object aggregate should have: jack+google+(jane,branden)
-                                                    activity = activityStream.items[1];
-                                                    assert.ok(activity.target['oae:collection']);
-                                                    assert.equal(activity.target['oae:collection'].length, 2);
-
-                                                    callback();
-                                                });
-                                            });
+                                            return callback();
                                         });
                                     });
                                 });
@@ -2054,61 +1954,45 @@ describe('Content Activity', function() {
          * in the feed before a third is collected.
          */
         it('verify content-share activities aggregate and are branched properly when collected before last share', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                        // Share google link with jane and branden
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id, branden.user.id], function(err) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                            // Perform a collection to activate some aggregates ahead of time
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Share google link with jane and branden
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id, branden.id], function(err) {
+                                // Share Yahoo link with jane only
+                                RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                     assert.ok(!err);
 
-                                    // Perform a collection to activate some aggregates ahead of time
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    // Verify that the share activities aggregated in both pivot points
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
+                                        assert.ok(activityStream);
+                                        assert.equal(activityStream.items.length, 3);
 
-                                        // Share Yahoo link with jane only
-                                        RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
-                                            assert.ok(!err);
+                                        // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
+                                        var activity = activityStream.items[0];
+                                        assert.ok(activity.object['oae:collection']);
+                                        assert.equal(activity.object['oae:collection'].length, 2);
 
-                                            // Verify that the share activities aggregated in both pivot points
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                assert.ok(!err);
-                                                assert.ok(activityStream);
-                                                assert.equal(activityStream.items.length, 3);
+                                        // 2. actor+object aggregate should have: jack+google+(jane,branden)
+                                        activity = activityStream.items[1];
+                                        assert.ok(activity.target['oae:collection']);
+                                        assert.equal(activity.target['oae:collection'].length, 2);
 
-                                                // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
-                                                var activity = activityStream.items[0];
-                                                assert.ok(activity.object['oae:collection']);
-                                                assert.equal(activity.object['oae:collection'].length, 2);
-
-                                                // 2. actor+object aggregate should have: jack+google+(jane,branden)
-                                                activity = activityStream.items[1];
-                                                assert.ok(activity.target['oae:collection']);
-                                                assert.equal(activity.target['oae:collection'].length, 2);
-
-                                                callback();
-                                            });
-                                        });
+                                        return callback();
                                     });
                                 });
                             });
@@ -2123,69 +2007,53 @@ describe('Content Activity', function() {
          * and delivered to the feed one by one.
          */
         it('verify content-share activities aggregate and are branched properly when collected after each share', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                        // Share google link with jane
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id], function(err) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                            // Perform a collection to activate some aggregates ahead of time
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Share google link with jane
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id], function(err) {
+                                // Share google now with branden, should aggregate with the previous
+                                RestAPI.Content.shareContent(jack.restContext, googleLink.id, [branden.user.id], function(err) {
                                     assert.ok(!err);
 
                                     // Perform a collection to activate some aggregates ahead of time
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
-                                        // Share google now with branden, should aggregate with the previous
-                                        RestAPI.Content.shareContent(jackCtx, googleLink.id, [branden.id], function(err) {
+                                        // Share Yahoo link with jane only
+                                        RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                             assert.ok(!err);
 
-                                            // Perform a collection to activate some aggregates ahead of time
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                            // Verify that the share activities aggregated in both pivot points
+                                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                 assert.ok(!err);
+                                                assert.ok(activityStream);
+                                                assert.equal(activityStream.items.length, 3);
 
-                                                // Share Yahoo link with jane only
-                                                RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
-                                                    assert.ok(!err);
+                                                // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
+                                                var activity = activityStream.items[0];
+                                                assert.ok(activity.object['oae:collection']);
+                                                assert.equal(activity.object['oae:collection'].length, 2);
 
-                                                    // Verify that the share activities aggregated in both pivot points
-                                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                        assert.ok(!err);
-                                                        assert.ok(activityStream);
-                                                        assert.equal(activityStream.items.length, 3);
+                                                // 2. actor+object aggregate should have: jack+google+(jane,branden)
+                                                activity = activityStream.items[1];
+                                                assert.ok(activity.target['oae:collection']);
+                                                assert.equal(activity.target['oae:collection'].length, 2);
 
-                                                        // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
-                                                        var activity = activityStream.items[0];
-                                                        assert.ok(activity.object['oae:collection']);
-                                                        assert.equal(activity.object['oae:collection'].length, 2);
-
-                                                        // 2. actor+object aggregate should have: jack+google+(jane,branden)
-                                                        activity = activityStream.items[1];
-                                                        assert.ok(activity.target['oae:collection']);
-                                                        assert.equal(activity.target['oae:collection'].length, 2);
-
-                                                        callback();
-                                                    });
-                                                });
+                                                return callback();
                                             });
                                         });
                                     });
@@ -2421,4 +2289,3 @@ describe('Content Activity', function() {
         });
     });
 });
-

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -106,7 +106,8 @@ describe('Content', function() {
         var contexts = {};
         var createUser = function(identifier, visibility, displayName) {
             var userId = TestsUtil.generateTestUserId(identifier);
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', displayName, {'visibility' : visibility}, function(err, createdUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', displayName, email, {'visibility' : visibility}, function(err, createdUser) {
                 if (err) {
                     assert.fail('Could not create test user');
                 }

--- a/node_modules/oae-content/tests/test-library-search.js
+++ b/node_modules/oae-content/tests/test-library-search.js
@@ -31,7 +31,7 @@ describe('Library Search', function() {
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
-        callback();
+        return callback();
     });
 
     /**
@@ -101,64 +101,47 @@ describe('Library Search', function() {
          * Test that verifies all users can search public user library items
          */
         it('verify all users see public user library item', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                        RestAPI.Content.shareContent(doer.restContext, content.id, [jack.user.id], function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                            // Verify anonymous can see the content item
+                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.equal(results.total, 1);
+                                assert.equal(results.results[0].id, content.id);
 
-                                RestAPI.Content.shareContent(doerRestContext, content.id, [jack.id], function(err) {
+                                // Verify tenant admin can see the content item
+                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Verify anonymous can see the content item
-                                    SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                    // Verify the target user can see the content item
+                                    SearchTestsUtil.searchAll(jack.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                         assert.ok(!err);
                                         assert.equal(results.total, 1);
                                         assert.equal(results.results[0].id, content.id);
 
-                                        // Verify tenant admin can see the content item
-                                        SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                        // Verify a different loggedin user can see the content item
+                                        SearchTestsUtil.searchAll(jane.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
                                             assert.equal(results.total, 1);
                                             assert.equal(results.results[0].id, content.id);
 
-                                            // Verify the target user can see the content item
-                                            SearchTestsUtil.searchAll(jackRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                            // Verify the cross-tenant user can see the content item
+                                            SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
                                                 assert.equal(results.total, 1);
                                                 assert.equal(results.results[0].id, content.id);
-
-                                                // Verify a different loggedin user can see the content item
-                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 1);
-                                                    assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify the cross-tenant user can see the content item
-                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-                                                        callback();
-                                                    });
-                                                });
+                                                return callback();
                                             });
                                         });
                                     });
@@ -174,65 +157,48 @@ describe('Library Search', function() {
          * Test that verifies that anonymous and cross-tenant users cannot search loggedin user library items.
          */
         it('verify anonymous and cross-tenant user cannot see loggedin user library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    // Create the content item as 'loggedin'
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                        RestAPI.Content.shareContent(doer.restContext, content.id, [jack.user.id], function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            // Create the content item as 'loggedin'
-                            RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                            // Verify anonymous cannot see it
+                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.equal(results.total, 0);
+                                assert.ok(!results.results[0]);
 
-                                RestAPI.Content.shareContent(doerRestContext, content.id, [jack.id], function(err) {
+                                // Verify tenant admin can see it
+                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Verify anonymous cannot see it
-                                    SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                    // Verify the target user can see it
+                                    SearchTestsUtil.searchAll(jack.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                         assert.ok(!err);
-                                        assert.equal(results.total, 0);
-                                        assert.ok(!results.results[0]);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        // Verify tenant admin can see it
-                                        SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                        // Verify another loggedin user can see it
+                                        SearchTestsUtil.searchAll(jane.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
                                             assert.equal(results.total, 1);
                                             assert.equal(results.results[0].id, content.id);
 
-                                            // Verify the target user can see it
-                                            SearchTestsUtil.searchAll(jackRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                            // Verify the cross-tenant user cannot see it
+                                            SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.equal(results.total, 1);
-                                                assert.equal(results.results[0].id, content.id);
-
-                                                // Verify another loggedin user can see it
-                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 1);
-                                                    assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify the cross-tenant user cannot see it
-                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 0);
-                                                        assert.ok(!results.results[0]);
-                                                        callback();
-                                                    });
-                                                });
+                                                assert.equal(results.total, 0);
+                                                assert.ok(!results.results[0]);
+                                                return callback();
                                             });
                                         });
                                     });
@@ -248,65 +214,48 @@ describe('Library Search', function() {
          * Test that verifies only admin and the user themselves can search private user library items.
          */
         it('verify only self and admin can see private user library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    // Create the private content item
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                        RestAPI.Content.shareContent(doer.restContext, content.id, [jack.user.id], function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            // Create the private content item
-                            RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                            // Verify anonymous cannot search it
+                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.equal(results.total, 0);
+                                assert.ok(!results.results[0]);
 
-                                RestAPI.Content.shareContent(doerRestContext, content.id, [jack.id], function(err) {
+                                // Verify tenant admin can search it
+                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Verify anonymous cannot search it
-                                    SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                    // Verify the target user can search it
+                                    SearchTestsUtil.searchAll(jack.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                         assert.ok(!err);
-                                        assert.equal(results.total, 0);
-                                        assert.ok(!results.results[0]);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        // Verify tenant admin can search it
-                                        SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                        // Verify another loggedin user cannot search it
+                                        SearchTestsUtil.searchAll(jane.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
-                                            assert.equal(results.total, 1);
-                                            assert.equal(results.results[0].id, content.id);
+                                            assert.equal(results.total, 0);
+                                            assert.ok(!results.results[0]);
 
-                                            // Verify the target user can search it
-                                            SearchTestsUtil.searchAll(jackRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                            // Verify the cross-tenant user cannot search it
+                                            SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.equal(results.total, 1);
-                                                assert.equal(results.results[0].id, content.id);
-
-                                                // Verify another loggedin user cannot search it
-                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 0);
-                                                    assert.ok(!results.results[0]);
-
-                                                    // Verify the cross-tenant user cannot search it
-                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 0);
-                                                        assert.ok(!results.results[0]);
-                                                        callback();
-                                                    });
-                                                });
+                                                assert.equal(results.total, 0);
+                                                assert.ok(!results.results[0]);
+                                                return callback();
                                             });
                                         });
                                     });
@@ -325,74 +274,51 @@ describe('Library Search', function() {
          * Test that verifies all users can see public group library items.
          */
         it('verify all users see public group library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 4, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [], function(err, group) {
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [jack.user.id], function(err, group) {
                         assert.ok(!err);
 
-                        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                        // Create the public content item and share it with the group
+                        RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                             assert.ok(!err);
-                            var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                            var membership = {};
-                            membership[jack.id] = 'member';
-                            RestAPI.Group.setGroupMembers(doerRestContext, group.id, membership, function(err) {
+                            RestAPI.Content.shareContent(doer.restContext, content.id, [group.id], function(err) {
                                 assert.ok(!err);
 
-                                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                                // Verify anonymous can see it
+                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
                                     assert.ok(!err);
-                                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Create the public content item and share it with the group
-                                    RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                                    // Verify tenant admin can see it
+                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
                                         assert.ok(!err);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        RestAPI.Content.shareContent(doerRestContext, content.id, [group.id], function(err) {
+                                        // Verify a member can see it
+                                        SearchTestsUtil.searchAll(jack.restContext, 'content-library', [group.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 1);
+                                            assert.equal(results.results[0].id, content.id);
 
-                                            // Verify anonymous can see it
-                                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
+                                            // Verify a loggedin non-member can see it
+                                            SearchTestsUtil.searchAll(jane.restContext, 'content-library', [group.id], null, function(err, results) {
                                                 assert.ok(!err);
                                                 assert.equal(results.total, 1);
                                                 assert.equal(results.results[0].id, content.id);
 
-                                                // Verify tenant admin can see it
-                                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                // Verify a cross-tenant user can see it
+                                                SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [group.id], null, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.equal(results.total, 1);
                                                     assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify a member can see it
-                                                    SearchTestsUtil.searchAll(jackRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-
-                                                        // Verify a loggedin non-member can see it
-                                                        SearchTestsUtil.searchAll(janeRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.equal(results.total, 1);
-                                                            assert.equal(results.results[0].id, content.id);
-
-                                                            // Verify a cross-tenant user can see it
-                                                            SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.equal(results.total, 1);
-                                                                assert.equal(results.results[0].id, content.id);
-                                                                callback();
-                                                            });
-                                                        });
-                                                    });
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -409,74 +335,51 @@ describe('Library Search', function() {
          * Test that verifies that anonymous and cross-tenant users cannot search loggedin group library items.
          */
         it('verify anonymous and cross-tenant users cannot see loggedin group library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 4, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [], function(err, group) {
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [jack.user.id], function(err, group) {
                         assert.ok(!err);
 
-                        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                        // Create the loggedin content item and share it with the group
+                        RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                             assert.ok(!err);
-                            var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                            var membership = {};
-                            membership[jack.id] = 'member';
-                            RestAPI.Group.setGroupMembers(doerRestContext, group.id, membership, function(err) {
+                            RestAPI.Content.shareContent(doer.restContext, content.id, [group.id], function(err) {
                                 assert.ok(!err);
 
-                                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                                // Verify anonymous cannot see it
+                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
                                     assert.ok(!err);
-                                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                                    assert.equal(results.total, 0);
+                                    assert.ok(!results.results[0]);
 
-                                    // Create the loggedin content item and share it with the group
-                                    RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                                    // Verify tenant admin can see it
+                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
                                         assert.ok(!err);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        RestAPI.Content.shareContent(doerRestContext, content.id, [group.id], function(err) {
+                                        // Verify member user can see it
+                                        SearchTestsUtil.searchAll(jack.restContext, 'content-library', [group.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 1);
+                                            assert.equal(results.results[0].id, content.id);
 
-                                            // Verify anonymous cannot see it
-                                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
+                                            // Verify a loggedin non-member can see it
+                                            SearchTestsUtil.searchAll(jane.restContext, 'content-library', [group.id], null, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.equal(results.total, 0);
-                                                assert.ok(!results.results[0]);
+                                                assert.equal(results.total, 1);
+                                                assert.equal(results.results[0].id, content.id);
 
-                                                // Verify tenant admin can see it
-                                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                // Verify a cross-tenant user cannot see it
+                                                SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [group.id], null, function(err, results) {
                                                     assert.ok(!err);
-                                                    assert.equal(results.total, 1);
-                                                    assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify member user can see it
-                                                    SearchTestsUtil.searchAll(jackRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-
-                                                        // Verify a loggedin non-member can see it
-                                                        SearchTestsUtil.searchAll(janeRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.equal(results.total, 1);
-                                                            assert.equal(results.results[0].id, content.id);
-
-                                                            // Verify a cross-tenant user cannot see it
-                                                            SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.equal(results.total, 0);
-                                                                assert.ok(!results.results[0]);
-                                                                callback();
-                                                            });
-                                                        });
-                                                    });
+                                                    assert.equal(results.total, 0);
+                                                    assert.ok(!results.results[0]);
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -494,87 +397,57 @@ describe('Library Search', function() {
          * belong to a different tenant.
          */
         it('verify only member and admin users can see private group library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy McSithypants', null, function(err, sith) {
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [sith.user.id, jack.user.id], function(err, group) {
                         assert.ok(!err);
-                        var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
 
-                        // create group with sith as a member
-                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [sith.id], function(err, group) {
+                        // Create the private content item and share it with the group
+                        RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                             assert.ok(!err);
 
-                            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                            RestAPI.Content.shareContent(doer.restContext, content.id, [group.id], function(err) {
                                 assert.ok(!err);
-                                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                                var membership = {};
-                                membership[jack.id] = 'member';
-                                RestAPI.Group.setGroupMembers(doerRestContext, group.id, membership, function(err) {
+                                // Verify anonymous cannot see the private content item
+                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 0);
+                                    assert.ok(!results.results[0]);
 
-                                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                                    // Verify cam admin can see the private content item
+                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
                                         assert.ok(!err);
-                                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        // Create the private content item and share it with the group
-                                        RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                                        // Verify the same-tenant member can see the private content item
+                                        SearchTestsUtil.searchAll(jack.restContext, 'content-library', [group.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 1);
+                                            assert.equal(results.results[0].id, content.id);
 
-                                            RestAPI.Content.shareContent(doerRestContext, content.id, [group.id], function(err) {
+                                            // Verify the cross-tenant member can see the private content item
+                                            SearchTestsUtil.searchAll(sith.restContext, 'content-library', [group.id], null, function(err, results) {
                                                 assert.ok(!err);
+                                                assert.equal(results.total, 1);
+                                                assert.equal(results.results[0].id, content.id);
 
-                                                // Verify anonymous cannot see the private content item
-                                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                // Verify another loggedin user cannot see the private content item
+                                                SearchTestsUtil.searchAll(jane.restContext, 'content-library', [group.id], null, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.equal(results.total, 0);
                                                     assert.ok(!results.results[0]);
 
-                                                    // Verify cam admin can see the private content item
-                                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                    // Verify cross-tenant non-member user cannot see the private content item
+                                                    SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [group.id], null, function(err, results) {
                                                         assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-
-                                                        // Verify the same-tenant member can see the private content item
-                                                        SearchTestsUtil.searchAll(jackRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.equal(results.total, 1);
-                                                            assert.equal(results.results[0].id, content.id);
-
-                                                            // Verify the cross-tenant member can see the private content item
-                                                            SearchTestsUtil.searchAll(sithRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.equal(results.total, 1);
-                                                                assert.equal(results.results[0].id, content.id);
-
-                                                                // Verify another loggedin user cannot see the private content item
-                                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                    assert.ok(!err);
-                                                                    assert.equal(results.total, 0);
-                                                                    assert.ok(!results.results[0]);
-
-                                                                    // Verify cross-tenant non-member user cannot see the private content item
-                                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                        assert.ok(!err);
-                                                                        assert.equal(results.total, 0);
-                                                                        assert.ok(!results.results[0]);
-                                                                        callback();
-                                                                    });
-                                                                });
-                                                            });
-                                                        });
+                                                        assert.equal(results.total, 0);
+                                                        assert.ok(!results.results[0]);
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -595,19 +468,16 @@ describe('Library Search', function() {
          * Test that verifies paging of library search works correctly
          */
         it('verify paging the library search feed works correctly', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(doerRestContext, 'Google Website', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, content) {
+                    RestAPI.Content.createLink(doer.restContext, 'Google Website', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, content) {
                         assert.ok(!err);
 
-                        SearchTestsUtil.searchRefreshed(doerRestContext, 'content-library', [doer.id], {'limit': 2, 'start': 0}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(doer.restContext, 'content-library', [doer.user.id], {'limit': 2, 'start': 0}, function(err, results) {
                             assert.ok(!err);
                             assert.ok(results.results);
                             assert.equal(results.results.length, 2);
@@ -619,19 +489,19 @@ describe('Library Search', function() {
                             assert.ok(secondId);
 
                             // Verify the first item comes on the first page. We don't need to refresh this search because we haven't indexed anything since the previous search
-                            RestAPI.Search.search(doerRestContext, 'content-library', [doer.id], {'limit': 1, 'start': 0}, function(err, results) {
+                            RestAPI.Search.search(doer.restContext, 'content-library', [doer.user.id], {'limit': 1, 'start': 0}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(results.results);
                                 assert.equal(results.results.length, 1);
                                 assert.equal(results.results[0].id, firstId);
 
                                 // Verify the second item comes on the first page.
-                                RestAPI.Search.search(doerRestContext, 'content-library', [doer.id], {'limit': 1, 'start': 1}, function(err, results) {
+                                RestAPI.Search.search(doer.restContext, 'content-library', [doer.user.id], {'limit': 1, 'start': 1}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(results.results);
                                     assert.equal(results.results.length, 1);
                                     assert.equal(results.results[0].id, secondId);
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-content/tests/test-search.js
+++ b/node_modules/oae-content/tests/test-search.js
@@ -139,16 +139,14 @@ describe('Search', function() {
          * item.
          */
         it('verify indexing without full content item', function(callback) {
-            // Create a content item to verify re-indexing
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'test-search index-without-full-content-item', 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
+                RestAPI.Content.createLink(doer.restContext, 'test-search index-without-full-content-item', 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Verify the content item exists
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
                         assert.ok(!err);
                         var contentDoc = _getDocById(results, link.id);
                         assert.ok(contentDoc);
@@ -158,7 +156,7 @@ describe('Search', function() {
                             assert.ok(!err);
 
                             // Verify the content item no longer exists
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
+                            SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
                                 assert.ok(!err);
                                 var contentDoc = _getDocById(results, link.id);
                                 assert.ok(!contentDoc);
@@ -168,7 +166,7 @@ describe('Search', function() {
                                     assert.ok(!err);
 
                                     // Ensure that the full content item is now back in the search index
-                                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
+                                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
                                         assert.ok(!err);
                                         var contentDoc = _getDocById(results, link.id);
                                         assert.ok(contentDoc);
@@ -177,7 +175,7 @@ describe('Search', function() {
                                         assert.ok(_.isObject(contentDoc.tenant));
                                         assert.ok(contentDoc.tenant.displayName);
                                         assert.ok(contentDoc.tenant.alias);
-                                        callback();
+                                        return callback();
                                     });
                                 });
                             });
@@ -191,16 +189,15 @@ describe('Search', function() {
          * Verify that the mime property only returns on search results of type 'file'.
          */
         it('verify mime type', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
                 // Make sure links don't have mime field
                 var description = TestsUtil.generateTestUserId('mimetype-test');
-                RestAPI.Content.createLink(doerRestContext, 'Test Content 1', description, 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
+                RestAPI.Content.createLink(doer.restContext, 'Test Content 1', description, 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
                     assert.ok(!err);
 
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
                         assert.ok(!err);
                         var contentDoc = _getDocById(results, link.id);
                         assert.ok(contentDoc);
@@ -209,18 +206,18 @@ describe('Search', function() {
                         // Make sure files do get mime field
                         var file = fs.createReadStream( __dirname + '/data/oae-video.png');
                         description = TestsUtil.generateTestUserId('mimetype-test');
-                        RestAPI.Content.createFile(doerRestContext, 'Test Content 2', description, 'public', file,  [], [], [], function(err, contentObj) {
+                        RestAPI.Content.createFile(doer.restContext, 'Test Content 2', description, 'public', file,  [], [], [], function(err, contentObj) {
                             assert.ok(!err);
                             assert.ok(contentObj);
                             assert.equal(contentObj.mime, 'image/png');
 
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
+                            SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
                                 assert.ok(!err);
                                 var contentDoc = _getDocById(results, contentObj.id);
                                 assert.ok(contentDoc);
                                 assert.equal(contentDoc.mime, 'image/png');
 
-                                callback();
+                                return callback();
                             });
                         });
                     });

--- a/node_modules/oae-content/tests/test-tenant-separation.js
+++ b/node_modules/oae-content/tests/test-tenant-separation.js
@@ -51,7 +51,7 @@ describe('Content', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
-        callback();
+        return callback();
     });
 
     describe('Tenant separation', function() {
@@ -375,46 +375,33 @@ describe('Content', function() {
          * Test that verifies that a user from an external tenant is limited to only the public content library of users
          */
         it('verify user sees only public libraries of external tenant users', function(callback) {
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A (cam)
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create 2 users in tenant A (cam)
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                // Create a second user in tenant A (A2)
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User A2', null, function(err, userA2) {
+                // Create a user in tenant B (gt)
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create user in tenant B (gt)
-                    RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                    // Create "public" content in tenant A
+                    RestAPI.Content.createLink(userA.restContext, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.user.id], [], [], function(err, publicContentA) {
                         assert.ok(!err);
-                        var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
-                        // Create "public" content in tenant A
-                        RestAPI.Content.createLink(restCtxA, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.id], [], [], function(err, publicContentA) {
+                        // Create "loggedin" content in tenant A
+                        RestAPI.Content.createLink(userA.restContext, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.user.id], [], [], function(err, loggedInContentA) {
                             assert.ok(!err);
 
-                            // Create "loggedin" content in tenant A
-                            RestAPI.Content.createLink(restCtxA, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.id], [], [], function(err, loggedInContentA) {
+                            // Verify user A2 can see both public and logged in content items
+                            RestAPI.Content.getLibrary(userA2.restContext, userA.user.id, null, 10, function(err, libraryA) {
                                 assert.ok(!err);
+                                assert.equal(libraryA.results.length, 2);
 
-                                // Verify user A2 can see both public and logged in content items
-                                RestAPI.Content.getLibrary(restCtxA2, userA.id, null, 10, function(err, libraryA) {
+                                // Verify user B cannot see the loggedin content item, but can see the public content item
+                                RestAPI.Content.getLibrary(userB.restContext, userA.user.id, null, 10, function(err, libraryA) {
                                     assert.ok(!err);
-                                    assert.equal(libraryA.results.length, 2);
-
-                                    // Verify user B cannot see the loggedin content item, but can see the public content item
-                                    RestAPI.Content.getLibrary(restCtxB, userA.id, null, 10, function(err, libraryA) {
-                                        assert.ok(!err);
-                                        assert.equal(libraryA.results.length, 1);
-                                        assert.equal(libraryA.results[0].id, publicContentA.id);
-                                        callback();
-                                    });
+                                    assert.equal(libraryA.results.length, 1);
+                                    assert.equal(libraryA.results[0].id, publicContentA.id);
+                                    return callback();
                                 });
                             });
                         });
@@ -427,43 +414,38 @@ describe('Content', function() {
          * Test that verifies that users from an external tenant are limited to a group's public content library
          */
         it('verify user sees only public library of external tenant groups', function(callback) {
-            var usernameA = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A (cam)
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create a user in tenant A (cam)
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, userA) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                // Create a group in tenant A
-                RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'public', 'no', [], [], function(err, groupA) {
+                // Create a user in tenant B (gt)
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
 
-                    // Create user in tenant B (gt)
-                    RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                    // Create a group in tenant A
+                    var groupName = TestsUtil.generateTestUserId();
+                    RestAPI.Group.createGroup(userA.restContext, groupName, groupName, 'public', 'no', [], [], function(err, groupA) {
                         assert.ok(!err);
-                        var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
                         // Create "public" content in tenant A
-                        RestAPI.Content.createLink(restCtxA, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.id], [groupA.id], [], function(err, publicContentA) {
+                        RestAPI.Content.createLink(userA.restContext, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.user.id], [groupA.id], [], function(err, publicContentA) {
                             assert.ok(!err);
 
                             // Create "loggedin" content in tenant A
-                            RestAPI.Content.createLink(restCtxA, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.id], [groupA.id], [], function(err, loggedInContentA) {
+                            RestAPI.Content.createLink(userA.restContext, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.user.id], [groupA.id], [], function(err, loggedInContentA) {
                                 assert.ok(!err);
 
                                 // Verify user A can see both public and logged in content items for the group
-                                RestAPI.Content.getLibrary(restCtxA, groupA.id, null, 10, function(err, libraryA) {
+                                RestAPI.Content.getLibrary(userA.restContext, groupA.id, null, 10, function(err, libraryA) {
                                     assert.ok(!err);
                                     assert.equal(libraryA.results.length, 2);
 
                                     // Verify user B cannot see the loggedin content item, but can see the public content item
-                                    RestAPI.Content.getLibrary(restCtxB, groupA.id, null, 10, function(err, libraryB) {
+                                    RestAPI.Content.getLibrary(userB.restContext, groupA.id, null, 10, function(err, libraryB) {
                                         assert.ok(!err);
                                         assert.equal(libraryB.results.length, 1);
                                         assert.equal(libraryB.results[0].id, publicContentA.id);
-                                        callback();
+                                        return callback();
                                     });
                                 });
                             });

--- a/node_modules/oae-context/tests/test-context.js
+++ b/node_modules/oae-context/tests/test-context.js
@@ -28,8 +28,8 @@ describe('Context', function() {
      * Test that verifies a simple context
      */
     it('verify simple context', function(callback) {
-        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'public', 'Bert', 'Pareyn', 'PhysX');
-        var imposter = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:simong', 'simong', 'private', 'Simon', 'Gaeremynck', 'simong');
+        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'bert@apereo.org');
+        var imposter = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:simong', 'simong', 'simon@apereo.org');
         var ctx = new Context(global.oaeTests.tenants.cam, user, 'twitter', null, imposter);
         assert.deepEqual(ctx.tenant(), global.oaeTests.tenants.cam);
         assert.deepEqual(ctx.user(), user);
@@ -43,7 +43,7 @@ describe('Context', function() {
      * Test that verifies the locale setter can handle defaulted locales
      */
     it('verify the locale setter can handle defaulted locales', function(callback) {
-        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'public', 'Bert', 'Pareyn', 'PhysX');
+        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'bert@apereo.org');
         var ctx = new Context(global.oaeTests.tenants.cam, user, 'twitter', 'en_UK');
         assert.deepEqual(ctx.tenant(), global.oaeTests.tenants.cam);
         assert.deepEqual(ctx.user(), user);

--- a/node_modules/oae-discussions/tests/test-activity.js
+++ b/node_modules/oae-discussions/tests/test-activity.js
@@ -21,6 +21,7 @@ var ShortId = require('shortid');
 var AuthzUtil = require('oae-authz/lib/util');
 var log = require('oae-logger').logger('test-activity');
 var PreviewConstants = require('oae-preview-processor/lib/constants');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var Sanitization = require('oae-util/lib/sanitization');
@@ -66,8 +67,7 @@ describe('Discussion Activity', function() {
              * Test that verifies the properties of the discussion entity
              */
             it('verify the discussion entity model contains the correct information', function(callback) {
-                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
-                    var simon = _.values(users)[0];
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simon) {
 
                     RestAPI.Discussions.createDiscussion(simon.restContext, 'Goats', 'Start discussing this sweet topic', 'loggedin', null, null, function(err, discussion) {
                         assert.ok(!err);
@@ -98,8 +98,7 @@ describe('Discussion Activity', function() {
              * Test that verifies the properties of the discussion entity when updating.
              */
             it('verify the discussion entity model contains the correct information when updating a discussion', function(callback) {
-                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
-                    var simon = _.values(users)[0];
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simon) {
 
                     RestAPI.Discussions.createDiscussion(simon.restContext, 'Bonobos', 'Start discussing this sweet topic', 'loggedin', null, null, function(err, discussion) {
                         assert.ok(!err);
@@ -476,131 +475,28 @@ describe('Discussion Activity', function() {
          * are appropriately scrubbed.
          */
         it('verify discussion message email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, mrvisser, simong, nicolaas) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-                var nicolaas = _.values(users)[2];
-
-                // Generate e-mail addresses
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
 
-                // Update the users
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
+                // Update Simon
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the discussion
+                    RestAPI.Discussions.createDiscussion(mrvisser.restContext, 'A talk', 'about computers', 'public', [], [], function(err, discussion) {
                         assert.ok(!err);
 
-                        // Create the discussion
-                        RestAPI.Discussions.createDiscussion(mrvisser.restContext, 'A talk', 'about computers', 'public', [], [], function(err, discussion) {
+                        // Post a new message
+                        RestAPI.Discussions.createMessage(simong.restContext, discussion.id, '<b>Nice discussion.</b>\n\nWould read again', null, function(err, simongMessage) {
                             assert.ok(!err);
 
-                            // Post a new message
-                            RestAPI.Discussions.createMessage(simong.restContext, discussion.id, '<b>Nice discussion.</b>\n\nWould read again', null, function(err, simongMessage) {
-                                assert.ok(!err);
-
-                                EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                    // There should be exactly one email, the one sent to mrvisser (manager of discussion receives discussion-message notification)
-                                    assert.equal(emails.length, 1);
-
-                                    var stringEmail = JSON.stringify(emails[0]);
-                                    var email = emails[0];
-
-                                    // Sanity check that the email is to mrvisser
-                                    assert.equal(email.to[0].address, mrvisser.user.email);
-
-                                    // Ensure that the subject of the email contains the poster's name
-                                    assert.notEqual(email.subject.indexOf('swappedFromPublicAlias'), -1);
-
-                                    // Ensure some data expected to be in the email is there
-                                    assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
-                                    assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
-                                    assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
-
-                                    // Ensure simong's private info is nowhere to be found
-                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
-
-                                    // The email should contain the public alias
-                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-
-                                    // The message should have escaped the HTML content in the original message
-                                    assert.strictEqual(stringEmail.indexOf('<b>Nice discussion.</b>'), -1);
-
-                                    // The new line characters should've been converted into paragraphs
-                                    assert.notEqual(stringEmail.indexOf('Would read again</p>'), -1);
-
-                                    // Send a message as nicolaas and ensure the recent commenter, simong receives an email about it
-                                    RestAPI.Discussions.createMessage(nicolaas.restContext, discussion.id, 'I have a computer, too', null, function(err, nicolaasMessage) {
-                                        assert.ok(!err);
-
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                            // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
-                                            assert.equal(emails.length, 2);
-
-                                            var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
-                                            assert.ok(_.contains(emailAddresses, simong.user.email));
-                                            assert.ok(_.contains(emailAddresses, mrvisser.user.email));
-                                            return callback();
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-
-        /**
-         * Test that verifies an email is sent to the members when a discussion is created, and that private users are
-         * appropriately scrubbed.
-         */
-        it('verify discussion-create email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
-                assert.ok(!err);
-
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                // Generate e-mail addresses
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
-                // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
-                var simongUpdate = {
-                    'email': simong.user.email,
-                    'visibility': 'private',
-                    'publicAlias': 'swappedFromPublicAlias'
-                };
-
-                // Update the users
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
-                        assert.ok(!err);
-
-                        // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
-                        RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'not about computers', 'public', [], [mrvisser.user.id], function(err, discussion) {
-                            assert.ok(!err);
-
-                            // Mrvisser should get an email, with simong's information scrubbed
                             EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                // There should be exactly one email, the one sent to mrvisser
+                                // There should be exactly one email, the one sent to mrvisser (manager of discussion receives discussion-message notification)
                                 assert.equal(emails.length, 1);
 
                                 var stringEmail = JSON.stringify(emails[0]);
@@ -608,6 +504,9 @@ describe('Discussion Activity', function() {
 
                                 // Sanity check that the email is to mrvisser
                                 assert.equal(email.to[0].address, mrvisser.user.email);
+
+                                // Ensure that the subject of the email contains the poster's name
+                                assert.notEqual(email.subject.indexOf('swappedFromPublicAlias'), -1);
 
                                 // Ensure some data expected to be in the email is there
                                 assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
@@ -622,8 +521,79 @@ describe('Discussion Activity', function() {
                                 // The email should contain the public alias
                                 assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
 
-                                callback();
+                                // The message should have escaped the HTML content in the original message
+                                assert.strictEqual(stringEmail.indexOf('<b>Nice discussion.</b>'), -1);
+
+                                // The new line characters should've been converted into paragraphs
+                                assert.notEqual(stringEmail.indexOf('Would read again</p>'), -1);
+
+                                // Send a message as nicolaas and ensure the recent commenter, simong receives an email about it
+                                RestAPI.Discussions.createMessage(nicolaas.restContext, discussion.id, 'I have a computer, too', null, function(err, nicolaasMessage) {
+                                    assert.ok(!err);
+
+                                    EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                                        // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
+                                        assert.equal(emails.length, 2);
+
+                                        var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
+                                        assert.ok(_.contains(emailAddresses, simong.user.email));
+                                        assert.ok(_.contains(emailAddresses, mrvisser.user.email));
+                                        return callback();
+                                    });
+                                });
                             });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies an email is sent to the members when a discussion is created, and that private users are
+         * appropriately scrubbed.
+         */
+        it('verify discussion-create email and privacy', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
+                assert.ok(!err);
+
+                // Simon is private and mrvisser is public
+                var simongUpdate = {
+                    'visibility': 'private',
+                    'publicAlias': 'swappedFromPublicAlias'
+                };
+
+                // Update Simon
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
+
+                    // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
+                    RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'not about computers', 'public', [], [mrvisser.user.id], function(err, discussion) {
+                        assert.ok(!err);
+
+                        // Mrvisser should get an email, with simong's information scrubbed
+                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                            // There should be exactly one email, the one sent to mrvisser
+                            assert.equal(emails.length, 1);
+
+                            var stringEmail = JSON.stringify(emails[0]);
+                            var email = emails[0];
+
+                            // Sanity check that the email is to mrvisser
+                            assert.equal(email.to[0].address, mrvisser.user.email);
+
+                            // Ensure some data expected to be in the email is there
+                            assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
+                            assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
+                            assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
+
+                            // Ensure simong's private info is nowhere to be found
+                            assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.locale), -1);
+
+                            // The email should contain the public alias
+                            assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+
+                            return callback();
                         });
                     });
                 });
@@ -635,66 +605,52 @@ describe('Discussion Activity', function() {
          * appropriately scrubbed.
          */
         it('verify discussion-share email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                // Generate e-mail addresses
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
 
-                // Update the users
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
+                // Update Simon
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
+                    RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'about the moon', 'public', [], [], function(err, discussion) {
                         assert.ok(!err);
 
-                        // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
-                        RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'about the moon', 'public', [], [], function(err, discussion) {
-                            assert.ok(!err);
+                        // Collect the createLink activity
+                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
 
-                            // Collect the createLink activity
-                            EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                            RestAPI.Discussions.shareDiscussion(simong.restContext, discussion.id, [mrvisser.user.id], function(err) {
+                                assert.ok(!err);
 
-                                RestAPI.Discussions.shareDiscussion(simong.restContext, discussion.id, [mrvisser.user.id], function(err) {
-                                    assert.ok(!err);
+                                // Mrvisser should get an email, with simong's information scrubbed
+                                EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                                    // There should be exactly one email, the one sent to mrvisser
+                                    assert.equal(emails.length, 1);
 
-                                    // Mrvisser should get an email, with simong's information scrubbed
-                                    EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                        // There should be exactly one email, the one sent to mrvisser
-                                        assert.equal(emails.length, 1);
+                                    var stringEmail = JSON.stringify(emails[0]);
+                                    var email = emails[0];
 
-                                        var stringEmail = JSON.stringify(emails[0]);
-                                        var email = emails[0];
+                                    // Sanity check that the email is to mrvisser
+                                    assert.equal(email.to[0].address, mrvisser.user.email);
 
-                                        // Sanity check that the email is to mrvisser
-                                        assert.equal(email.to[0].address, mrvisser.user.email);
+                                    // Ensure some data expected to be in the email is there
+                                    assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
+                                    assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
+                                    assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
 
-                                        // Ensure some data expected to be in the email is there
-                                        assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
-                                        assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
-                                        assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
+                                    // Ensure simong's private info is nowhere to be found
+                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                        // Ensure simong's private info is nowhere to be found
-                                        assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.locale), -1);
-
-                                        // The email should contain the public alias
-                                        assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-                                        callback();
-                                    });
+                                    // The email should contain the public alias
+                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-folders/lib/test/util.js
+++ b/node_modules/oae-folders/lib/test/util.js
@@ -368,7 +368,7 @@ var assertCreateFolderSucceeds = module.exports.assertCreateFolderSucceeds = fun
                 );
 
                 // The current user is only made a manager if he can't manage any other managers
-                var user = new User(me.tenant.alias, me.id, me.displayName, me);
+                var user = new User(me.tenant.alias, me.id, me.displayName, me.email, me);
                 var ctx = new Context(me.tenant, user);
                 PrincipalsAPI.canManageAny(ctx, managerIds, function(err, canManage) {
                     assert.ok(!err);

--- a/node_modules/oae-logger/tests/test-logger.js
+++ b/node_modules/oae-logger/tests/test-logger.js
@@ -47,7 +47,7 @@ describe('Logger', function() {
         TelemetryAPI.init({'enabled': false}, function(err) {
             assert.ok(!err);
             return callback();
-        }); 
+        });
     });
 
     /**

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -46,6 +46,7 @@ var PrincipalsEmitter = require('./internal/emitter');
 var PrincipalsModel = require('./model');
 var PrincipalsTermsAndConditionsAPI = require('./api.termsAndConditions');
 var PrincipalsUtil = require('./util');
+var User = require('./model').User;
 
 var fullUserProfileDecorators = {};
 
@@ -79,6 +80,7 @@ var registerFullUserProfileDecorator = module.exports.registerFullUserProfileDec
  *
  * @param  {Context}   ctx                      Standard context object containing the current user and the current tenant
  * @param  {String}    displayName              The display name for the user
+ * @param  {String}    email                    The email address for the user
  * @param  {Object}    [opts]                   Optional parameters for the user
  * @param  {String}    [opts.visibility]        The visibility of the user. One of AuthzConstants.visibility
  * @param  {String}    [opts.locale]            The locale for the user
@@ -92,7 +94,7 @@ var registerFullUserProfileDecorator = module.exports.registerFullUserProfileDec
  * @param  {Object}    callback.err             An error that occurred, if any
  * @param  {User}      callback.createdUser     The created user
  */
-var createUser = module.exports.createUser = function(ctx, tenantAlias, displayName, opts, callback) {
+var createUser = module.exports.createUser = function(ctx, tenantAlias, displayName, email, opts, callback) {
     tenantAlias = tenantAlias || ctx.tenant().alias;
     opts = opts || {};
     callback = callback || function(err) {
@@ -119,6 +121,7 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
         }
     }
 
+    var isAdmin = (ctx.user() && ctx.user().isAdmin(tenantAlias));
     opts.visibility = opts.visibility || PrincipalsConfig.getValue(tenantAlias, 'user', 'visibility');
     opts.publicAlias = opts.publicAlias || displayName;
     opts.acceptedTC = opts.acceptedTC || false;
@@ -127,55 +130,68 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
     var validator = new Validator();
     validator.check(displayName, {'code': 400, 'msg': 'A display name must be provided'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
+    validator.check(email, {'code': 400, 'msg': 'An email address must be provided'}).notEmpty();
+    validator.check(email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
     validator.check(opts.visibility, {'code': 400, 'msg': 'The specified visibility setting is unknown'}).isIn(_.values(AuthzConstants.visibility));
     validator.check(opts.emailPreference, {'code': 400, 'msg': 'The specified email preference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
-
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
 
-    var id = AuthzUtil.toId('u', tenantAlias, ShortId.generate());
+    // Verify no user with this email address exists already
+    PrincipalsDAO.getUserByEmail(email, function(err, existingUser) {
+        if (err && err.code !== 404) {
+            return callback(err);
+        } else if (existingUser) {
+            return callback({'code': 400, 'msg': 'A user with this email address already exists'});
+        }
 
-    var values = {
-        'tenantAlias': tenantAlias,
-        'displayName': displayName,
-        'visibility': opts.visibility,
-        'email': opts.email,
-        'emailPreference': opts.emailPreference,
-        'locale': opts.locale,
-        'publicAlias': opts.publicAlias,
-        'smallPictureUri': opts.smallPictureUri,
-        'mediumPictureUri': opts.mediumPictureUri,
-        'largePictureUri': opts.lagePictureUri
-    };
+        var id = AuthzUtil.toId('u', tenantAlias, ShortId.generate());
+        var user = new User(tenantAlias, id, displayName, email, {
+            'visibility': opts.visibility,
+            'locale': opts.locale,
+            'publicAlias': opts.publicAlias,
+            'emailPreference': opts.emailPreference,
+            'smallPictureUri': opts.smallPictureUri,
+            'mediumPictureUri': opts.mediumPictureUri,
+            'largePictureUri': opts.lagePictureUri,
+            'acceptedTC': 0,
+            'guest': opts.guest
+        });
 
-    // We store the timestamp at which the user accepted the Terms and Conditions
-    // This allows for allowing users to re-accept the Terms and Conditions after they have been updated
-    var tcEnabled = PrincipalsConfig.getValue(tenantAlias, 'termsAndConditions', 'enabled');
-    if (tcEnabled && opts.acceptedTC) {
-        // Store the acceptedTC on the return user object
-        opts.acceptedTC = Date.now();
+        // We store the timestamp at which the user accepted the Terms and Conditions
+        // This allows for allowing users to re-accept the Terms and Conditions after they have been updated
+        user.needsToAcceptTC = PrincipalsConfig.getValue(tenantAlias, 'termsAndConditions', 'enabled');
+        if (user.needsToAcceptTC && opts.acceptedTC) {
+            user.acceptedTC = Date.now();
+            user.needsToAcceptTC = false;
+        }
 
-        // Also persist it, but it must be a String because that is the column data-type in Cassandra
-        values.acceptedTC = opts.acceptedTC.toString();
-    }
+        return _createUser(ctx, user, callback);
+    });
+};
 
-    var q = Cassandra.constructUpsertCQL('Principals', 'principalId', id, values);
-    if (!q) {
-        return callback({'code': 500, 'msg': 'Could not create a proper CQL query'});
-    }
-
-    // Create the user
-    Cassandra.runQuery(q.query, q.parameters, function (err) {
+/**
+ * Create a new user record. This assumes all validation has happened
+ * at an earlier point in time
+ *
+ * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
+ * @param  {User}       user                        The user to create
+ * @param  {Function}   callback                    Standard callback function
+ * @param  {Object}     callback.err                An error that occurred, if any
+ * @param  {User}       callback.createdUser        The created user
+ */
+var _createUser = function(ctx, user, callback) {
+    PrincipalsDAO.createUser(user, function(err) {
         if (err) {
             return callback(err);
         }
 
-        var createdUser = new PrincipalsModel.User(tenantAlias, id, displayName, opts);
-        createdUser.needsToAcceptTC = false;
+        // Emit an event indicating a user account has been created
+        PrincipalsEmitter.emit(PrincipalsConstants.events.CREATED_USER, ctx, user);
 
-        PrincipalsEmitter.emit(PrincipalsConstants.events.CREATED_USER, ctx, createdUser);
-        return callback(null, createdUser);
+        // Return to the caller
+        return callback(null, user);
     });
 };
 
@@ -292,7 +308,7 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                 var externalId = user[0];
                 // Construct the first name and last name into a display name
                 var displayName = util.format('%s %s', user[2], user[1]).trim();
-                opts.email = user[3];
+                var email = user[3];
 
                 /*!
                  * Gets called when the user has been created or updated
@@ -327,7 +343,7 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                 // If the user already exists but has a different displayName from the one
                 // in the CSV file, we update it
                 // TODO: Fix cross-dependency between the Authentication API and the Principals API
-                require('oae-authentication').getOrCreateUser(adminCtx, authenticationStrategy, externalId, providerProperties, displayName, opts, function(err, user, loginId, created) {
+                require('oae-authentication').getOrCreateUser(adminCtx, authenticationStrategy, externalId, providerProperties, displayName, email, opts, function(err, user, loginId, created) {
                     if (err) {
                         return finishImportUser(err);
 
@@ -343,8 +359,8 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                             if (user.publicAlias !== displayName) {
                                 update['publicAlias'] = displayName;
                             }
-                            if (user.email !== opts.email) {
-                                update['email'] = opts.email;
+                            if (user.email !== email) {
+                                update['email'] = email;
                             }
                         } else {
                             // Only update the user's displayname or email when their is value in doing it
@@ -354,9 +370,6 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                             if (!user.publicAlias || user.publicAlias === externalId) {
                                 update['publicAlias'] = displayName;
                             }
-                            if (!user.email) {
-                                update['email'] = opts.email;
-                            }
                         }
 
                         if (!_.isEmpty(update)) {
@@ -364,7 +377,7 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                                 'externalId': externalId,
                                 'user': user,
                                 'update': update
-                            }, 'Updating display name and/or email during import from CSV');
+                            }, 'Updating display name, public alias and/or email during import from CSV');
                             updateUser(adminCtx, user.id, update, finishImportUser);
                         } else {
                             finishImportUser();
@@ -438,7 +451,7 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
     validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).notEmpty();
     validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).isUserId();
 
-    // Check that there is at least one updated profile field.
+    // Check that there is at least one updated profile field
     validator.check(profileFieldKeys.length, {'code': 400, 'msg': 'At least one basic profile field should be specified'}).min(1);
 
     // verify that restricted properties aren't set here
@@ -449,13 +462,14 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
         validator.check(profileFields['displayName'], {'code': 400, 'msg': 'A display name cannot be empty'}).notEmpty();
         validator.check(profileFields['displayName'], {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
     }
-
-    // In case a new visibility has been passed in, we check for its validity
     if (profileFields['visibility']) {
         validator.check(profileFields['visibility'], {'code': 400, 'msg': 'An invalid visibility option has been specified'}).isIn(_.values(AuthzConstants.visibility));
     }
     if (profileFields['emailPreference']) {
         validator.check(profileFields['emailPreference'], {'code': 400, 'msg': 'The specified emailPreference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
+    }
+    if (profileFields['email']) {
+        validator.check(profileFields['email'], {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
     }
 
     validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to update a user'}).isLoggedInUser(ctx);
@@ -474,6 +488,8 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
         if (err) {
             return callback(err);
         }
+
+        // TODO: Email verification if the email address was changed
 
         // Overlay the correct lastModified date
         profileFields = _.extend({}, profileFields, {'lastModified': Date.now()});

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -134,8 +134,8 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
     validator.check(opts.emailPreference, {'code': 400, 'msg': 'The specified email preference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
 
     // Because some SSO strategies do not release an email address, we allow user accounts to be
-    // created without providing the email. The UI however, will keep nagging users about filling
-    // one in
+    // created without providing the email.
+    // TODO: The UI however, will keep nagging users about filling one in
     if (opts.email) {
         validator.check(opts.email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
     }
@@ -160,8 +160,7 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
             'smallPictureUri': opts.smallPictureUri,
             'mediumPictureUri': opts.mediumPictureUri,
             'largePictureUri': opts.lagePictureUri,
-            'acceptedTC': 0,
-            'guest': opts.guest
+            'acceptedTC': 0
         });
 
         // We store the timestamp at which the user accepted the Terms and Conditions

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -468,7 +468,7 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
     if (profileFields['emailPreference']) {
         validator.check(profileFields['emailPreference'], {'code': 400, 'msg': 'The specified emailPreference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
     }
-    if (profileFields['email']) {
+    if (!_.isUndefined(profileFields['email'])) {
         validator.check(profileFields['email'], {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
     }
 
@@ -489,19 +489,54 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
             return callback(err);
         }
 
-        // TODO: Email verification if the email address was changed
-
-        // Overlay the correct lastModified date
-        profileFields = _.extend({}, profileFields, {'lastModified': Date.now()});
-        PrincipalsDAO.updatePrincipal(userId, profileFields, function(err) {
+        // Ensure the provided email, if any, is not used by another user
+        _checkEmailUsage(oldUser, profileFields.email, function(err) {
             if (err) {
                 return callback(err);
             }
 
-            var newUser = PrincipalsUtil.createUpdatedUser(oldUser, profileFields);
-            PrincipalsEmitter.emit(PrincipalsConstants.events.UPDATED_USER, ctx, newUser, oldUser);
-            return getUser(ctx, userId, callback);
+            // TODO: Email verification if the email address was changed
+
+            // Overlay the correct lastModified date
+            profileFields = _.extend({}, profileFields, {'lastModified': Date.now()});
+            PrincipalsDAO.updatePrincipal(userId, profileFields, function(err) {
+                if (err) {
+                    return callback(err);
+                }
+
+                var newUser = PrincipalsUtil.createUpdatedUser(oldUser, profileFields);
+                PrincipalsEmitter.emit(PrincipalsConstants.events.UPDATED_USER, ctx, newUser, oldUser);
+                return getUser(ctx, userId, callback);
+            });
         });
+    });
+};
+
+/**
+ * Check if an email address is already used by another user. If the email address is being used
+ * by another user, an error will be sent back
+ *
+ * @param  {User}       oldUser         The user who wants to change his email address
+ * @param  {String}     email           The email address the users wants to use
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error that occurred, if any
+ * @api private
+ */
+var _checkEmailUsage = function(oldUser, email, callback) {
+    // There's no need to check if the email address is already in use if it hasn't changed
+    if (!email || oldUser.email === email) {
+        return callback();
+    }
+
+    // Check if another user is already using this email address
+    PrincipalsDAO.getUserByEmail(email, function(err, user) {
+        if (err && err.code !== 404) {
+            return callback(err);
+        } else if (user && user.id !== oldUser.id) {
+            return callback({'code': 400, 'msg': 'The email address is already used by another user'});
+        }
+
+        return callback();
     });
 };
 

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -80,12 +80,12 @@ var registerFullUserProfileDecorator = module.exports.registerFullUserProfileDec
  *
  * @param  {Context}   ctx                      Standard context object containing the current user and the current tenant
  * @param  {String}    displayName              The display name for the user
- * @param  {String}    email                    The email address for the user
  * @param  {Object}    [opts]                   Optional parameters for the user
  * @param  {String}    [opts.visibility]        The visibility of the user. One of AuthzConstants.visibility
  * @param  {String}    [opts.locale]            The locale for the user
  * @param  {String}    [opts.publicAlias]       The name to show when the user is inaccessible to a user
  * @param  {Boolean}   [opts.acceptedTC]        Whether or not the user has accepted the Terms & Conditions
+ * @param  {String}    [opts.email]             The email address for the user
  * @param  {String}    [opts.emailPreference]   The email preference for the user. One of PrincipalsConstants.emailPreference
  * @param  {String}    [opts.smallPictureUri]   The URI for the small picture
  * @param  {String}    [opts.mediumPictureUri]  The URI for the medium picture
@@ -94,7 +94,7 @@ var registerFullUserProfileDecorator = module.exports.registerFullUserProfileDec
  * @param  {Object}    callback.err             An error that occurred, if any
  * @param  {User}      callback.createdUser     The created user
  */
-var createUser = module.exports.createUser = function(ctx, tenantAlias, displayName, email, opts, callback) {
+var createUser = module.exports.createUser = function(ctx, tenantAlias, displayName, opts, callback) {
     tenantAlias = tenantAlias || ctx.tenant().alias;
     opts = opts || {};
     callback = callback || function(err) {
@@ -130,24 +130,29 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
     var validator = new Validator();
     validator.check(displayName, {'code': 400, 'msg': 'A display name must be provided'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
-    validator.check(email, {'code': 400, 'msg': 'An email address must be provided'}).notEmpty();
-    validator.check(email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
     validator.check(opts.visibility, {'code': 400, 'msg': 'The specified visibility setting is unknown'}).isIn(_.values(AuthzConstants.visibility));
     validator.check(opts.emailPreference, {'code': 400, 'msg': 'The specified email preference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
+
+    // Because some SSO strategies do not release an email address, we allow user accounts to be
+    // created without providing the email. The UI however, will keep nagging users about filling
+    // one in
+    if (opts.email) {
+        validator.check(opts.email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
+    }
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
 
-    // Verify no user with this email address exists already
-    PrincipalsDAO.getUserByEmail(email, function(err, existingUser) {
+    // Verify this email address, if any, is not already mapped to another user
+    _getUserByEmailIfNecessary(opts.email, null, function(err, existingUser) {
         if (err && err.code !== 404) {
             return callback(err);
         } else if (existingUser) {
-            return callback({'code': 400, 'msg': 'A user with this email address already exists'});
+            return callback({'code': 400, 'msg': 'This email address is already associated with another user'});
         }
 
         var id = AuthzUtil.toId('u', tenantAlias, ShortId.generate());
-        var user = new User(tenantAlias, id, displayName, email, {
+        var user = new User(tenantAlias, id, displayName, opts.email, {
             'visibility': opts.visibility,
             'locale': opts.locale,
             'publicAlias': opts.publicAlias,
@@ -308,7 +313,7 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                 var externalId = user[0];
                 // Construct the first name and last name into a display name
                 var displayName = util.format('%s %s', user[2], user[1]).trim();
-                var email = user[3];
+                opts.email = user[3];
 
                 /*!
                  * Gets called when the user has been created or updated
@@ -343,7 +348,7 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                 // If the user already exists but has a different displayName from the one
                 // in the CSV file, we update it
                 // TODO: Fix cross-dependency between the Authentication API and the Principals API
-                require('oae-authentication').getOrCreateUser(adminCtx, authenticationStrategy, externalId, providerProperties, displayName, email, opts, function(err, user, loginId, created) {
+                require('oae-authentication').getOrCreateUser(adminCtx, authenticationStrategy, externalId, providerProperties, displayName, opts, function(err, user, loginId, created) {
                     if (err) {
                         return finishImportUser(err);
 
@@ -359,8 +364,8 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                             if (user.publicAlias !== displayName) {
                                 update['publicAlias'] = displayName;
                             }
-                            if (user.email !== email) {
-                                update['email'] = email;
+                            if (user.email !== opts.email) {
+                                update['email'] = opts.email;
                             }
                         } else {
                             // Only update the user's displayname or email when their is value in doing it
@@ -490,9 +495,11 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
         }
 
         // Ensure the provided email, if any, is not used by another user
-        _checkEmailUsage(oldUser, profileFields.email, function(err) {
-            if (err) {
+        _getUserByEmailIfNecessary(profileFields.email, oldUser.email, function(err, user) {
+            if (err && err.code !== 404) {
                 return callback(err);
+            } else if (user && user.id !== oldUser.id) {
+                return callback({'code': 400, 'msg': 'This email address is already associated with another user'});
             }
 
             // TODO: Email verification if the email address was changed
@@ -513,31 +520,23 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
 };
 
 /**
- * Check if an email address is already used by another user. If the email address is being used
- * by another user, an error will be sent back
+ * Get a user by their email address if necessary.
  *
- * @param  {User}       oldUser         The user who wants to change his email address
- * @param  {String}     email           The email address the users wants to use
- * @param  {Function}   callback        Standard callback function
- * @param  {Object}     callback.err    An error that occurred, if any
+ * @param  {String}     [email]             The email address the users wants to use
+ * @param  {String}     [oldEmail]          The user's old email address, if any
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error that occurred, if any
+ * @param  {User}       callback.user       The user associated with the given email address
  * @api private
  */
-var _checkEmailUsage = function(oldUser, email, callback) {
+var _getUserByEmailIfNecessary = function(email, oldEmail, callback) {
     // There's no need to check if the email address is already in use if it hasn't changed
-    if (!email || oldUser.email === email) {
+    if (!email || oldEmail === email) {
         return callback();
     }
 
     // Check if another user is already using this email address
-    PrincipalsDAO.getUserByEmail(email, function(err, user) {
-        if (err && err.code !== 404) {
-            return callback(err);
-        } else if (user && user.id !== oldUser.id) {
-            return callback({'code': 400, 'msg': 'The email address is already used by another user'});
-        }
-
-        return callback();
-    });
+    PrincipalsDAO.getUserByEmail(email, callback);
 };
 
 /**

--- a/node_modules/oae-principals/lib/init.js
+++ b/node_modules/oae-principals/lib/init.js
@@ -81,5 +81,5 @@ var _ensureGlobalAdmin = function(config, callback) {
     var globalContext = new Context(globalTenant, globalAdmin);
 
     // Create the global admin user if they don't exist yet with the username "administrator"
-    return AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', globalAdmin.displayName, globalAdmin.email, globalAdmin, callback);
+    return AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', globalAdmin.displayName, globalAdmin, callback);
 };

--- a/node_modules/oae-principals/lib/init.js
+++ b/node_modules/oae-principals/lib/init.js
@@ -55,7 +55,10 @@ module.exports = function(config, callback) {
  */
 var _ensureSchema = function(callback) {
     // Both user and group information will be stored inside of the Principals CF
-    Cassandra.createColumnFamily('Principals', 'CREATE TABLE "Principals" ("principalId" text PRIMARY KEY, "tenantAlias" text, "displayName" text, "description" text, "email" text, "emailPreference" text, "visibility" text, "joinable" text, "lastModified" text, "locale" text, "publicAlias" text, "largePictureUri" text, "mediumPictureUri" text, "smallPictureUri" text, "admin:global" text, "admin:tenant" text, "notificationsUnread" text, "notificationsLastRead" text, "acceptedTC" text, "createdBy" text, "created" timestamp, "deleted" timestamp)', callback);
+    Cassandra.createColumnFamilies({
+        'Principals': 'CREATE TABLE "Principals" ("principalId" text PRIMARY KEY, "tenantAlias" text, "displayName" text, "description" text, "email" text, "emailPreference" text, "visibility" text, "joinable" text, "lastModified" text, "locale" text, "publicAlias" text, "largePictureUri" text, "mediumPictureUri" text, "smallPictureUri" text, "admin:global" text, "admin:tenant" text, "notificationsUnread" text, "notificationsLastRead" text, "acceptedTC" text, "createdBy" text, "created" timestamp, "deleted" timestamp)',
+        'PrincipalsByEmail': 'CREATE TABLE "PrincipalsByEmail" ("email" text PRIMARY KEY, "principalId" text)'
+    }, callback);
 };
 
 /**
@@ -70,12 +73,13 @@ var _ensureSchema = function(callback) {
 var _ensureGlobalAdmin = function(config, callback) {
     // Mock a global admin request context so we can create a proper global administrator in the system
     var globalTenant = TenantsAPI.getTenant(config.servers.globalAdminAlias);
-    var globalUser = new User(globalTenant.alias, 'u:' + globalTenant.alias + ':admin', 'Global Administrator', {
+    var globalAdminId = 'u:' + globalTenant.alias + ':admin';
+    var globalAdmin = new User(globalTenant.alias, globalAdminId, 'Global Administrator', 'admin@example.com', {
         'visibility': AuthzConstants.visibility.PRIVATE,
         'isGlobalAdmin': true
     });
-    var globalContext = new Context(globalTenant, globalUser);
+    var globalContext = new Context(globalTenant, globalAdmin);
 
     // Create the global admin user if they don't exist yet with the username "administrator"
-    AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', null, callback);
+    return AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', globalAdmin.displayName, globalAdmin.email, globalAdmin, callback);
 };

--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -34,6 +34,38 @@ var User = require('oae-principals/lib/model').User;
 var RESTRICTED_FIELDS = ['acceptedTC', 'admin:tenant', 'admin:global', 'deleted'];
 
 /**
+ * Create a user record in the database
+ *
+ * @param  {User}       user            The user to persist
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ */
+var createUser = module.exports.createUser = function(user, callback) {
+    var queries = [];
+
+    // Persist the user object
+    var values = {
+        'tenantAlias': user.tenant.alias,
+        'displayName': user.displayName,
+        'visibility': user.visibility,
+        'email': user.email,
+        'emailPreference': user.emailPreference,
+        'locale': user.locale,
+        'publicAlias': user.publicAlias,
+        'smallPictureUri': user.picture.smallUri,
+        'mediumPictureUri': user.picture.mediumUri,
+        'largePictureUri': user.picture.largeUri,
+        'acceptedTC': (user.acceptedTC ? user.acceptedTC.toString() : null)
+    };
+    queries.push(Cassandra.constructUpsertCQL('Principals', 'principalId', user.id, values));
+
+    // Map the email address to the user id
+    queries.push(Cassandra.constructUpsertCQL('PrincipalsByEmail', 'email', user.email, {'principalId': user.id}));
+
+    return Cassandra.runBatchQuery(queries, callback);
+};
+
+/**
  * Create a group record in the database
  *
  * @param  {String}     groupId             The ID of the new group
@@ -184,28 +216,71 @@ var updatePrincipal = module.exports.updatePrincipal = function(principalId, pro
         return callback(validator.getFirstError());
     }
 
-    profileFields.lastModified = Date.now().toString();
-
-    var q = Cassandra.constructUpsertCQL('Principals', 'principalId', principalId, profileFields);
-    if (!q) {
-        return callback({'code': 500, 'msg': 'Unable to store profile fields'});
-    }
-
-    Cassandra.runQuery(q.query, q.parameters, function(err) {
+    // If a change is being made to the email address, we need to update the mapping
+    _isEmailAddressUpdate(principalId, profileFields, function(err, isEmailAddressUpdate, oldEmail) {
         if (err) {
             return callback(err);
         }
 
-        if (isUser(principalId)) {
-            // Update the user in cache
+        // Update when this principal was last modified
+        profileFields.lastModified = Date.now().toString();
 
-            // Ensure the `principalId` is not part of the hash to avoid revalidating a stale cache entry
-            profileFields = _.extend({}, profileFields);
-            delete profileFields.principalId;
-            return _updateCachedUser(principalId, profileFields, callback);
-        } else {
-            return callback();
+        var queries = [];
+
+        // Update the principal record
+        queries.push(Cassandra.constructUpsertCQL('Principals', 'principalId', principalId, profileFields));
+
+        // If the user's email address needs to be updated, we remove the old one from the mapping
+        if (isEmailAddressUpdate) {
+            queries.push({'query': 'DELETE FROM "PrincipalsByEmail" WHERE "email" = ?', 'parameters': [oldEmail]});
+            queries.push(Cassandra.constructUpsertCQL('PrincipalsByEmail', 'email', profileFields.email, {'principalId': principalId}));
         }
+
+        // Execute the queries
+        Cassandra.runBatchQuery(queries, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            if (isUser(principalId)) {
+                // Update the user in cache. Ensure the `principalId` is not
+                // part of the hash to avoid revalidating a stale cache entry
+                profileFields = _.extend({}, profileFields);
+                delete profileFields.principalId;
+                return _updateCachedUser(principalId, profileFields, callback);
+            } else {
+                return callback();
+            }
+        });
+    });
+};
+
+/**
+ * Check whether the email address for a user would be updated when updating a set of `profileFields`
+ *
+ * @param  {String}     principalId                         The id of the principal to update
+ * @param  {Object}     profileFields                       An object containing the profile field updates to apply
+ * @param  {Function}   callback                            Standard callback function
+ * @param  {Object}     callback.err                        An error that occurred, if any
+ * @param  {Boolean}    calllback.isEmailAddressUpdate      Whether the email address will be updated
+ * @param  {String}     callback.oldEmail                   The user's old email address
+ * @api private
+ */
+var _isEmailAddressUpdate = function(principalId, profileFields, callback) {
+    if (!isUser(principalId) || !profileFields.email) {
+        return callback(null, false);
+    }
+
+    getPrincipal(principalId, function(err, user) {
+        if (err) {
+            return callback(err);
+        }
+
+        if (user.email !== profileFields.email) {
+            return callback(null, true, user.email);
+        }
+
+        return callback(null, false);
     });
 };
 
@@ -343,6 +418,28 @@ var setAdmin = module.exports.setAdmin = function(adminType, isAdmin, userId, ca
         }
 
         return invalidateCachedUsers([userId], callback);
+    });
+};
+
+/**
+ * Get a user by their email address. If no user could be found for a given email address,
+ * a 404 error will be returned
+ *
+ * @param  {String}     email           The email address that is associated with a user
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ * @param  {User}       callback.user   The user that was associated with the email
+ */
+var getUserByEmail = module.exports.getUserByEmail = function(email, callback) {
+    Cassandra.runQuery('SELECT * FROM "PrincipalsByEmail" WHERE "email" = ?', [email], function(err, rows) {
+        if (err) {
+            return callback(err);
+        } else if (_.isEmpty(rows)) {
+            return callback({'code': 404, 'msg': 'No user found by that email'});
+        }
+
+        var principalId = rows[0].get('principalId').value;
+        return getPrincipal(principalId, callback);
     });
 };
 
@@ -546,10 +643,9 @@ var _getUserFromRow = function(row) {
  * @return {User}               User object representing the created user
  * @api private
  */
-var _hashToUser = function(hash) {
-    var user = new User(hash.tenantAlias, hash.principalId, hash.displayName, {
+var hashToUser = function(hash) {
+    var user = new User(hash.tenantAlias, hash.principalId, hash.displayName, hash.email, {
         'visibility': hash.visibility,
-        'email': hash.email,
         'locale': hash.locale,
         'publicAlias': hash.publicAlias,
         'isGlobalAdmin': sanitize(hash['admin:global']).toBooleanStrict(),

--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -643,7 +643,7 @@ var _getUserFromRow = function(row) {
  * @return {User}               User object representing the created user
  * @api private
  */
-var hashToUser = function(hash) {
+var _hashToUser = function(hash) {
     var user = new User(hash.tenantAlias, hash.principalId, hash.displayName, hash.email, {
         'visibility': hash.visibility,
         'locale': hash.locale,

--- a/node_modules/oae-principals/lib/model.user.js
+++ b/node_modules/oae-principals/lib/model.user.js
@@ -24,9 +24,9 @@ var TenantsAPI = require('oae-tenants');
  * @param  {String}     tenantAlias                     The tenant this user belongs to.
  * @param  {String}     id                              The globally unique userId for this user. e.g.: u:cam:johndoe
  * @param  {String}     displayName                     The display name of the user
+ * @param  {String}     email                           The email address of the user
  * @param  {Object}     [opts]                          Optional additional user properties
  * @param  {String}     [opts.visibility]               The visibility of this user account. e.g.: loggedin
- * @param  {String}     [opts.email]                    The email of the user
  * @param  {String}     [opts.locale]                   The user's locale
  * @param  {String}     [opts.publicAlias]              The name of the user which is displayed to a user who does not have access to view the user
  * @param  {String}     [opts.smallPictureUri]          The uri of the small picture. It will be made available at user.picture.smallUri
@@ -40,7 +40,7 @@ var TenantsAPI = require('oae-tenants');
  * @param  {Boolean}    [opts.isGlobalAdmin]            Whether or not the user is a global admin
  * @param  {Boolean}    [opts.isTenantAdmin]            Whether or not the user is a tenant admin
  */
-module.exports.User = function(tenantAlias, id, displayName, opts) {
+module.exports.User = function(tenantAlias, id, displayName, email, opts) {
     opts = opts || {};
 
     // Explicit checks on true for admin.
@@ -54,8 +54,8 @@ module.exports.User = function(tenantAlias, id, displayName, opts) {
     that.tenant = tenant.compact();
     that.id = id;
     that.displayName = displayName;
+    that.email = email;
     that.visibility = opts.visibility;
-    that.email = opts.email;
     that.locale = opts.locale;
     that.publicAlias = opts.publicAlias;
     that.picture = {};

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -277,7 +277,7 @@ OAE.tenantRouter.on('post', '/api/user/create', function(req, res) {
      * Create a local user account
      */
     var createUser = function() {
-        AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, req.body.username, { password: req.body.password }, req.body.displayName, opts, function(err, newUser, loginId, created) {
+        AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, req.body.username, {'password': req.body.password}, req.body.displayName, opts, function(err, newUser, loginId, created) {
             if (err) {
                 return res.send(err.code, err.msg);
             } else if (!created) {

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -83,7 +83,7 @@ OAE.tenantRouter.on('post', '/api/user/:userId/termsAndConditions', function(req
  * @FormParam   {string}        displayName             The display name for the global administrator
  * @FormParam   {string}        password                The password for the global administrator
  * @FormParam   {string}        username                The unique username for the global administrator
- * @FormParam   {string}        [email]                 The email address for the global administrator
+ * @FormParam   {string}        email                   The email address for the global administrator
  * @FormParam   {string}        [emailPreference]       The email preference for the global administrator   [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the global administrator
  * @FormParam   {string}        [publicAlias]           The name to show when the global administrator is inaccessible to a user
@@ -101,7 +101,7 @@ OAE.globalAdminRouter.on('post', '/api/user/createGlobalAdminUser', function(req
     var opts = _getOptionalProfileParameters(req.body);
 
     // Create the user as global admin
-    AuthenticationAPI.getOrCreateGlobalAdminUser(req.ctx, req.body.username, req.body.password, req.body.displayName, opts, function(err, user, loginId, created) {
+    AuthenticationAPI.getOrCreateGlobalAdminUser(req.ctx, req.body.username, req.body.password, req.body.displayName, req.body.email, opts, function(err, user, loginId, created) {
         if (err) {
             return res.send(err.code, err.msg);
         } else if (!created) {
@@ -124,8 +124,8 @@ OAE.globalAdminRouter.on('post', '/api/user/createGlobalAdminUser', function(req
  * @FormParam   {string}        displayName             The display name for the tenant administrator
  * @FormParam   {string}        password                The password for the tenant administrator
  * @FormParam   {string}        username                The unique username for the tenant administrator
+ * @FormParam   {string}        email                   The email address for the tenant administrator
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the tenant administrator has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the tenant administrator
  * @FormParam   {string}        [emailPreference]       The email preference for the tenant administrator   [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the tenant administrator
  * @FormParam   {string}        [publicAlias]           The name to show when the tenant administrator is inaccessible to a user
@@ -151,8 +151,8 @@ OAE.globalAdminRouter.on('post', '/api/user/createGlobalAdminUser', function(req
  * @FormParam   {string}        displayName             The display name for the tenant administrator
  * @FormParam   {string}        password                The password for the tenant administrator
  * @FormParam   {string}        username                The unique username for the tenant administrator
+ * @FormParam   {string}        email                   The email address for the global administrator
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the tenant administrator has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the global administrator
  * @FormParam   {string}        [emailPreference]       The email preference for the tenant administrator   [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the tenant administrator
  * @FormParam   {string}        [publicAlias]           The name to show when the tenant administrator is inaccessible to a user
@@ -171,8 +171,8 @@ var _handleCreateTenantAdminUser = function(req, res) {
     var loginId = new LoginId(tenantAlias, AuthenticationConstants.providers.LOCAL, req.body.username, {'password': req.body.password});
     var opts = _getOptionalProfileParameters(req.body);
 
-    // Create the user as a tenant admin
-    AuthenticationAPI.createTenantAdminUser(ctx, loginId, req.body.displayName, opts, function(err, user) {
+    // Create the user as a tenant administrator
+    AuthenticationAPI.createTenantAdminUser(ctx, loginId, req.body.displayName, req.body.email, opts, function(err, user) {
         if (err) {
             return res.send(err.code, err.msg);
         }
@@ -197,8 +197,8 @@ OAE.tenantRouter.on('post', '/api/user/createTenantAdminUser', _handleCreateTena
  * @FormParam   {string}        displayName             The display name for the user
  * @FormParam   {string}        password                The password for the user
  * @FormParam   {string}        username                The unique username for the user
+ * @FormParam   {string}        email                   The email address for the user
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the user has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the user
  * @FormParam   {string}        [emailPreference]       The email preference for the user       [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the user
  * @FormParam   {string}        [publicAlias]           The name to show when the user is inaccessible to a user
@@ -225,7 +225,7 @@ OAE.globalAdminRouter.on('post', '/api/user/:tenantAlias/create', function(req, 
         'acceptedTC': (req.body.acceptedTC === 'true')
     };
 
-    AuthenticationAPI.createUser(req.ctx, loginId, req.body.displayName, opts, function(err, newUser) {
+    AuthenticationAPI.createUser(req.ctx, loginId, req.body.displayName, req.body.email, opts, function(err, newUser) {
         if (err) {
             return res.send(err.code, err.msg);
         }
@@ -245,8 +245,8 @@ OAE.globalAdminRouter.on('post', '/api/user/:tenantAlias/create', function(req, 
  * @FormParam   {string}        displayName             The display name for the user
  * @FormParam   {string}        password                The password for the user
  * @FormParam   {string}        username                The unique username for the user
+ * @FormParam   {string}        email                   The email address for the user
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the user has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the user
  * @FormParam   {string}        [emailPreference]       The email preference for the user       [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the user
  * @FormParam   {string}        [publicAlias]           The name to show when the user is inaccessible to a user
@@ -272,10 +272,11 @@ OAE.tenantRouter.on('post', '/api/user/create', function(req, res) {
      * Create a local user account
      */
     var createUser = function() {
-        var loginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, req.body.username, { password: req.body.password });
-        AuthenticationAPI.createUser(ctx, loginId, req.body.displayName, opts, function(err, newUser) {
+        AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, req.body.username, { password: req.body.password }, req.body.displayName, req.body.email, opts, function(err, newUser, loginId, created) {
             if (err) {
                 return res.send(err.code, err.msg);
+            } else if (!created) {
+                return res.send(400, 'A user with that username already exists');
             }
 
             return res.send(201, newUser);
@@ -569,7 +570,6 @@ OAE.tenantRouter.on('post', '/api/user/:userId/picture', function(req, res) {
 var _getOptionalProfileParameters = function(parameters) {
     return {
         'visibility': parameters.visibility,
-        'email': parameters.email,
         'emailPreference': parameters.emailPreference,
         'locale': parameters.locale,
         'publicAlias': parameters.publicAlias,

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -101,7 +101,7 @@ OAE.globalAdminRouter.on('post', '/api/user/createGlobalAdminUser', function(req
     var opts = _getOptionalProfileParameters(req.body);
 
     // Create the user as global admin
-    AuthenticationAPI.getOrCreateGlobalAdminUser(req.ctx, req.body.username, req.body.password, req.body.displayName, req.body.email, opts, function(err, user, loginId, created) {
+    AuthenticationAPI.getOrCreateGlobalAdminUser(req.ctx, req.body.username, req.body.password, req.body.displayName, opts, function(err, user, loginId, created) {
         if (err) {
             return res.send(err.code, err.msg);
         } else if (!created) {
@@ -172,7 +172,7 @@ var _handleCreateTenantAdminUser = function(req, res) {
     var opts = _getOptionalProfileParameters(req.body);
 
     // Create the user as a tenant administrator
-    AuthenticationAPI.createTenantAdminUser(ctx, loginId, req.body.displayName, req.body.email, opts, function(err, user) {
+    AuthenticationAPI.createTenantAdminUser(ctx, loginId, req.body.displayName, opts, function(err, user) {
         if (err) {
             return res.send(err.code, err.msg);
         }
@@ -225,7 +225,7 @@ OAE.globalAdminRouter.on('post', '/api/user/:tenantAlias/create', function(req, 
         'acceptedTC': (req.body.acceptedTC === 'true')
     };
 
-    AuthenticationAPI.createUser(req.ctx, loginId, req.body.displayName, req.body.email, opts, function(err, newUser) {
+    AuthenticationAPI.createUser(req.ctx, loginId, req.body.displayName, opts, function(err, newUser) {
         if (err) {
             return res.send(err.code, err.msg);
         }
@@ -268,11 +268,16 @@ OAE.tenantRouter.on('post', '/api/user/create', function(req, res) {
     var user = ctx.user();
     var opts = _getOptionalProfileParameters(req.body);
 
+    // We enforce an email address, the API will take care of validating the actual value
+    if (!opts.email) {
+        return res.status(400).send('A valid email address is required when creating a local account');
+    }
+
     /*!
      * Create a local user account
      */
     var createUser = function() {
-        AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, req.body.username, { password: req.body.password }, req.body.displayName, req.body.email, opts, function(err, newUser, loginId, created) {
+        AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, req.body.username, { password: req.body.password }, req.body.displayName, opts, function(err, newUser, loginId, created) {
             if (err) {
                 return res.send(err.code, err.msg);
             } else if (!created) {
@@ -570,6 +575,7 @@ OAE.tenantRouter.on('post', '/api/user/:userId/picture', function(req, res) {
 var _getOptionalProfileParameters = function(parameters) {
     return {
         'visibility': parameters.visibility,
+        'email': parameters.email,
         'emailPreference': parameters.emailPreference,
         'locale': parameters.locale,
         'publicAlias': parameters.publicAlias,

--- a/node_modules/oae-principals/lib/search.js
+++ b/node_modules/oae-principals/lib/search.js
@@ -292,7 +292,7 @@ var _transformUserDocuments = function(ctx, docs, callback) {
         // First we need to convert the data in this document back into the source user object so that we may use PrincipalsUtil.hideUserData
         // to hide its information. We will then after convert the user *back* to a search document once the user information has been
         // scrubbed
-        var user = new User(tenantAlias, docId, displayName, {
+        var user = new User(tenantAlias, docId, displayName, null, {
             'visibility': visibility,
             'publicAlias': extra.publicAlias,
             'mediumPictureUri': thumbnailUrl

--- a/node_modules/oae-principals/lib/test/util.js
+++ b/node_modules/oae-principals/lib/test/util.js
@@ -1002,3 +1002,48 @@ var getAllGroupMembers = module.exports.getAllGroupMembers = function(restCtx, g
         return getAllGroupMembers(restCtx, groupId, opts, callback, _nextToken, _members, _responses);
     });
 };
+
+/**
+ * Attempt to update a user's profile, ensuring it succeeds. It will also verify the changes were
+ * persisted correctly by retrieving the user's profile
+ *
+ * @param  {RestContext}    restCtx             The REST context of a user who can perform the update
+ * @param  {String}         userId              The id of the user to update
+ * @param  {Object}         update              Object representing the profile fields that need to be updated. The keys are the profile fields, the values are the profile field values
+ * @param  {Function}       callback            Invoked when the user has been updated
+ * @param  {User}           callback.user       The updated user profile
+ * @throws {AssertionError}                     Thrown if the update is unsuccessful or the expected results of updating a user don't hold true
+ */
+var assertUpdateUserSucceeds = module.exports.assertUpdateUserSucceeds = function(restCtx, userId, update, callback) {
+    RestAPI.User.updateUser(restCtx, userId, update, function(err) {
+        assert.ok(!err);
+
+        // Assert the changes were persisted correctly
+        RestAPI.User.getUser(restCtx, userId, function(err, user) {
+            assert.ok(!err);
+            _.each(update, function(value, key) {
+                assert.strictEqual(user[key], value);
+            });
+
+            return callback(user);
+        });
+    });
+};
+
+/**
+ * Attempt to update a user's profile, ensuring that the operation fails with the given HTTP code
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who can perform the update
+ * @param  {String}         userId          The id of the user to update
+ * @param  {Object}         update          Object representing the profile fields that need to be updated. The keys are the profile fields, the values are the profile field values
+ * @param  {Number}         httpCode        The expected HTTP code of the failed update operation
+ * @param  {Function}       callback        Invoked when the update user operation fails as expected
+ * @throws {AssertionError}                 Thrown if the update operation does not fail as expected
+ */
+var assertUpdateUserFails = module.exports.assertUpdateUserFails = function(restCtx, userId, update, httpCode, callback) {
+    RestAPI.User.updateUser(restCtx, userId, update, function(err) {
+        assert.ok(err);
+        assert.strictEqual(err.code, httpCode);
+        return callback();
+    });
+};

--- a/node_modules/oae-principals/lib/util.js
+++ b/node_modules/oae-principals/lib/util.js
@@ -170,9 +170,9 @@ var hideUserData = module.exports.hideUserData = function(ctx, user) {
  */
 var createUpdatedUser = module.exports.createUpdatedUser = function(user, fieldUpdates) {
     var newDisplayName = fieldUpdates.displayName || user.displayName;
-    var newUser = new User(user.tenant.alias, user.id, newDisplayName, {
+    var newEmail = fieldUpdates.email || user.email;
+    var newUser = new User(user.tenant.alias, user.id, newDisplayName, newEmail, {
         'visibility': fieldUpdates.visibility || user.visibility,
-        'email': fieldUpdates.email || user.email,
         'emailPreference': fieldUpdates.emailPreference || user.emailPreference,
         'locale': fieldUpdates.locale || user.locale,
         'publicAlias': fieldUpdates.publicAlias || user.publicAlias,

--- a/node_modules/oae-principals/tests/data/users-with-password-alias.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password-alias.csv
@@ -1,0 +1,25 @@
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@alias.test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@alias.test.com
+user-mIAUwkeNS,password3,Visser,Branden,branden@alias.test.com
+user-HlKKreaDP,password4,Gaeremynck,,simon@alias.test.com
+user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@alias.test.com
+user-JjuyZssJQ,password6,Reynolds,Malcom,mal@alias.test.com
+user-HgRNdDzQd,password7,Washburn,Zoe,zoe@alias.test.com
+user-DGdlFUNzv,password8,Washburn,Hoban,wash@alias.test.com
+user-gPvjYjVHh,password9,Serra,Inara,inara@alias.test.com
+user-TUolZGzsm,password10,Cobb,Jayne,jayne@alias.test.com
+user-CIwpSRwXk,password11,Frye,Kaylee,kaylee@alias.test.com
+user-SUMbWTWKD,password13,Tam,River,river@alias.test.com
+user-PZCWYjPkm,password14,Book,Derrial,book@alias.test.com
+user-crqhYVPaO,password15,Grant,Alan,alan@alias.test.com
+user-sXzLFyWDK,password16,Malcom,Ian,ian@alias.test.com
+user-czkFzYYOD,password17,Sattler,Ellie,ellie@alias.test.com
+user-Tibmrtgvc,password18,Guitierrez,Martin,marty@alias.test.com
+user-jUDvjjySh,password19,Muldoon,Robert,robert@alias.test.com
+user-daHPDePdl,password20,Hammond,John,john@alias.test.com
+user-RwONmsFaM,password21,Nedry,Dennis,nedry@alias.test.com
+user-TEnUBtlRL,password22,Gennaro,Donald,don@alias.test.com
+user-lJJTHWYTX,password23,Arnold,John,ray@alias.test.com
+user-KhfBKaGwy,password24,Wu,Henry,henry@alias.test.com
+user-XUclyraoP,password25,Murphy,Lex,lex@alias.test.com
+user-bbLwAWxpd,password26,Thomas,Stephen,stephen@alias.test.com

--- a/node_modules/oae-principals/tests/data/users-with-password-displayname.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password-displayname.csv
@@ -1,0 +1,25 @@
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@displayname.test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@displayname.test.com
+user-mIAUwkeNS,password3,Visser,Branden,branden@displayname.test.com
+user-HlKKreaDP,password4,Gaeremynck,,simon@displayname.test.com
+user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@displayname.test.com
+user-JjuyZssJQ,password6,Reynolds,Malcom,mal@displayname.test.com
+user-HgRNdDzQd,password7,Washburn,Zoe,zoe@displayname.test.com
+user-DGdlFUNzv,password8,Washburn,Hoban,wash@displayname.test.com
+user-gPvjYjVHh,password9,Serra,Inara,inara@displayname.test.com
+user-TUolZGzsm,password10,Cobb,Jayne,jayne@displayname.test.com
+user-CIwpSRwXk,password11,Frye,Kaylee,kaylee@displayname.test.com
+user-SUMbWTWKD,password13,Tam,River,river@displayname.test.com
+user-PZCWYjPkm,password14,Book,Derrial,book@displayname.test.com
+user-crqhYVPaO,password15,Grant,Alan,alan@displayname.test.com
+user-sXzLFyWDK,password16,Malcom,Ian,ian@displayname.test.com
+user-czkFzYYOD,password17,Sattler,Ellie,ellie@displayname.test.com
+user-Tibmrtgvc,password18,Guitierrez,Martin,marty@displayname.test.com
+user-jUDvjjySh,password19,Muldoon,Robert,robert@displayname.test.com
+user-daHPDePdl,password20,Hammond,John,john@displayname.test.com
+user-RwONmsFaM,password21,Nedry,Dennis,nedry@displayname.test.com
+user-TEnUBtlRL,password22,Gennaro,Donald,don@displayname.test.com
+user-lJJTHWYTX,password23,Arnold,John,ray@displayname.test.com
+user-KhfBKaGwy,password24,Wu,Henry,henry@displayname.test.com
+user-XUclyraoP,password25,Murphy,Lex,lex@displayname.test.com
+user-bbLwAWxpd,password26,Thomas,Stephen,stephen@displayname.test.com

--- a/node_modules/oae-principals/tests/data/users-with-password-email.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password-email.csv
@@ -1,0 +1,25 @@
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@email.test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@email.test.com
+user-mIAUwkeNS,password3,Visser,Branden,branden@email.test.com
+user-HlKKreaDP,password4,Gaeremynck,,simon@email.test.com
+user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@email.test.com
+user-JjuyZssJQ,password6,Reynolds,Malcom,mal@email.test.com
+user-HgRNdDzQd,password7,Washburn,Zoe,zoe@email.test.com
+user-DGdlFUNzv,password8,Washburn,Hoban,wash@email.test.com
+user-gPvjYjVHh,password9,Serra,Inara,inara@email.test.com
+user-TUolZGzsm,password10,Cobb,Jayne,jayne@email.test.com
+user-CIwpSRwXk,password11,Frye,Kaylee,kaylee@email.test.com
+user-SUMbWTWKD,password13,Tam,River,river@email.test.com
+user-PZCWYjPkm,password14,Book,Derrial,book@email.test.com
+user-crqhYVPaO,password15,Grant,Alan,alan@email.test.com
+user-sXzLFyWDK,password16,Malcom,Ian,ian@email.test.com
+user-czkFzYYOD,password17,Sattler,Ellie,ellie@email.test.com
+user-Tibmrtgvc,password18,Guitierrez,Martin,marty@email.test.com
+user-jUDvjjySh,password19,Muldoon,Robert,robert@email.test.com
+user-daHPDePdl,password20,Hammond,John,john@email.test.com
+user-RwONmsFaM,password21,Nedry,Dennis,nedry@email.test.com
+user-TEnUBtlRL,password22,Gennaro,Donald,don@email.test.com
+user-lJJTHWYTX,password23,Arnold,John,ray@email.test.com
+user-KhfBKaGwy,password24,Wu,Henry,henry@email.test.com
+user-XUclyraoP,password25,Murphy,Lex,lex@email.test.com
+user-bbLwAWxpd,password26,Thomas,Stephen,stephen@email.test.com

--- a/node_modules/oae-principals/tests/data/users-with-password.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password.csv
@@ -1,5 +1,5 @@
-user-zfdHliPLa, password1, Matthijs, Nicolaas, nicolaas@test.com
-user-plOPperDe, password2, Pareyn, Bert, bert@test.com
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@test.com
 user-mIAUwkeNS,password3,Visser,Branden,branden@test.com
 user-HlKKreaDP,password4,Gaeremynck,,simon@test.com
 user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@test.com

--- a/node_modules/oae-principals/tests/test-activity.js
+++ b/node_modules/oae-principals/tests/test-activity.js
@@ -46,7 +46,7 @@ describe('Principals Activity', function() {
         anonymousGtRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host);
         // Fill up global admin rest context
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
-        callback();
+        return callback();
     });
 
     /**
@@ -95,66 +95,58 @@ describe('Principals Activity', function() {
     describe('Routes', function() {
 
         it('verify cyclic group memberships terminate while routing an activity', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var jackUsername = TestsUtil.generateTestUserId('jack');
             var group1Alias = TestsUtil.generateTestUserId('group1');
             var group2Alias = TestsUtil.generateTestUserId('group2');
             var group3Alias = TestsUtil.generateTestUserId('group3');
             var group4Alias = TestsUtil.generateTestUserId('group4');
 
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
                 assert.ok(!err);
-                var doerCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                // Create the 4 groups that will form a cycle
+                RestAPI.Group.createGroup(doer.restContext, group1Alias, group1Alias, 'public', 'no', [], [], function(err, group1) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    // Create the 4 groups that will form a cycle
-                    RestAPI.Group.createGroup(doerCtx, group1Alias, group1Alias, 'public', 'no', [], [], function(err, group1) {
+                    RestAPI.Group.createGroup(doer.restContext, group2Alias, group2Alias, 'public', 'no', [group1.id], [], function(err, group2) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(doerCtx, group2Alias, group2Alias, 'public', 'no', [group1.id], [], function(err, group2) {
+                        // Group 3 will be joinable, so Jack can join it to trigger an activity
+                        RestAPI.Group.createGroup(doer.restContext, group3Alias, group3Alias, 'public', 'yes', [group2.id], [], function(err, group3) {
                             assert.ok(!err);
 
-                            // Group 3 will be joinable, so Jack can join it to trigger an activity
-                            RestAPI.Group.createGroup(doerCtx, group3Alias, group3Alias, 'public', 'yes', [group2.id], [], function(err, group3) {
+                            RestAPI.Group.createGroup(doer.restContext, group4Alias, group4Alias, 'public', 'no', [group3.id], [], function(err, group4) {
                                 assert.ok(!err);
 
-                                RestAPI.Group.createGroup(doerCtx, group4Alias, group4Alias, 'public', 'no', [group3.id], [], function(err, group4) {
+                                // Add group4 as manager to group1 to complete the cycle
+                                var cycleChange = {};
+                                cycleChange[group4.id] = 'manager';
+                                RestAPI.Group.setGroupMembers(doer.restContext, group1.id, cycleChange, function(err) {
                                     assert.ok(!err);
 
-                                    // Add group4 as manager to group1 to complete the cycle
-                                    var cycleChange = {};
-                                    cycleChange[group4.id] = 'manager';
-                                    RestAPI.Group.setGroupMembers(doerCtx, group1.id, cycleChange, function(err) {
+                                    RestAPI.Group.joinGroup(jack.restContext, group3.id, function(err) {
                                         assert.ok(!err);
 
-                                        RestAPI.Group.joinGroup(jackCtx, group3.id, function(err) {
+                                        // Verify that each group now has this as its most recent activity
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group1.id, null, function(err, activityStream) {
                                             assert.ok(!err);
+                                            assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
+                                            assert.equal(activityStream.items[0].object['oae:id'], group3.id);
 
-                                            // Verify that each group now has this as its most recent activity
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group1.id, null, function(err, activityStream) {
+                                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group2.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
                                                 assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
                                                 assert.equal(activityStream.items[0].object['oae:id'], group3.id);
 
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group2.id, null, function(err, activityStream) {
+                                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group3.id, null, function(err, activityStream) {
                                                     assert.ok(!err);
                                                     assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
                                                     assert.equal(activityStream.items[0].object['oae:id'], group3.id);
 
-                                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group3.id, null, function(err, activityStream) {
+                                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group4.id, null, function(err, activityStream) {
                                                         assert.ok(!err);
                                                         assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
                                                         assert.equal(activityStream.items[0].object['oae:id'], group3.id);
-
-                                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group4.id, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
-                                                            assert.equal(activityStream.items[0].object['oae:id'], group3.id);
-                                                            return callback();
-                                                        });
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -173,67 +165,52 @@ describe('Principals Activity', function() {
          * only be routed to managers, as well as a regular update operation which should get routed to all members.
          */
         it('verify group activities are routed to group member descendants', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var managerGroupMemberUsername = TestsUtil.generateTestUserId('managerGroupMember');
-
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, managerGroupMember) {
                 assert.ok(!err);
-                var doerCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                // Create the member group, which will be member to the group that gets updated and has a user added. This group should not receive the "user added" activity
+                RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('memberGroup'), TestsUtil.generateTestUserId('memberGroup'), 'public', 'no', [], [], function(err, memberGroup) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, managerGroupMemberUsername, 'password', 'Jane', null, function(err, managerGroupMember) {
+                    // Create the manager group, which should receive both update and "user added" activities
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('managerGroup'), TestsUtil.generateTestUserId('managerGroup'), 'public', 'no', [], [], function(err, managerGroup) {
                         assert.ok(!err);
-                        var managerGroupMemberCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, managerGroupMemberUsername, 'password');
 
-                        // Create the member group, which will be member to the group that gets updated and has a user added. This group should not receive the "user added" activity
-                        RestAPI.Group.createGroup(doerCtx, TestsUtil.generateTestUserId('memberGroup'), TestsUtil.generateTestUserId('memberGroup'), 'public', 'no', [], [], function(err, memberGroup) {
+                        // ManagerGroupMember should be a member of the manager group to verify indirect group member routing
+                        var membership = {};
+                        membership[managerGroupMember.user.id] = 'manager';
+                        RestAPI.Group.setGroupMembers(doer.restContext, managerGroup.id, membership, function(err) {
                             assert.ok(!err);
 
-                            // Create the manager group, which should receive both update and "user added" activities
-                            RestAPI.Group.createGroup(doerCtx, TestsUtil.generateTestUserId('managerGroup'), TestsUtil.generateTestUserId('managerGroup'), 'public', 'no', [], [], function(err, managerGroup) {
+                            // Create the target group, manager group and member group are members
+                            RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('targetGroup'), TestsUtil.generateTestUserId('targetGroup'), 'public', 'yes', [managerGroup.id], [memberGroup.id], function(err, targetGroup) {
                                 assert.ok(!err);
 
-                                // ManagerGroupMember should be a member of the manager group to verify indirect group member routing
-                                var membership = {};
-                                membership[managerGroupMember.id] = 'manager';
-                                RestAPI.Group.setGroupMembers(doerCtx, managerGroup.id, membership, function(err) {
+                                RestAPI.Group.joinGroup(jack.restContext, targetGroup.id, function(err) {
                                     assert.ok(!err);
 
-                                    // Create the target group, manager group and member group are members
-                                    RestAPI.Group.createGroup(doerCtx, TestsUtil.generateTestUserId('targetGroup'), TestsUtil.generateTestUserId('targetGroup'), 'public', 'yes', [managerGroup.id], [memberGroup.id], function(err, targetGroup) {
+                                    // Update the group to propagate an activity
+                                    RestAPI.Group.updateGroup(doer.restContext, targetGroup.id, {'displayName': 'Ha ha I make change'}, function(err) {
                                         assert.ok(!err);
 
-                                        RestAPI.Group.joinGroup(jackCtx, targetGroup.id, function(err) {
+                                        // Ensure manager group received both update and join activities
+                                        ActivityTestsUtil.collectAndGetActivityStream(doer.restContext, managerGroup.id, null, function(err, activityStream) {
                                             assert.ok(!err);
+                                            assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
+                                            assert.ok(_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
 
-                                            // Update the group to propagate an activity
-                                            RestAPI.Group.updateGroup(doerCtx, targetGroup.id, {'displayName': 'Ha ha I make change'}, function(err) {
+                                            // Ensure the member group received update, but not join
+                                            ActivityTestsUtil.collectAndGetActivityStream(doer.restContext, memberGroup.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
+                                                assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
+                                                assert.ok(!_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
 
-                                                // Ensure manager group received both update and join activities
-                                                ActivityTestsUtil.collectAndGetActivityStream(doerCtx, managerGroup.id, null, function(err, activityStream) {
+                                                // Ensure member of the manager group got both update and join
+                                                ActivityTestsUtil.collectAndGetActivityStream(managerGroupMember.restContext, managerGroupMember.user.id, null, function(err, activityStream) {
                                                     assert.ok(!err);
                                                     assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
                                                     assert.ok(_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
-
-                                                    // Ensure the member group received update, but not join
-                                                    ActivityTestsUtil.collectAndGetActivityStream(doerCtx, memberGroup.id, null, function(err, activityStream) {
-                                                        assert.ok(!err);
-                                                        assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
-                                                        assert.ok(!_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
-
-                                                        // Ensure member of the manager group got both update and join
-                                                        ActivityTestsUtil.collectAndGetActivityStream(managerGroupMemberCtx, managerGroupMember.id, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
-                                                            assert.ok(_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
-                                                            callback();
-                                                        });
-                                                    });
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -272,32 +249,25 @@ describe('Principals Activity', function() {
          * Test that verifies the contents of the full group and user activity entity models.
          */
         it('verify the user and group activity entity model', function(callback) {
-            var publicUsername = TestsUtil.generateTestUserId('userPublic');
-            var privateUsername = TestsUtil.generateTestUserId('userPrivate');
-
-            // Create a public user so we can verify all the information is returned
-            RestAPI.User.createUser(camAdminRestContext, publicUsername, 'password', 'Jack McJackerson', {'visibility': 'public'}, function(err, publicUser) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, publicUser, privateUser) {
                 assert.ok(!err);
-                var publicUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, publicUsername, 'password');
 
-                var sizes = {
-                    'x': 0,
-                    'y': 0,
-                    'width': 35,
-                    'height': 35
-                };
-
-                // Give the users a profile picture so we can verify it is on the entity model
-                RestAPI.User.uploadPicture(publicUserRestContext, publicUser.id, _getPictureStream, sizes, function(err) {
+                RestAPI.User.updateUser(privateUser.restContext, privateUser.user.id, {'visibility': 'private'}, function(err) {
                     assert.ok(!err);
 
-                    // Create private user so we can verify information is properly hidden where appropriate
-                    RestAPI.User.createUser(camAdminRestContext, privateUsername, 'password', 'Jane Janerville', {'visibility': 'private', 'publicAlias': 'Jane'}, function(err, privateUser) {
+                    var sizes = {
+                        'x': 0,
+                        'y': 0,
+                        'width': 35,
+                        'height': 35
+                    };
+
+                    // Give the users a profile picture so we can verify it is on the entity model
+                    RestAPI.User.uploadPicture(publicUser.restContext, publicUser.user.id, _getPictureStream, sizes, function(err) {
                         assert.ok(!err);
-                        var privateUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, privateUsername, 'password');
 
                         // Add a profile picture to the private user so we can verify it gets hidden
-                        RestAPI.User.uploadPicture(privateUserRestContext, privateUser.id, _getPictureStream, sizes, function(err) {
+                        RestAPI.User.uploadPicture(privateUser.restContext, privateUser.user.id, _getPictureStream, sizes, function(err) {
                             assert.ok(!err);
 
                             // Create a group
@@ -310,13 +280,13 @@ describe('Principals Activity', function() {
 
                                     // Add both the public and private users to the group. They should receive eachother's user entities in the feeds
                                     var permissionChanges = {};
-                                    permissionChanges[publicUser.id] = 'manager';
-                                    permissionChanges[privateUser.id] = 'manager';
+                                    permissionChanges[publicUser.user.id] = 'manager';
+                                    permissionChanges[privateUser.user.id] = 'manager';
                                     RestAPI.Group.setGroupMembers(camAdminRestContext, group.id, permissionChanges, function(err) {
                                         assert.ok(!err);
 
                                         // Verify the publicUser and group model in the public user group-add-member activity
-                                        ActivityTestsUtil.collectAndGetActivityStream(publicUserRestContext, publicUser.id, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(publicUser.restContext, publicUser.user.id, null, function(err, activityStream) {
                                             assert.ok(!err);
 
                                             // Pluck the group-add-member activity from the user's feed
@@ -337,28 +307,28 @@ describe('Principals Activity', function() {
                                             var privateUserActivityEnity = null;
                                             _.each(object['oae:collection'], function(user) {
                                                 var resourceId = AuthzUtil.getResourceFromId(user['oae:id']).resourceId;
-                                                if (user['oae:id'] === publicUser.id) {
+                                                if (user['oae:id'] === publicUser.user.id) {
                                                     publicUserActivityEntity = user;
 
                                                     // Verify the public user model
-                                                    assert.ok(user['id'].indexOf(publicUser.id) !== -1);
-                                                    assert.equal(user['displayName'], publicUser.displayName);
+                                                    assert.ok(user['id'].indexOf(publicUser.user.id) !== -1);
+                                                    assert.equal(user['displayName'], publicUser.user.displayName);
                                                     assert.equal(user['objectType'], 'user');
-                                                    assert.equal(user['oae:id'], publicUser.id);
-                                                    assert.equal(user['oae:profilePath'], publicUser.profilePath);
-                                                    assert.equal(user['oae:visibility'], publicUser.visibility);
+                                                    assert.equal(user['oae:id'], publicUser.user.id);
+                                                    assert.equal(user['oae:profilePath'], publicUser.user.profilePath);
+                                                    assert.equal(user['oae:visibility'], 'public');
                                                     assert.equal(user['url'], 'http://' + global.oaeTests.tenants.cam.host + '/user/camtest/' + resourceId);
                                                     assert.ok(user['image']);
-                                                } else if (user['oae:id'] === privateUser.id) {
+                                                } else if (user['oae:id'] === privateUser.user.id) {
                                                     privateUserActivityEnity = user;
 
                                                     // Verify the private user model
-                                                    assert.ok(user['id'].indexOf(privateUser.id) !== -1);
-                                                    assert.equal(user['displayName'], privateUser.publicAlias);
+                                                    assert.ok(user['id'].indexOf(privateUser.user.id) !== -1);
+                                                    assert.equal(user['displayName'], privateUser.user.publicAlias);
                                                     assert.equal(user['objectType'], 'user');
-                                                    assert.equal(user['oae:id'], privateUser.id);
+                                                    assert.equal(user['oae:id'], privateUser.user.id);
                                                     assert.equal(user['oae:profilePath'], undefined);
-                                                    assert.equal(user['oae:visibility'], privateUser.visibility);
+                                                    assert.equal(user['oae:visibility'], 'private');
 
                                                     // Url and image are not defined for unprivileged users in feeds
                                                     assert.ok(!user['url']);
@@ -568,14 +538,10 @@ describe('Principals Activity', function() {
          * Test that verifies the group-create, group-update and group-update-visibility activities gets generated
          */
         it('verify group-create, group-update, group-update-visibility activities are delivered', function(callback) {
-            var username = TestsUtil.generateTestUserId('user');
-
-            // Create a user with which to create a group, then ensure the user gets the activity
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Jack McJackerson', null, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
-                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'no', [user.id], [], function(err, group) {
+                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'no', [jack.user.id], [], function(err, group) {
                     assert.ok(!err);
 
                     RestAPI.Group.updateGroup(camAdminRestContext, group.id, {'visibility': 'loggedin'}, function(err) {
@@ -584,12 +550,12 @@ describe('Principals Activity', function() {
                         RestAPI.Group.updateGroup(camAdminRestContext, group.id, {'displayName': 'har har har'}, function(err) {
                             assert.ok(!err);
 
-                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, user.id, null, function(err, activityStream) {
+                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(_getActivity(activityStream, 'group-create', 'object', group.id));
                                 assert.ok(_getActivity(activityStream, 'group-update', 'object', group.id));
                                 assert.ok(_getActivity(activityStream, 'group-update-visibility', 'object', group.id));
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -601,30 +567,19 @@ describe('Principals Activity', function() {
          * Test that verifies the group-join activity gets fired
          */
         it('verify group-join activity is delivered', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var username = TestsUtil.generateTestUserId('user');
-
-            // Create the user with which to perform setup
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
                 assert.ok(!err);
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-                // Create a user with which to create a group, then ensure the user gets the activity
-                RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Jack McJackerson', null, function(err, user) {
+                RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
-                    var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
-                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
+                    RestAPI.Group.joinGroup(jack.restContext, group.id, function(err) {
                         assert.ok(!err);
 
-                        RestAPI.Group.joinGroup(userRestContext, group.id, function(err) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
-
-                            ActivityTestsUtil.collectAndGetActivityStream(userRestContext, user.id, null, function(err, activityStream) {
-                                assert.ok(!err);
-                                assert.ok(_getActivity(activityStream, 'group-join', 'object', group.id));
-                                callback();
-                            });
+                            assert.ok(_getActivity(activityStream, 'group-join', 'object', group.id));
+                            return callback();
                         });
                     });
                 });
@@ -663,22 +618,18 @@ describe('Principals Activity', function() {
          * Test that verifies the group-add-member activity gets generated
          */
         it('verify group-add-member activity gets generated', function(callback) {
-            var username = TestsUtil.generateTestUserId('user');
-
-            // Create a user with which to create a group, then ensure the user gets the activity
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Jack McJackerson', null, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                 RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
 
                     var memberships = {};
-                    memberships[user.id] = 'member';
+                    memberships[jack.user.id] = 'member';
                     RestAPI.Group.setGroupMembers(camAdminRestContext, group.id, memberships, function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, user.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(_getActivity(activityStream, 'group-add-member', 'target', group.id));
 
@@ -729,47 +680,32 @@ describe('Principals Activity', function() {
          * Test that verifies group-join activities aggregate.
          */
         it('verify group-join activities aggregation', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('branden');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
-                    var janeCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden', null, function(err, branden) {
+                    // Join as jane
+                    RestAPI.Group.joinGroup(jane.restContext, group.id, function(err) {
                         assert.ok(!err);
-                        var brandenCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUsername, 'password');
 
-                        RestAPI.Group.createGroup(jackCtx, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
+                        // Join as branden
+                        RestAPI.Group.joinGroup(branden.restContext, group.id, function(err) {
                             assert.ok(!err);
 
-                            // Join as jane
-                            RestAPI.Group.joinGroup(janeCtx, group.id, function(err) {
+                            // Get jack's own feed
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Join as branden
-                                RestAPI.Group.joinGroup(brandenCtx, group.id, function(err) {
-                                    assert.ok(!err);
+                                // Verify 1 for the group create, plus 1 for the aggregated group-join activities
+                                assert.equal(activityStream.items.length, 2);
 
-                                    // Get jack's own feed
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                        assert.ok(!err);
-
-                                        // Verify 1 for the group create, plus 1 for the aggregated group-join activities
-                                        assert.equal(activityStream.items.length, 2);
-
-                                        // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
-                                        var entity = activityStream.items[0].actor;
-                                        assert.ok(entity['oae:collection']);
-                                        assert.equal(entity['oae:collection'].length, 2);
-                                        callback();
-                                    });
-                                });
+                                // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
+                                var entity = activityStream.items[0].actor;
+                                assert.ok(entity['oae:collection']);
+                                assert.equal(entity['oae:collection'].length, 2);
+                                return callback();
                             });
                         });
                     });
@@ -781,48 +717,35 @@ describe('Principals Activity', function() {
          * Test that verifies group-add-member activities aggregate.
          */
         it('verify group-add-member activities aggregation', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('branden');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden', null, function(err, branden) {
+                    // Join as jane
+                    var membership = {};
+                    membership[jane.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(jack.restContext, group.id, membership, function(err) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(jackCtx, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
+                        // Join as branden
+                        membership = {};
+                        membership[branden.user.id] = 'member';
+                        RestAPI.Group.setGroupMembers(jack.restContext, group.id, membership, function(err) {
                             assert.ok(!err);
 
-                            // Join as jane
-                            var membership = {};
-                            membership[jane.id] = 'member';
-                            RestAPI.Group.setGroupMembers(jackCtx, group.id, membership, function(err) {
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Join as branden
-                                membership = {};
-                                membership[branden.id] = 'member';
-                                RestAPI.Group.setGroupMembers(jackCtx, group.id, membership, function(err) {
-                                    assert.ok(!err);
+                                // Verify 1 for the group create, plus 1 for the aggregated group-add-member activities
+                                assert.equal(activityStream.items.length, 2);
 
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                        assert.ok(!err);
-
-                                        // Verify 1 for the group create, plus 1 for the aggregated group-add-member activities
-                                        assert.equal(activityStream.items.length, 2);
-
-                                        // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
-                                        var entity = activityStream.items[0].object;
-                                        assert.ok(entity['oae:collection']);
-                                        assert.equal(entity['oae:collection'].length, 2);
-                                        callback();
-                                    });
-                                });
+                                // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
+                                var entity = activityStream.items[0].object;
+                                assert.ok(entity['oae:collection']);
+                                assert.equal(entity['oae:collection'].length, 2);
+                                return callback();
                             });
                         });
                     });

--- a/node_modules/oae-principals/tests/test-activity.js
+++ b/node_modules/oae-principals/tests/test-activity.js
@@ -28,6 +28,8 @@ var RestContext = require('oae-rest/lib/model').RestContext;
 var RestUtil = require('oae-rest/lib/util');
 var TestsUtil = require('oae-tests');
 
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
+
 describe('Principals Activity', function() {
 
     // Rest context that can be used every time we need to make a request as an anonymous user
@@ -761,60 +763,46 @@ describe('Principals Activity', function() {
          * that private user information is appropriately scrubbed from the email.
          */
         it('verify group-create email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the group with a user. We will ensure that user receives an email
+                    RestAPI.Group.createGroup(simong.restContext, 'emailGroupCreate', 'emailGroupCreate', 'public', 'yes', [], [mrvisser.user.id], function(err, group) {
                         assert.ok(!err);
 
-                        // Create the group with a user. We will ensure that user receives an email
-                        RestAPI.Group.createGroup(simong.restContext, 'emailGroupCreate', 'emailGroupCreate', 'public', 'yes', [], [mrvisser.user.id], function(err, group) {
-                            assert.ok(!err);
+                        // Mrvisser should get an email, with simong's information scrubbed
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                            // Mrvisser should get an email, with simong's information scrubbed
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            // There should be exactly one message, the one sent to mrvisser
+                            assert.equal(messages.length, 1);
 
-                                // There should be exactly one message, the one sent to mrvisser
-                                assert.equal(messages.length, 1);
+                            var stringMessage = JSON.stringify(messages[0]);
+                            var message = messages[0];
 
-                                var stringMessage = JSON.stringify(messages[0]);
-                                var message = messages[0];
+                            // Sanity check that the message is to mrvisser
+                            assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                // Sanity check that the message is to mrvisser
-                                assert.equal(message.to[0].address, mrvisser.user.email);
+                            // Ensure some data expected to be in the email is there
+                            assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
+                            assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
+                            assert.notEqual(stringMessage.indexOf(group.displayName), -1);
 
-                                // Ensure some data expected to be in the email is there
-                                assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
-                                assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
-                                assert.notEqual(stringMessage.indexOf(group.displayName), -1);
+                            // Ensure simong's private info is *nowhere* to be found
+                            assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
+                            assert.equal(stringMessage.indexOf(simong.user.email), -1);
+                            assert.equal(stringMessage.indexOf(simong.user.locale), -1);
 
-                                // Ensure simong's private info is *nowhere* to be found
-                                assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
-                                assert.equal(stringMessage.indexOf(simong.user.email), -1);
-                                assert.equal(stringMessage.indexOf(simong.user.locale), -1);
+                            // The message probably contains the public alias, though
+                            assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
 
-                                // The message probably contains the public alias, though
-                                assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
-
-                                callback();
-                            });
+                            return callback();
                         });
                     });
                 });
@@ -841,12 +829,10 @@ describe('Principals Activity', function() {
                 };
 
                 // Make Bert loggedin
-                RestAPI.User.updateUser(bert.restContext, bert.user.id, bertUpdate, function(err) {
-                    assert.ok(!err);
+                PrincipalsTestUtil.assertUpdateUserSucceeds(bert.restContext, bert.user.id, bertUpdate, function() {
 
                     // Make Simon private
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
-                        assert.ok(!err);
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
                         // Create the group and then share it after. We will verify the share triggered an email
                         RestAPI.Group.createGroup(mrvisser.restContext, 'emailGroupAddMember', 'emailGroupAddMember', 'public', 'yes', [], [], function(err, group) {
@@ -961,62 +947,51 @@ describe('Principals Activity', function() {
             TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the group and then share it after. We will verify the share triggered an email
+                    RestAPI.Group.createGroup(simong.restContext, 'emailGroupAddMember', 'emailGroupAddMember', 'public', 'yes', [], [], function(err, group) {
                         assert.ok(!err);
 
-                        // Create the group and then share it after. We will verify the share triggered an email
-                        RestAPI.Group.createGroup(simong.restContext, 'emailGroupAddMember', 'emailGroupAddMember', 'public', 'yes', [], [], function(err, group) {
-                            assert.ok(!err);
+                        // Collect the createGroup activity and emails before adding a member
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                            // Collect the createGroup activity and emails before adding a member
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            var roleChanges = {};
+                            roleChanges[mrvisser.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(simong.restContext, group.id, roleChanges, function(err) {
+                                assert.ok(!err);
 
-                                var roleChanges = {};
-                                roleChanges[mrvisser.user.id] = 'member';
-                                RestAPI.Group.setGroupMembers(simong.restContext, group.id, roleChanges, function(err) {
-                                    assert.ok(!err);
+                                // Mrvisser should get an email, with simong's information scrubbed
+                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                                    // Mrvisser should get an email, with simong's information scrubbed
-                                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                    // There should be exactly one message, the one sent to mrvisser
+                                    assert.equal(messages.length, 1);
 
-                                        // There should be exactly one message, the one sent to mrvisser
-                                        assert.equal(messages.length, 1);
+                                    var stringMessage = JSON.stringify(messages[0]);
+                                    var message = messages[0];
 
-                                        var stringMessage = JSON.stringify(messages[0]);
-                                        var message = messages[0];
+                                    // Sanity check that the message is to mrvisser
+                                    assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                        // Sanity check that the message is to mrvisser
-                                        assert.equal(message.to[0].address, mrvisser.user.email);
+                                    // Ensure some data expected to be in the email is there
+                                    assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
+                                    assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
+                                    assert.notEqual(stringMessage.indexOf(group.displayName), -1);
 
-                                        // Ensure some data expected to be in the email is there
-                                        assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
-                                        assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
-                                        assert.notEqual(stringMessage.indexOf(group.displayName), -1);
+                                    // Ensure simong's private info is *nowhere* to be found
+                                    assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
+                                    assert.equal(stringMessage.indexOf(simong.user.email), -1);
+                                    assert.equal(stringMessage.indexOf(simong.user.locale), -1);
 
-                                        // Ensure simong's private info is *nowhere* to be found
-                                        assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
-                                        assert.equal(stringMessage.indexOf(simong.user.email), -1);
-                                        assert.equal(stringMessage.indexOf(simong.user.locale), -1);
+                                    // The message probably contains the public alias, though
+                                    assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
 
-                                        // The message probably contains the public alias, though
-                                        assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-principals/tests/test-dao.js
+++ b/node_modules/oae-principals/tests/test-dao.js
@@ -32,12 +32,7 @@ describe('Principals DAO', function() {
     before(function(callback) {
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
-
-        // Log in the tenant admin so their cookie jar is set up appropriately
-        RestAPI.User.getMe(camAdminRestContext, function(err, meObj) {
-            assert.ok(!err);
-            callback();
-        });
+        return callback();
     });
 
 
@@ -68,7 +63,7 @@ describe('Principals DAO', function() {
                     assert.ok(!err);
 
                     // Create one new one, and ensure the new number of principals is numPrincipalsOrig + 1
-                    RestAPI.User.createUser(camAdminRestContext, testUsername, 'password', 'test-create-displayName', null, function(err, createdUser) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, createdUser) {
                         assert.ok(!err);
 
                         var numPrincipalsAfter = 0;
@@ -79,7 +74,7 @@ describe('Principals DAO', function() {
                             if (principalRows) {
                                 numPrincipalsAfter += principalRows.length;
                                 _.each(principalRows, function(principalRow) {
-                                    if (principalRow.principalId === createdUser.id) {
+                                    if (principalRow.principalId === createdUser.user.id) {
                                         hasNewPrincipal = true;
                                     }
                                 });

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -1073,18 +1073,12 @@ describe('Groups', function() {
                             assert.equal(members.results.length, 1);
                             assert.equal(members.results[0].profile.id, userA1.user.id);
 
-                            // Create user in tenant B
-                            RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
-                                assert.ok(!err);
-                                var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
-
-                                // Verify userB cannot see userA as a member of groupA
-                                RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
-                                    assert.ok(!members);
-                                    return callback();
-                                });
+                            // Verify userB cannot see userA as a member of groupA
+                            RestAPI.Group.getGroupMembers(userB.restContext, groupA.id, null, 10, function(err, members) {
+                                assert.ok(err);
+                                assert.equal(err.code, 401);
+                                assert.ok(!members);
+                                return callback();
                             });
                         });
                     });

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -65,22 +65,18 @@ describe('Groups', function() {
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
 
         // Create the REST context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
             assert.ok(!err);
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            RestAPI.User.getMe(johnRestContext, function(err) {
+            johnRestContext = john.restContext;
+
+            // Add the full user id onto the REST context for use inside of this test
+            johnRestContext.user = john.user;
+
+            // Create the REST context for a global admin who is authenticated to a user tenant
+            RestAPI.Admin.loginOnTenant(TestsUtil.createGlobalAdminRestContext(), 'localhost', null, function(err, ctx) {
                 assert.ok(!err);
-
-                // Add the full user id onto the REST context for use inside of this test
-                johnRestContext.id = createdUser.id;
-
-                // Create the REST context for a global admin who is authenticated to a user tenant
-                RestAPI.Admin.loginOnTenant(TestsUtil.createGlobalAdminRestContext(), 'localhost', null, function(err, ctx) {
-                    assert.ok(!err);
-                    globalAdminOnTenantRestContext = ctx;
-                    return callback();
-                });
+                globalAdminOnTenantRestContext = ctx;
+                return callback();
             });
         });
     });
@@ -315,31 +311,27 @@ describe('Groups', function() {
          * Test that verifies that a list of members and meanagers can be passed in during group creation
          */
         it('verify that members can be specified on group creation', function(callback) {
-            // Create 2 users.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
-                    assert.ok(!err);
 
-                    RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.id], [jack.id], function(err, groupObj) {
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.user.id], [jack.user.id], function(err, groupObj) {
+                    assert.ok(!err);
+                    assert.ok(groupObj.id);
+                    assert.equal(groupObj.displayName, 'Group title');
+                    assert.equal(groupObj.resourceType, 'group');
+                    assert.equal(groupObj.profilePath, '/group/' + groupObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupObj.id).resourceId);
+
+                    // Get the members of this group
+                    RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, undefined, undefined, function(err, members) {
                         assert.ok(!err);
-                        assert.ok(groupObj.id);
-                        assert.equal(groupObj.displayName, 'Group title');
-                        assert.equal(groupObj.resourceType, 'group');
-                        assert.equal(groupObj.profilePath, '/group/' + groupObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupObj.id).resourceId);
-                        // Get the members of this group.
-                        RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, undefined, undefined, function(err, members) {
-                            assert.ok(!err);
-                            assert.equal(members.results.length, 3);
-                            // Morph results to hash for easy access.
-                            var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
-                            assert.equal(hash[jack.id][0].role, 'member');
-                            assert.equal(hash[jane.id][0].role, 'manager');
-                            assert.equal(hash[johnRestContext.id][0].role, 'manager');
-                            return callback();
-                        });
+                        assert.equal(members.results.length, 3);
+
+                        // Morph results to hash for easy access
+                        var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
+                        assert.equal(hash[jack.user.id][0].role, 'member');
+                        assert.equal(hash[jane.user.id][0].role, 'manager');
+                        assert.equal(hash[johnRestContext.user.id][0].role, 'manager');
+                        return callback();
                     });
                 });
             });
@@ -368,7 +360,7 @@ describe('Groups', function() {
                         assert.equal(fetchedGroup.visibility, 'private');
                         assert.equal(fetchedGroup.joinable, 'request');
                         assert.equal(fetchedGroup.createdBy.id.substr(0, 10), 'u:camtest:');
-                        assert.equal(fetchedGroup.createdBy.displayName, 'John Doe');
+                        assert.equal(fetchedGroup.createdBy.displayName, johnRestContext.user.displayName);
                         assert.ok(fetchedGroup.created);
                         assert.equal(fetchedGroup.resourceType, 'group');
                         assert.equal(createdGroup.profilePath, '/group/' + createdGroup.tenant.alias + '/' + AuthzUtil.getResourceFromId(createdGroup.id).resourceId);
@@ -444,64 +436,48 @@ describe('Groups', function() {
          * group profile in different situations
          */
         it('verify isMember and isManager', function(callback) {
-            // Create 3 users.
-            // We'll make jane a group manager and jack a group member
-            // Joe won't be a member of the group.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            var joeUserId = TestsUtil.generateTestUserId('joe');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            // Create 3 users. We'll make jane a group manager and jack a group
+            // member. Joe won't be a member of the group
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, joe) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Create a group in which Jane is a manager and Jack is a member
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.user.id], [jack.user.id], function(err, newGroup) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, joeUserId, 'password', 'Joe Doe', null, function(err, joe) {
+                    // For each of the users, check the appropriate value of the isMember and isManager property
+                    RestAPI.Group.getGroup(johnRestContext, newGroup.id, function(err, groupData) {
                         assert.ok(!err);
-                        var joeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, joeUserId, 'password');
+                        assert.ok(groupData.isMember);
+                        assert.ok(groupData.isManager);
 
-                        // Create a group in which Jane is a manager and Jack is a member
-                        RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.id], [jack.id], function(err, newGroup) {
+                        RestAPI.Group.getGroup(jack.restContext, newGroup.id, function(err, groupData) {
                             assert.ok(!err);
+                            assert.ok(groupData.isMember);
+                            assert.ok(!groupData.isManager);
 
-                            // For each of the users, check the appropriate value of the isMember and isManager property
-                            RestAPI.Group.getGroup(johnRestContext, newGroup.id, function(err, groupData) {
+                            RestAPI.Group.getGroup(jane.restContext, newGroup.id, function(err, groupData) {
                                 assert.ok(!err);
                                 assert.ok(groupData.isMember);
                                 assert.ok(groupData.isManager);
 
-                                RestAPI.Group.getGroup(jackRestContext, newGroup.id, function(err, groupData) {
+                                RestAPI.Group.getGroup(joe.restContext, newGroup.id, function(err, groupData) {
                                     assert.ok(!err);
-                                    assert.ok(groupData.isMember);
+                                    assert.ok(!groupData.isMember);
                                     assert.ok(!groupData.isManager);
 
-                                    RestAPI.Group.getGroup(janeRestContext, newGroup.id, function(err, groupData) {
+                                    // Tenant admins are considered members and managers.
+                                    RestAPI.Group.getGroup(camAdminRestContext, newGroup.id, function(err, groupData) {
                                         assert.ok(!err);
                                         assert.ok(groupData.isMember);
                                         assert.ok(groupData.isManager);
 
-                                        RestAPI.Group.getGroup(joeRestContext, newGroup.id, function(err, groupData) {
+                                        // Verify another tenant admin is not a manager or member.
+                                        RestAPI.Group.getGroup(gtAdminRestContext, newGroup.id, function(err, groupData) {
                                             assert.ok(!err);
                                             assert.ok(!groupData.isMember);
                                             assert.ok(!groupData.isManager);
-
-                                            // Tenant admins are considered members and managers.
-                                            RestAPI.Group.getGroup(camAdminRestContext, newGroup.id, function(err, groupData) {
-                                                assert.ok(!err);
-                                                assert.ok(groupData.isMember);
-                                                assert.ok(groupData.isManager);
-
-                                                // Verify another tenant admin is not a manager or member.
-                                                RestAPI.Group.getGroup(gtAdminRestContext, newGroup.id, function(err, groupData) {
-                                                    assert.ok(!err);
-                                                    assert.ok(!groupData.isMember);
-                                                    assert.ok(!groupData.isManager);
-                                                    return callback();
-                                                });
-                                            });
+                                            return callback();
                                         });
                                     });
                                 });
@@ -957,34 +933,26 @@ describe('Groups', function() {
          */
         it('verify updating as a non-manager is not allowed', function(callback) {
             // We create 2 users. Jack will be a member, Jane will not be a member
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Create the group with Jack as a member
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'private', 'request', [], [jack.user.id], function(err, newGroup) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
 
-                    // Create the group with Jack as a member
-                    RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'private', 'request', [], [jack.id], function(err, newGroup) {
-                        assert.ok(!err);
-
-                        // Try to update the group as a member
-                        RestAPI.Group.updateGroup(jackRestContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
+                    // Try to update the group as a member
+                    RestAPI.Group.updateGroup(jack.restContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
+                        assert.equal(err.code, 401);
+                        assert.ok(!updatedGroup);
+                        // Try to update the group as a non-member
+                        RestAPI.Group.updateGroup(jane.restContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
                             assert.equal(err.code, 401);
                             assert.ok(!updatedGroup);
-                            // Try to update the group as a non-member
-                            RestAPI.Group.updateGroup(janeRestContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
+                            // Try to update the group as an anonymous user
+                            RestAPI.Group.updateGroup(TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host), newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
                                 assert.equal(err.code, 401);
                                 assert.ok(!updatedGroup);
-                                // Try to update the group as an anonymous user
-                                RestAPI.Group.updateGroup(TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host), newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
-                                    assert.equal(err.code, 401);
-                                    assert.ok(!updatedGroup);
-                                    return callback();
-                                });
+                                return callback();
                             });
                         });
                     });
@@ -1024,7 +992,7 @@ describe('Groups', function() {
                             var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
 
                             // Make sure that all of the expected members are there
-                            assert.equal(hash[johnRestContext.id][0].role, 'manager');
+                            assert.equal(hash[johnRestContext.user.id][0].role, 'manager');
                             assert.equal(hash[managerUserIds[0]][0].role, 'manager');
                             assert.equal(hash[managerUserIds[1]][0].role, 'manager');
                             assert.equal(hash[managerUserIds[2]][0].role, 'manager');
@@ -1062,17 +1030,15 @@ describe('Groups', function() {
          */
         it('verify private members visibility', function(callback) {
             // Create the user
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'tr123', null, function(err, branden) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, branden) {
                 assert.ok(!err);
-                var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
 
                 // Create a group
                 RestAPI.Group.createGroup(johnRestContext, 'Non-Canadians', 'Group', 'private', 'yes', [], [], function(err, nonCanadiansGroup) {
                     assert.ok(!err);
 
                     // Branden should not be able to see the group members
-                    RestAPI.Group.getGroupMembers(brandenRestContext, nonCanadiansGroup.id, null, null, function(err, members) {
+                    RestAPI.Group.getGroupMembers(branden.restContext, nonCanadiansGroup.id, null, null, function(err, members) {
                         assert.ok(err);
                         assert.equal(err.code, 401);
                         assert.ok(!members);
@@ -1087,32 +1053,25 @@ describe('Groups', function() {
          * tenant.
          */
         it('verify loggedin members visibility', function(callback) {
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create user2 in tenant A
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                // Create a user in tenant B
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
                     // Create a "loggedin" group in tenant A
-                    RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'loggedin', 'no', [], [], function(err, groupA) {
+                    var groupNameA = TestsUtil.generateTestUserId();
+                    RestAPI.Group.createGroup(userA1.restContext, groupNameA, groupNameA, 'loggedin', 'no', [], [], function(err, groupA) {
                         assert.ok(!err);
 
                         // Ensure user A2 can see userA in the members list
-                        RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
+                        RestAPI.Group.getGroupMembers(userA2.restContext, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
                             assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, userA.id);
-
-                            var usernameB = TestsUtil.generateTestUserId();
+                            assert.equal(members.results[0].profile.id, userA1.user.id);
 
                             // Create user in tenant B
                             RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
@@ -1137,45 +1096,33 @@ describe('Groups', function() {
          * Test that verifies that group members of public groups are returned for users who are not logged in to the group's tenant
          */
         it('verify public members visibility', function(callback) {
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create user2 in tenant A
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                // Create a user in tenant B
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
                     // Create a "loggedin" group in tenant A, with userA as a member
-                    RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'public', 'no', [], [userA.id], function(err, groupA) {
+                    var groupNameA = TestsUtil.generateTestUserId();
+                    RestAPI.Group.createGroup(userA1.restContext, groupNameA, groupNameA, 'public', 'no', [], [userA1.user.id], function(err, groupA) {
                         assert.ok(!err);
 
                         // Ensure user A2 can see userA in the members list
-                        RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
+                        RestAPI.Group.getGroupMembers(userA2.restContext, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
                             assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, userA.id);
+                            assert.equal(members.results[0].profile.id, userA1.user.id);
 
-                            var usernameB = TestsUtil.generateTestUserId();
-
-                            // Create user in tenant B
-                            RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                            // Verify userB can see userA1 as a member of groupA
+                            RestAPI.Group.getGroupMembers(userB.restContext, groupA.id, null, 10, function(err, members) {
                                 assert.ok(!err);
-                                var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
-
-                                // Verify userB cann see userA as a member of groupA
-                                RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
-                                    assert.ok(!err);
-                                    assert.ok(members);
-                                    assert.equal(members.results.length, 1);
-                                    assert.equal(members.results[0].profile.id, userA.id);
-                                    return callback();
-                                });
+                                assert.ok(members);
+                                assert.equal(members.results.length, 1);
+                                assert.equal(members.results[0].profile.id, userA1.user.id);
+                                return callback();
                             });
                         });
                     });
@@ -1188,27 +1135,20 @@ describe('Groups', function() {
          * can still access the group members view of an external group that belongs to a private tenant
          */
         it('verify user can see group members to which he is a member in an external private tenant', function(callback) {
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var groupNameB = TestsUtil.generateTestUserId();
-
             // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, userA) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
                 // Create tenant B
+                var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
                 TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
                     assert.ok(!err);
-                    var usernameB = TestsUtil.generateTestUserId();
-
-                    // Create user in tenant B
-                    RestAPI.User.createUser(adminRestCtxB, usernameB, 'password', 'Private User', null, function(err, userB) {
+                    TestsUtil.generateTestUsers(adminRestCtxB, 1, function(err, users, userB) {
                         assert.ok(!err);
-                        var restCtxB = TestsUtil.createTenantRestContext(tenantAliasB, usernameB, 'password');
 
                         // Create a "loggedin" group in tenant B, with userB and userA as a member
-                        RestAPI.Group.createGroup(restCtxB, groupNameB, groupNameB, 'loggedin', 'no', [], [userA.id, userB.id], function(err, groupB) {
+                        var groupNameB = TestsUtil.generateTestUserId();
+                        RestAPI.Group.createGroup(userB.restContext, groupNameB, groupNameB, 'loggedin', 'no', [], [userA.user.id, userB.user.id], function(err, groupB) {
                             assert.ok(!err);
 
                             // Make tenant B private
@@ -1216,7 +1156,7 @@ describe('Groups', function() {
                                 assert.ok(!err);
 
                                 // Ensure user B can still see the memberships, even though the tenans has been "barred"
-                                RestAPI.Group.getGroupMembers(restCtxB, groupB.id, null, 10, function(err, members) {
+                                RestAPI.Group.getGroupMembers(userB.restContext, groupB.id, null, 10, function(err, members) {
                                     assert.ok(!err);
                                     assert.ok(members);
                                     assert.equal(members.results.length, 2);
@@ -1384,86 +1324,77 @@ describe('Groups', function() {
          */
         it('verify simple member adding', function(callback) {
             // Create a first user to use inside of test
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, branden, nicolaas) {
                 assert.ok(!err);
-                var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
 
-                // Create a second user to use inside of test
-                var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-                RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
+                // Create a group
+                RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
                     assert.ok(!err);
-                    var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                    // Create a group
-                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
-                        assert.ok(!err);
+                    // Try and add a user as a non-member
+                    var membersToAdd = {};
+                    membersToAdd[nicolaas.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
 
-                        // Try and add a user as a non-member
-                        var membersToAdd = {};
-                        membersToAdd[nicolaas.id] = 'member';
-                        RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 401);
+                        // Verify that the user has not been added
+                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
+                            assert.ok(!err);
+                            assert.equal(groupMemberships.results.length, 0);
 
-                            // Verify that the user has not been added
-                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                            // Add branden as a member, and make sure that he still cannot add a member
+                            membersToAdd = {};
+                            membersToAdd[branden.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                 assert.ok(!err);
-                                assert.equal(groupMemberships.results.length, 0);
 
-                                // Add branden as a member, and make sure that he still cannot add a member
+                                // Try to add nicolaas as a member
                                 membersToAdd = {};
-                                membersToAdd[branden.id] = 'member';
-                                RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
-                                    assert.ok(!err);
+                                membersToAdd[nicolaas.user.id] = 'member';
+                                RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 401);
 
-                                    // Try to add nicolaas as a member
-                                    membersToAdd = {};
-                                    membersToAdd[nicolaas.id] = 'member';
-                                    RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 401);
+                                    // Verify that the user has not been added
+                                    RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
+                                        assert.ok(!err);
+                                        assert.equal(groupMemberships.results.length, 0);
 
-                                        // Verify that the user has not been added
-                                        RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                                        // Add branden a manager, and make sure that he can add a member
+                                        membersToAdd = {};
+                                        membersToAdd[branden.user.id] = 'manager';
+                                        RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                             assert.ok(!err);
-                                            assert.equal(groupMemberships.results.length, 0);
 
-                                            // Add branden a manager, and make sure that he can add a member
+                                            // Try to add nicolaas as a member
                                             membersToAdd = {};
-                                            membersToAdd[branden.id] = 'manager';
-                                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
+                                            membersToAdd[nicolaas.user.id] = 'member';
+                                            RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
                                                 assert.ok(!err);
 
-                                                // Try to add nicolaas as a member
-                                                membersToAdd = {};
-                                                membersToAdd[nicolaas.id] = 'member';
-                                                RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
+                                                // Verify that the user has not been added
+                                                RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
                                                     assert.ok(!err);
+                                                    assert.equal(groupMemberships.results.length, 1);
+                                                    assert.equal(groupMemberships.results[0].id, groupObj.id);
 
-                                                    // Verify that the user has not been added
-                                                    RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                                                    // Verify that members can be removed
+                                                    membersToAdd = {};
+                                                    membersToAdd[nicolaas.user.id] = false;
+                                                    RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
                                                         assert.ok(!err);
-                                                        assert.equal(groupMemberships.results.length, 1);
-                                                        assert.equal(groupMemberships.results[0].id, groupObj.id);
 
-                                                        // Verify that members can be removed
-                                                        membersToAdd = {};
-                                                        membersToAdd[nicolaas.id] = false;
-                                                        RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
+                                                        // Verify that the user has been removed as a member
+                                                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
                                                             assert.ok(!err);
+                                                            assert.equal(groupMemberships.results.length, 0);
 
-                                                            // Verify that the user has been removed as a member
-                                                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                                                            // Ensure the lastModified date of the group has been updated as a result of these memberships changes
+                                                            RestAPI.Group.getGroup(johnRestContext, groupObj.id, function(err, updatedGroup) {
                                                                 assert.ok(!err);
-                                                                assert.equal(groupMemberships.results.length, 0);
-
-                                                                // Ensure the lastModified date of the group has been updated as a result of these memberships changes
-                                                                RestAPI.Group.getGroup(johnRestContext, groupObj.id, function(err, updatedGroup) {
-                                                                    assert.ok(!err);
-                                                                    assert.ok(groupObj.lastModified < updatedGroup.lastModified);
-                                                                    return callback();
-                                                                });
+                                                                assert.ok(groupObj.lastModified < updatedGroup.lastModified);
+                                                                return callback();
                                                             });
                                                         });
                                                     });
@@ -1483,77 +1414,61 @@ describe('Groups', function() {
          * Test that verifies that adding/removing multiple members at the same time is possible
          */
         it('verify combination of roles is possible', function(callback) {
-            // Create 3 users.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            var joeUserId = TestsUtil.generateTestUserId('joe');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, joe) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Create the test group
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [], [], function(err, newGroup) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, joeUserId, 'password', 'Joe Doe', null, function(err, joe) {
+                    // Add 3 members at the same time, using a combination of roles
+                    var membersToAdd = {};
+                    membersToAdd[jack.user.id] = 'member';
+                    membersToAdd[jane.user.id] = 'manager';
+                    membersToAdd[joe.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
                         assert.ok(!err);
-                        var joeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, joeUserId, 'password');
 
-                        // Create the test group
-                        RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [], [], function(err, newGroup) {
+                        // Verify that each member has the correct role
+                        RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
                             assert.ok(!err);
+                            assert.equal(members.results.length, 4);
+                            // Morph results to hash for easy access.
+                            var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
+                            assert.equal(hash[johnRestContext.user.id][0].role, 'manager');
+                            assert.equal(hash[jack.user.id][0].role, 'member');
+                            assert.equal(hash[jane.user.id][0].role, 'manager');
+                            assert.equal(hash[joe.user.id][0].role, 'member');
 
-                            // Add 3 members at the same time, using a combination of roles
-                            var membersToAdd = {};
-                            membersToAdd[jack.id] = 'member';
-                            membersToAdd[jane.id] = 'manager';
-                            membersToAdd[joe.id] = 'member';
-                            RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
+                            // Make sure that the group shows up in Joe's membership list
+                            RestAPI.Group.getMembershipsLibrary(joe.restContext, joe.user.id, null, null, function(err, memberships) {
                                 assert.ok(!err);
+                                assert.equal(memberships.results.length, 1);
+                                assert.equal(memberships.results[0].id, newGroup.id);
 
-                                // Verify that each member has the correct role
-                                RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
+                                // Delete Joe and make Jane a member
+                                membersToAdd = {};
+                                membersToAdd[jane.user.id] = 'member';
+                                membersToAdd[joe.user.id] = false;
+                                RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
                                     assert.ok(!err);
-                                    assert.equal(members.results.length, 4);
-                                    // Morph results to hash for easy access.
-                                    var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
-                                    assert.equal(hash[johnRestContext.id][0].role, 'manager');
-                                    assert.equal(hash[jack.id][0].role, 'member');
-                                    assert.equal(hash[jane.id][0].role, 'manager');
-                                    assert.equal(hash[joe.id][0].role, 'member');
 
-                                    // Make sure that the group shows up in Joe's membership list
-                                    RestAPI.Group.getMembershipsLibrary(joeRestContext, joe.id, null, null, function(err, memberships) {
+                                    // Make sure that the membership changes have happened
+                                    RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
                                         assert.ok(!err);
-                                        assert.equal(memberships.results.length, 1);
-                                        assert.equal(memberships.results[0].id, newGroup.id);
+                                        assert.equal(members.results.length, 3);
+                                        // Morph results to hash for easy access.
+                                        var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
+                                        assert.equal(hash[johnRestContext.user.id][0].role, 'manager');
+                                        assert.equal(hash[jack.user.id][0].role, 'member');
+                                        assert.equal(hash[jane.user.id][0].role, 'member');
+                                        assert.equal(hash[joe.user.id], undefined);
 
-                                        // Delete Joe and make Jane a member
-                                        membersToAdd = {};
-                                        membersToAdd[jane.id] = 'member';
-                                        membersToAdd[joe.id] = false;
-                                        RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
+                                        // Make sure that the group does not show up in Joe's membership list
+                                        RestAPI.Group.getMembershipsLibrary(joe.restContext, joe.user.id, null, null, function(err, memberships) {
                                             assert.ok(!err);
-
-                                            // Make sure that the membership changes have happened
-                                            RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
-                                                assert.ok(!err);
-                                                assert.equal(members.results.length, 3);
-                                                // Morph results to hash for easy access.
-                                                var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
-                                                assert.equal(hash[johnRestContext.id][0].role, 'manager');
-                                                assert.equal(hash[jack.id][0].role, 'member');
-                                                assert.equal(hash[jane.id][0].role, 'member');
-                                                assert.equal(hash[joe.id], undefined);
-
-                                                // Make sure that the group does not show up in Joe's membership list
-                                                RestAPI.Group.getMembershipsLibrary(joeRestContext, joe.id, null, null, function(err, memberships) {
-                                                    assert.ok(!err);
-                                                    assert.equal(memberships.results.length, 0);
-                                                    return callback();
-                                                });
-                                            });
+                                            assert.equal(memberships.results.length, 0);
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1568,65 +1483,57 @@ describe('Groups', function() {
          * Test that verifies that it should not be possible to add members as an unprivileged user
          */
         it('verify add members no access', function(callback) {
-            var simonUserId = TestsUtil.generateTestUserId('simong');
-            RestAPI.User.createUser(camAdminRestContext, simonUserId, 'password', 'Simon Gaeremynck', null, function(err, simon) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, simon, nicolaas) {
                 assert.ok(!err);
-                var simonRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, simonUserId, 'password');
-                // Create a second user to use inside of test
-                var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-                RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
+
+                // Create a test group
+                RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
                     assert.ok(!err);
-                    var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                    // Create a test group
-                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
-                        assert.ok(!err);
+                    // Try and add nicolaas to the group as an unprivileged user
+                    var membersToAdd = {};
+                    membersToAdd[nicolaas.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(simon.restContext, groupObj.id, membersToAdd, function(err) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
+                        // Verify that nicolaas has not been added to the group
+                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
+                            assert.ok(!err);
+                            assert.equal(memberships.results.length, 0);
 
-                        // Try and add nicolaas to the group as an unprivileged user
-                        var membersToAdd = {};
-                        membersToAdd[nicolaas.id] = 'member';
-                        RestAPI.Group.setGroupMembers(simonRestContext, groupObj.id, membersToAdd, function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 401);
-                            // Verify that nicolaas has not been added to the group
-                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
+                            // Add simon as a member of the group
+                            membersToAdd = {};
+                            membersToAdd[simon.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                 assert.ok(!err);
-                                assert.equal(memberships.results.length, 0);
 
-                                // Add simon as a member of the group
+                                // Make sure that simon still can't add any members
                                 membersToAdd = {};
-                                membersToAdd[simon.id] = 'member';
-                                RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
-                                    assert.ok(!err);
+                                membersToAdd[nicolaas.user.id] = 'member';
+                                RestAPI.Group.setGroupMembers(simon.restContext, groupObj.id, membersToAdd, function(err) {
+                                    assert.ok(err);
+                                    // Verify that nicolaas has not been added to the group
+                                    RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
+                                        assert.ok(!err);
+                                        assert.equal(memberships.results.length, 0);
 
-                                    // Make sure that simon still can't add any members
-                                    membersToAdd = {};
-                                    membersToAdd[nicolaas.id] = 'member';
-                                    RestAPI.Group.setGroupMembers(simonRestContext, groupObj.id, membersToAdd, function(err) {
-                                        assert.ok(err);
-                                        // Verify that nicolaas has not been added to the group
-                                        RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
+                                        // Add simon as a manager of the group
+                                        membersToAdd = {};
+                                        membersToAdd[simon.user.id] = 'manager';
+                                        RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                             assert.ok(!err);
-                                            assert.equal(memberships.results.length, 0);
 
-                                            // Add simon as a manager of the group
+                                            // Verify that simon can now add members to the group
                                             membersToAdd = {};
-                                            membersToAdd[simon.id] = 'manager';
-                                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
+                                            membersToAdd[nicolaas.user.id] = 'member';
+                                            RestAPI.Group.setGroupMembers(simon.restContext, groupObj.id, membersToAdd, function(err) {
                                                 assert.ok(!err);
-
-                                                // Verify that simon can now add members to the group
-                                                membersToAdd = {};
-                                                membersToAdd[nicolaas.id] = 'member';
-                                                RestAPI.Group.setGroupMembers(simonRestContext, groupObj.id, membersToAdd, function(err) {
+                                                // Verify that nicolaas has been added to the group
+                                                RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
                                                     assert.ok(!err);
-                                                    // Verify that nicolaas has been added to the group
-                                                    RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
-                                                        assert.ok(!err);
-                                                        assert.equal(memberships.results.length, 1);
-                                                        assert.equal(memberships.results[0].id, groupObj.id);
-                                                        return callback();
-                                                    });
+                                                    assert.equal(memberships.results.length, 1);
+                                                    assert.equal(memberships.results[0].id, groupObj.id);
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -1643,55 +1550,46 @@ describe('Groups', function() {
          * Test to verify that it should be possible for an indirect manager to add members
          */
         it('verify add members indirect access', function(callback) {
-            // Create a first user to use inside of test
-            var simonUserId = TestsUtil.generateTestUserId('simong');
-            RestAPI.User.createUser(camAdminRestContext, simonUserId, 'password', 'Simon Gaeremynck', null, function(err, simon) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, simon, nicolaas) {
                 assert.ok(!err);
-                var simonRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, simonUserId, 'password');
-                // Create a second user to use inside of test
-                var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-                RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
-                    assert.ok(!err);
-                    var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                    // Create the base group
-                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, managedByCambridge) {
+                // Create the base group
+                RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, managedByCambridge) {
+                    assert.ok(!err);
+
+                    // Create the "Cambridge" group that will manage the Managed-by-cambridge group
+                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, cambridge) {
                         assert.ok(!err);
 
-                        // Create the "Cambridge" group that will manage the Managed-by-cambridge group
-                        RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, cambridge) {
+                        // Make the "Cambridge" group a manager of the Managed-by-cambridge group
+                        var membersToAdd = {};
+                        membersToAdd[cambridge.id] = 'manager';
+                        RestAPI.Group.setGroupMembers(johnRestContext, managedByCambridge.id, membersToAdd, function(err) {
                             assert.ok(!err);
 
-                            // Make the "Cambridge" group a manager of the Managed-by-cambridge group
-                            var membersToAdd = {};
-                            membersToAdd[cambridge.id] = 'manager';
-                            RestAPI.Group.setGroupMembers(johnRestContext, managedByCambridge.id, membersToAdd, function(err) {
+                            // Make "simon" a member of the "Cambridge" group, then verify he can manage "Managed-by-cambridge"
+                            membersToAdd = {};
+                            membersToAdd[simon.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(johnRestContext, cambridge.id, membersToAdd, function(err) {
                                 assert.ok(!err);
 
-                                // Make "simon" a member of the "Cambridge" group, then verify he can manage "Managed-by-cambridge"
-                                membersToAdd = {};
-                                membersToAdd[simon.id] = 'member';
-                                RestAPI.Group.setGroupMembers(johnRestContext, cambridge.id, membersToAdd, function(err) {
+                                // Check if "simon" can manage the "Managed-by-cambridge" group through the internal Authz API
+                                AuthzAPI.hasRole(simon.user.id, managedByCambridge.id, 'manager', function(err, isAllowed) {
                                     assert.ok(!err);
+                                    assert.equal(isAllowed, true);
 
-                                    // Check if "simon" can manage the "Managed-by-cambridge" group through the internal Authz API
-                                    AuthzAPI.hasRole(simon.id, managedByCambridge.id, 'manager', function(err, isAllowed) {
+                                    // Verify that "simon" can add someone to the "Managed-by-cambridge" group
+                                    membersToAdd = {};
+                                    membersToAdd[nicolaas.user.id] = 'member';
+                                    RestAPI.Group.setGroupMembers(simon.restContext, managedByCambridge.id, membersToAdd, function(err) {
                                         assert.ok(!err);
-                                        assert.equal(isAllowed, true);
 
-                                        // Verify that "simon" can add someone to the "Managed-by-cambridge" group
-                                        membersToAdd = {};
-                                        membersToAdd[nicolaas.id] = 'member';
-                                        RestAPI.Group.setGroupMembers(simonRestContext, managedByCambridge.id, membersToAdd, function(err) {
+                                        // Verify that the "nicolaas" has been added to the group
+                                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
                                             assert.ok(!err);
-
-                                            // Verify that the "nicolaas" has been added to the group
-                                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
-                                                assert.ok(!err);
-                                                assert.equal(memberships.results.length, 1);
-                                                assert.equal(memberships.results[0].id, managedByCambridge.id);
-                                                return callback();
-                                            });
+                                            assert.equal(memberships.results.length, 1);
+                                            assert.equal(memberships.results[0].id, managedByCambridge.id);
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1706,8 +1604,7 @@ describe('Groups', function() {
          * Verify that non-existing users and/or groups cannot be added as members to a group
          */
         it('verify that non-existing principals cannot be added to a group', function(callback) {
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, branden) {
                 assert.ok(!err);
 
                 // Create the group
@@ -1716,7 +1613,7 @@ describe('Groups', function() {
 
                     // Try to add an existing and non-existing user
                     var membersToAdd = {};
-                    membersToAdd[branden.id] = 'member';
+                    membersToAdd[branden.user.id] = 'member';
                     membersToAdd['u:camtest:non-existing'] = 'member';
                     RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                         assert.ok(err);
@@ -1726,7 +1623,7 @@ describe('Groups', function() {
                         RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, null, null, function(err, members) {
                             assert.ok(!err);
                             assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, johnRestContext.id);
+                            assert.equal(members.results[0].profile.id, johnRestContext.user.id);
                             return callback();
                         });
                     });
@@ -1801,43 +1698,28 @@ describe('Groups', function() {
         });
 
         it('verify that a group that is part of a public tenant can add a user member from an external public tenant', function(callback) {
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
-
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create a "loggedin" group in tenant A, with userA as a member
-                    RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'loggedin', 'no', [], [], function(err, groupA) {
+                    // Create a "loggedin" group in tenant A, with userA1 as a member
+                    var groupNameA = TestsUtil.generateTestUserId();
+                    RestAPI.Group.createGroup(userA1.restContext, groupNameA, groupNameA, 'loggedin', 'no', [], [], function(err, groupA) {
                         assert.ok(!err);
 
                         // Ensure user A2 can see userA in the members list
-                        RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
+                        RestAPI.Group.getGroupMembers(userA2.restContext, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
                             assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, userA.id);
+                            assert.equal(members.results[0].profile.id, userA1.user.id);
 
-                            var usernameB = TestsUtil.generateTestUserId();
-
-                            // Create user in tenant B
-                            RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
-                                assert.ok(!err);
-                                var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
-
-                                // Verify userB cannot see userA as a member of groupA
-                                RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
-                                    return callback();
-                                });
+                            // Verify userB cannot see userA1 as a member of groupA
+                            RestAPI.Group.getGroupMembers(userB.restContext, groupA.id, null, 10, function(err, members) {
+                                assert.ok(err);
+                                assert.equal(err.code, 401);
+                                return callback();
                             });
                         });
                     });
@@ -1846,59 +1728,48 @@ describe('Groups', function() {
         });
 
         it('verify that a group that is part of a public tenant cannot add a user from an external private tenant', function(callback) {
-            var usernameB = TestsUtil.generateTestUserId();
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create users in tenant A
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                // Create a "public" group in tenant A, with userA1 as a member
+                var groupNameA = TestsUtil.generateTestUserId();
+                RestAPI.Group.createGroup(userA1.restContext, groupNameA, groupNameA, 'public', 'no', [], [], function(err, groupA) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create a "public" group in tenant A, with userA as a member
-                    RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'public', 'no', [], [], function(err, groupA) {
+                    // Ensure user A2 can see userA in the members list
+                    RestAPI.Group.getGroupMembers(userA2.restContext, groupA.id, null, 10, function(err, members) {
                         assert.ok(!err);
+                        assert.ok(members);
+                        assert.equal(members.results.length, 1);
+                        assert.equal(members.results[0].profile.id, userA1.user.id);
 
-                        // Ensure user A2 can see userA in the members list
-                        RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
+                        // Create tenant B
+                        var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
+                        TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
                             assert.ok(!err);
-                            assert.ok(members);
-                            assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, userA.id);
 
-                            // Create tenant B
-                            TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
+                            // Create user in tenant B
+                            TestsUtil.generateTestUsers(adminRestCtxB, 1, function(err, users, userB) {
                                 assert.ok(!err);
 
-                                // Create user in tenant B
-                                RestAPI.User.createUser(adminRestCtxB, usernameB, 'password', 'Private User', null, function(err, userB) {
+                                // Make tenant B private
+                                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAliasB, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                                     assert.ok(!err);
-                                    var restCtxB = TestsUtil.createTenantRestContext(tenantAliasB, usernameB, 'password');
 
-                                    // Make tenant B private
-                                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAliasB, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
-                                        assert.ok(!err);
+                                    // Verify we can't add userB as a member of groupA.
+                                    var newMemberB = {};
+                                    newMemberB[userB.user.id] = 'member';
+                                    RestAPI.Group.setGroupMembers(userA1.restContext, groupA.id, newMemberB, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
 
-                                        // Verify we can't add userB as a member of groupA.
-                                        var newMemberB = {};
-                                        newMemberB[userB.id] = 'member';
-                                        RestAPI.Group.setGroupMembers(restCtxA, groupA.id, newMemberB, function(err) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 401);
-
-                                            // Verify userB is not added to the group
-                                            RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
-                                                assert.ok(!err);
-                                                assert.equal(members.results.length, 1);
-                                                assert.equal(members.results[0].profile.id, userA.id);
-                                                return callback();
-                                            });
+                                        // Verify userB is not added to the group
+                                        RestAPI.Group.getGroupMembers(userB.restContext, groupA.id, null, 10, function(err, members) {
+                                            assert.ok(!err);
+                                            assert.equal(members.results.length, 1);
+                                            assert.equal(members.results[0].profile.id, userA1.user.id);
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1910,32 +1781,26 @@ describe('Groups', function() {
         });
 
         it('verify that a group that is part of a private tenant cannot add a user from an external public tenant', function(callback) {
-            var usernameB = TestsUtil.generateTestUserId();
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create users in tenant A
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                // Create tenant B
+                var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
+                TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create tenant B
-                    TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
+                    // Create user in tenant B
+                    TestsUtil.generateTestUsers(adminRestCtxB, 1, function(err, users, userB) {
                         assert.ok(!err);
 
-                        // Create user in tenant B
-                        RestAPI.User.createUser(adminRestCtxB, usernameB, 'password', 'Private User', null, function(err, userB) {
+                        // Make tenant B private
+                        ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAliasB, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                             assert.ok(!err);
-                            var restCtxB = TestsUtil.createTenantRestContext(tenantAliasB, usernameB, 'password');
 
                             // Create a "public" group in tenant B
-                            RestAPI.Group.createGroup(restCtxB, groupNameB, groupNameB, 'public', 'no', [], [], function(err, groupB) {
+                            var groupNameB = TestsUtil.generateTestUserId();
+                            RestAPI.Group.createGroup(userB.restContext, groupNameB, groupNameB, 'public', 'no', [], [], function(err, groupB) {
                                 assert.ok(!err);
 
                                 // Make tenant B private
@@ -1944,16 +1809,16 @@ describe('Groups', function() {
 
                                     // Verify we can't add userA as a member of groupA.
                                     var newMemberA = {};
-                                    newMemberA[userA.id] = 'member';
-                                    RestAPI.Group.setGroupMembers(restCtxB, groupB.id, newMemberA, function(err) {
+                                    newMemberA[userA1.user.id] = 'member';
+                                    RestAPI.Group.setGroupMembers(userB.restContext, groupB.id, newMemberA, function(err) {
                                         assert.ok(err);
                                         assert.equal(err.code, 401);
 
                                         // Verify userB cannot see userA as a member of groupA
-                                        RestAPI.Group.getGroupMembers(restCtxB, groupB.id, null, 10, function(err, members) {
+                                        RestAPI.Group.getGroupMembers(userB.restContext, groupB.id, null, 10, function(err, members) {
                                             assert.ok(!err);
                                             assert.equal(members.results.length, 1);
-                                            assert.equal(members.results[0].profile.id, userB.id);
+                                            assert.equal(members.results[0].profile.id, userB.user.id);
                                             return callback();
                                         });
                                     });
@@ -1969,58 +1834,47 @@ describe('Groups', function() {
          * Test that verifies validation of leaving a group
          */
         it('verify validation and success of leaving a group', function(callback) {
-
-            // Create a first user to setup the test
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, branden) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                // Create a user as our test subject
-                RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+                // Create a group that is joinable
+                RestAPI.Group.createGroup(jack.restContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
-                    var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
 
-                    // Create a group that is joinable
-                    RestAPI.Group.createGroup(jackRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, group) {
-                        assert.ok(!err);
+                    // Verify cannot leave group of which I am not a member
+                    PrincipalsTestUtil.assertLeaveGroupFails(branden.restContext, group.id, 400, function() {
 
-                        // Verify cannot leave group of which I am not a member
-                        PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, group.id, 400, function() {
+                        // Now join the group and ensure it was successful
+                        PrincipalsTestUtil.assertJoinGroupSucceeds(jack.restContext, branden.restContext, group.id, function() {
 
-                            // Now join the group and ensure it was successful
-                            PrincipalsTestUtil.assertJoinGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
+                            // Get the group state immediately after join so we can ensure the stability of its lastModified time
+                            RestAPI.Group.getGroup(jack.restContext, group.id, function(err, groupAfterJoin) {
 
-                                // Get the group state immediately after join so we can ensure the stability of its lastModified time
-                                RestAPI.Group.getGroup(jackRestContext, group.id, function(err, groupAfterJoin) {
+                                // Verify not a valid id
+                                PrincipalsTestUtil.assertLeaveGroupFails(branden.restContext, 'not-a-valid-id', 400, function() {
 
-                                    // Verify not a valid id
-                                    PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, 'not-a-valid-id', 400, function() {
+                                    // Verify a non-group id
+                                    PrincipalsTestUtil.assertLeaveGroupFails(branden.restContext, branden.user.id, 400, function() {
 
-                                        // Verify a non-group id
-                                        PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, branden.id, 400, function() {
+                                        // Verify anonymous user cannot leave
+                                        PrincipalsTestUtil.assertLeaveGroupFails(anonymousRestContext, group.id, 401, function() {
 
-                                            // Verify anonymous user cannot leave
-                                            PrincipalsTestUtil.assertLeaveGroupFails(anonymousRestContext, group.id, 401, function() {
+                                            // Verify branden is still a member
+                                            RestAPI.Group.getGroupMembers(branden.restContext, group.id, null, 10000, function(err, members) {
+                                                assert.ok(!err);
+                                                assert.equal(members.results.length, 2);
 
-                                                // Verify branden is still a member
-                                                RestAPI.Group.getGroupMembers(brandenRestContext, group.id, null, 10000, function(err, members) {
-                                                    assert.ok(!err);
-                                                    assert.equal(members.results.length, 2);
+                                                // Verify successful leave
+                                                PrincipalsTestUtil.assertLeaveGroupSucceeds(jack.restContext, branden.restContext, group.id, function() {
 
-                                                    // Verify successful leave
-                                                    PrincipalsTestUtil.assertLeaveGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
+                                                    RestAPI.Group.getGroup(jack.restContext, group.id, function(err, groupAfterLeave) {
+                                                        assert.ok(!err);
 
-                                                        RestAPI.Group.getGroup(jackRestContext, group.id, function(err, groupAfterLeave) {
-                                                            assert.ok(!err);
+                                                        // Make sure the lastModified has not changed as a result of a leave
+                                                        assert.equal(groupAfterJoin.lastModified, groupAfterLeave.lastModified);
 
-                                                            // Make sure the lastModified has not changed as a result of a leave
-                                                            assert.equal(groupAfterJoin.lastModified, groupAfterLeave.lastModified);
-
-                                                            // Verify that the last manager can't leave
-                                                            return PrincipalsTestUtil.assertLeaveGroupFails(jackRestContext, group.id, 400, callback);
-                                                        });
+                                                        // Verify that the last manager can't leave
+                                                        return PrincipalsTestUtil.assertLeaveGroupFails(jack.restContext, group.id, 400, callback);
                                                     });
                                                 });
                                             });
@@ -2038,56 +1892,51 @@ describe('Groups', function() {
          * Test that verifies validation of joining a group
          */
         it('verify validation and success of joining a group', function(callback) {
-
-            // Create a first user to setup the test
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, branden) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                // Create a user as our test subject
-                RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+                // Create a group that is not joinable
+                RestAPI.Group.createGroup(jack.restContext, 'Test Group', 'Group', 'public', 'request', [], [], function(err, group) {
                     assert.ok(!err);
-                    var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
 
-                    // Create a group that is not joinable
-                    RestAPI.Group.createGroup(jackRestContext, 'Test Group', 'Group', 'public', 'request', [], [], function(err, group) {
-                        assert.ok(!err);
+                    // Validate invalid group id
+                    RestAPI.Group.joinGroup(branden.restContext, 'not-a-valid-id', function(err) {
+                        assert.ok(err);
+                        assert.equal(err.code, 400);
 
                         // Validate invalid group id
-                        PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, 'not-a-valid-id', 400, function() {
+                        PrincipalsTestUtil.assertJoinGroupFails(branden.restContext, 'not-a-valid-id', 400, function() {
 
                             // Validate non-group group id
-                            PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, branden.id, 400, function() {
+                            PrincipalsTestUtil.assertJoinGroupFails(branden.restContext, branden.user.id, 400, function() {
 
                                 // Validate non-joinable group
-                                PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, group.id, 401, function() {
+                                PrincipalsTestUtil.assertJoinGroupFails(branden.restContext, group.id, 401, function() {
 
                                     // Make group joinable
-                                    RestAPI.Group.updateGroup(jackRestContext, group.id, {'joinable': 'yes'}, function(err) {
+                                    RestAPI.Group.updateGroup(jack.restContext, group.id, {'joinable': 'yes'}, function(err) {
                                         assert.ok(!err);
 
                                         // Join as anonymous and verify it still fails
                                         PrincipalsTestUtil.assertJoinGroupFails(anonymousRestContext, group.id, 401, function() {
 
                                             // Verify we still aren't a member
-                                            PrincipalsTestUtil.getAllGroupMembers(jackRestContext, group.id, null, function(members) {
+                                            PrincipalsTestUtil.getAllGroupMembers(jack.restContext, group.id, null, function(members) {
                                                 assert.equal(members.length, 1);
 
                                                 // Join as branden, should finally work
-                                                PrincipalsTestUtil.assertJoinGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
+                                                PrincipalsTestUtil.assertJoinGroupSucceeds(jack.restContext, branden.restContext, group.id, function() {
 
                                                     // Verify jack cannot join, he is already manager
-                                                    PrincipalsTestUtil.assertJoinGroupFails(jackRestContext, group.id, 400, function() {
+                                                    PrincipalsTestUtil.assertJoinGroupFails(jack.restContext, group.id, 400, function() {
 
                                                         // Verify he was not demoted to member
-                                                        PrincipalsTestUtil.getAllGroupMembers(jackRestContext, group.id, null, function(members) {
+                                                        PrincipalsTestUtil.getAllGroupMembers(jack.restContext, group.id, null, function(members) {
                                                             assert.equal(members.length, 2);
 
                                                             var hadJack = false;
                                                             _.each(members, function(result) {
-                                                                if (result.profile.id === jack.id) {
+                                                                if (result.profile.id === jack.user.id) {
                                                                     hadJack = true;
                                                                     assert.equal(result.role, 'manager');
                                                                 }
@@ -2116,35 +1965,26 @@ describe('Groups', function() {
          * Test that verifies that the getMembershipsLibrary function returns all of the groups a user is a member of
          */
         it('verify getMembershipsLibrary', function(callback) {
-            // Create the users to test with
-            var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-            RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, nicolaas, branden) {
                 assert.ok(!err);
-                var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-                RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
-                    assert.ok(!err);
-                    var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
+                // Create 3 groups
+                TestsUtil.generateTestGroups(nicolaas.restContext, 3, function() {
+                    var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
 
-                    // Create 3 groups
-                    TestsUtil.generateTestGroups(nicolaasRestContext, 3, function() {
-                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+                    // Check that all those groups are part of the memberships
+                    RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
+                        assert.ok(!err);
+                        assert.equal(memberships.results.length, 3);
+                        assert.ok(groupIds.indexOf(memberships.results[0].id) !== -1);
+                        assert.ok(groupIds.indexOf(memberships.results[1].id) !== -1);
+                        assert.ok(groupIds.indexOf(memberships.results[2].id) !== -1);
 
-                        // Check that all those groups are part of the memberships
-                        RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
+                        // Verify that the groups are not part of branden's membership list
+                        RestAPI.Group.getMembershipsLibrary(branden.restContext, branden.user.id, null, null, function(err, memberships) {
                             assert.ok(!err);
-                            assert.equal(memberships.results.length, 3);
-                            assert.ok(groupIds.indexOf(memberships.results[0].id) !== -1);
-                            assert.ok(groupIds.indexOf(memberships.results[1].id) !== -1);
-                            assert.ok(groupIds.indexOf(memberships.results[2].id) !== -1);
-
-                            // Verify that the groups are not part of branden's membership list
-                            RestAPI.Group.getMembershipsLibrary(brandenRestContext, branden.id, null, null, function(err, memberships) {
-                                assert.ok(!err);
-                                assert.equal(memberships.results.length, 0);
-                                return callback();
-                            });
+                            assert.equal(memberships.results.length, 0);
+                            return callback();
                         });
                     });
                 });
@@ -2343,11 +2183,10 @@ describe('Groups', function() {
                         }
                     });
                 } else {
-                    RestAPI.User.createUser(camAdminRestContext, principalId, 'password', metadata, null, function(err, userObj) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                         assert.ok(!err);
-                        var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, principalId, 'password');
-                        userRestContext.id = userObj.id;
-                        createdPrincipals[identifier] = userRestContext;
+                        user.restContext.id = user.user.id;
+                        createdPrincipals[identifier] = user.restContext;
                         if (_.keys(createdPrincipals).length === 12) {
                             return callback(createdPrincipals);
                         }

--- a/node_modules/oae-principals/tests/test-library.js
+++ b/node_modules/oae-principals/tests/test-library.js
@@ -431,61 +431,53 @@ describe('Memberships Library', function() {
          * returning in searches.
          */
         it('verify removing member from group removes it from private and non-private library', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
             var groupParentAlias = TestsUtil.generateTestUserId('groupParent');
             var groupChildAlias = TestsUtil.generateTestUserId('groupChild');
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
+                assert.ok(!err);
 
-                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, jack) {
+                // Create a group hierarchy to ensure they all show up in 'jack's group membership search
+                RestAPI.Group.createGroup(doer.restContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [], function(err, groupParent) {
                     assert.ok(!err);
 
-                    jack = _.values(jack)[0];
-
-                    // Create a group hierarchy to ensure they all show up in 'jack's group membership search
-                    RestAPI.Group.createGroup(doerRestContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [], function(err, groupParent) {
+                    RestAPI.Group.createGroup(doer.restContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [], function(err, groupChild) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(doerRestContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [], function(err, groupChild) {
+                        TestsUtil.generateGroupHierarchy(doer.restContext, [groupParent.id, groupChild.id, jack.user.id], 'member', function(err) {
                             assert.ok(!err);
 
-                            TestsUtil.generateGroupHierarchy(doerRestContext, [groupParent.id, groupChild.id, jack.user.id], 'member', function(err) {
+                            // Search all and ensure the private feed search contains both groups
+                            SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.ok(_getDocById(results, groupChild.id));
+                                assert.ok(_getDocById(results, groupParent.id));
 
-                                // Search all and ensure the private feed search contains both groups
-                                SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
+                                // Ensure loggedin feed has just the direct group
+                                SearchTestsUtil.searchAll(doer.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(_getDocById(results, groupChild.id));
-                                    assert.ok(_getDocById(results, groupParent.id));
+                                    assert.ok(!_getDocById(results, groupParent.id));
 
-                                    // Ensure loggedin feed has just the direct group
-                                    SearchTestsUtil.searchAll(doerRestContext, 'memberships-library', [jack.user.id], null, function(err, results) {
+                                    // Unlink the hierarchy by removing jack from the 'bottom' group
+                                    var changes = {};
+                                    changes[jack.user.id] = false;
+                                    RestAPI.Group.setGroupMembers(doer.restContext, groupChild.id, changes, function(err) {
                                         assert.ok(!err);
-                                        assert.ok(_getDocById(results, groupChild.id));
-                                        assert.ok(!_getDocById(results, groupParent.id));
 
-                                        // Unlink the hierarchy by removing jack from the 'bottom' group
-                                        var changes = {};
-                                        changes[jack.user.id] = false;
-                                        RestAPI.Group.setGroupMembers(doerRestContext, groupChild.id, changes, function(err) {
+                                        // Verify the private memberships search is now empty
+                                        SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 0);
+                                            assert.equal(results.results.length, 0);
 
-                                            // Verify the private memberships search is now empty
-                                            SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
+                                            // Verify the loggedin memberships search is now empty
+                                            SearchTestsUtil.searchAll(doer.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
                                                 assert.equal(results.total, 0);
                                                 assert.equal(results.results.length, 0);
 
-                                                // Verify the loggedin memberships search is now empty
-                                                SearchTestsUtil.searchAll(doerRestContext, 'memberships-library', [jack.user.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 0);
-                                                    assert.equal(results.results.length, 0);
-
-                                                    return callback();
-                                                });
+                                                return callback();
                                             });
                                         });
                                     });
@@ -501,58 +493,49 @@ describe('Memberships Library', function() {
          * Test that verifies paging works correctly in memberships search.
          */
         it('verify paging works correctly in memberships library search', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
             var groupParentAlias = TestsUtil.generateTestUserId('groupParent');
             var groupChildAlias = TestsUtil.generateTestUserId('groupChild');
 
-            // Create the user with which we'll set up the data
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, doer) {
 
-                // Create the user whose memberships to check
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                // Create a group hierarchy to ensure we have memberships
+                RestAPI.Group.createGroup(doer.restContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [jack.user.id], function(err, groupParent) {
                     assert.ok(!err);
 
-                    // Create a group hierarchy to ensure we have memberships
-                    RestAPI.Group.createGroup(doerRestContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [jack.id], function(err, groupParent) {
+                    RestAPI.Group.createGroup(doer.restContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [jack.user.id], function(err, groupChild) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(doerRestContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [jack.id], function(err, groupChild) {
+                        // Search only 2 documents to get the expected ids for paging afterward
+                        SearchTestsUtil.searchRefreshed(doer.restContext, 'memberships-library', [jack.user.id], {'limit': 2, 'start': 0}, function(err, results) {
                             assert.ok(!err);
+                            assert.ok(results.results);
+                            assert.ok(results.results.length, 2);
 
-                            // Search only 2 documents to get the expected ids for paging afterward
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'memberships-library', [jack.id], {'limit': 2, 'start': 0}, function(err, results) {
+                            // Get the ids of the first 2 expected results.
+                            var firstId = results.results[0].id;
+                            var secondId = results.results[1].id;
+
+                            assert.ok(firstId);
+                            assert.ok(secondId);
+
+                            // Verify page 1 gives the first id. We don't need to refresh since we haven't updated anything since the first refresh.
+                            RestAPI.Search.search(doer.restContext, 'memberships-library', [jack.user.id], {'limit': 1, 'start': 0}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(results.results);
-                                assert.ok(results.results.length, 2);
+                                assert.ok(results.results.length, 1);
+                                assert.equal(results.results[0].id, firstId);
+                                assert.equal(results.results[0].resourceType, 'group');
+                                assert.equal(results.results[0].profilePath, '/group/' + results.results[0].tenant.alias + '/' + AuthzUtil.getResourceFromId(results.results[0].id).resourceId);
 
-                                // Get the ids of the first 2 expected results.
-                                var firstId = results.results[0].id;
-                                var secondId = results.results[1].id;
-
-                                assert.ok(firstId);
-                                assert.ok(secondId);
-
-                                // Verify page 1 gives the first id. We don't need to refresh since we haven't updated anything since the first refresh.
-                                RestAPI.Search.search(doerRestContext, 'memberships-library', [jack.id], {'limit': 1, 'start': 0}, function(err, results) {
+                                // Verify page 2 gives the second id
+                                RestAPI.Search.search(doer.restContext, 'memberships-library', [jack.user.id], {'limit': 1, 'start': 1}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(results.results);
                                     assert.ok(results.results.length, 1);
-                                    assert.equal(results.results[0].id, firstId);
+                                    assert.equal(results.results[0].id, secondId);
                                     assert.equal(results.results[0].resourceType, 'group');
                                     assert.equal(results.results[0].profilePath, '/group/' + results.results[0].tenant.alias + '/' + AuthzUtil.getResourceFromId(results.results[0].id).resourceId);
-
-                                    // Verify page 2 gives the second id
-                                    RestAPI.Search.search(doerRestContext, 'memberships-library', [jack.id], {'limit': 1, 'start': 1}, function(err, results) {
-                                        assert.ok(!err);
-                                        assert.ok(results.results);
-                                        assert.ok(results.results.length, 1);
-                                        assert.equal(results.results[0].id, secondId);
-                                        assert.equal(results.results[0].resourceType, 'group');
-                                        assert.equal(results.results[0].profilePath, '/group/' + results.results[0].tenant.alias + '/' + AuthzUtil.getResourceFromId(results.results[0].id).resourceId);
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-principals/tests/test-members-search.js
+++ b/node_modules/oae-principals/tests/test-members-search.js
@@ -63,11 +63,6 @@ describe('Members Search', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
 
-        var publicUserMemberUsername = TestsUtil.generateTestUserId('publicUserMember');
-        var loggedinUserMemberUsername = TestsUtil.generateTestUserId('loggedinUserMember');
-        var privateUserMemberUsername = TestsUtil.generateTestUserId('privateUserMember');
-        var doerUsername = TestsUtil.generateTestUserId('privateUserMember');
-
         /*!
          * Creates the following variable setup for testing members search:
          *
@@ -85,72 +80,66 @@ describe('Members Search', function() {
          *  publicGroupMember:      A group with visibility 'public'. Is a member of all the target groups.
          *  privateGroupMember:     A group with visibility 'private'. Is a member of all the target groups.
          */
-        RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, _doerUser) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 4, function(err, users, doer, publicUser, loggedinUser, privateUser) {
             assert.ok(!err);
-            doerUser = _doerUser;
-            doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-            RestAPI.User.createUser(camAdminRestContext, publicUserMemberUsername, 'password', 'Public User Member', null, function(err, _publicUserMember) {
+            doerRestContext = doer.restContext;
+            publicUserMember = publicUser.user;
+
+            var loggedinOpts = {
+                'visibility': 'loggedin',
+                'publicAlias': 'LoggedinHidden'
+            };
+            RestAPI.User.updateUser(loggedinUser.restContext, loggedinUser.user.id, loggedinOpts, function(err, loggedinUser) {
                 assert.ok(!err);
-                publicUserMember = _publicUserMember;
-
-                var loggedinOpts = {
-                    'visibility': 'loggedin',
-                    'publicAlias': 'LoggedinHidden'
-                };
+                loggedinUserMember = loggedinUser;
 
                 var privateOpts = {
                     'visibility': 'private',
                     'publicAlias': 'PrivateHidden'
                 };
-
-                RestAPI.User.createUser(camAdminRestContext, loggedinUserMemberUsername, 'password', 'Loggedin User Member', loggedinOpts, function(err, _loggedinUserMember) {
+                RestAPI.User.updateUser(privateUser.restContext, privateUser.user.id, privateOpts, function(err, privateUser) {
                     assert.ok(!err);
-                    loggedinUserMember = _loggedinUserMember;
+                    privateUserMember = privateUser;
 
-                    RestAPI.User.createUser(camAdminRestContext, privateUserMemberUsername, 'password', 'Private User Member', privateOpts, function(err, _privateUserMember) {
+                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPublicGroup'), TestsUtil.generateTestUserId('targetPublicGroup'), 'public', 'no', [], [], function(err, _targetPublicGroup) {
                         assert.ok(!err);
-                        privateUserMember = _privateUserMember;
+                        targetPublicGroup = _targetPublicGroup;
 
-                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPublicGroup'), TestsUtil.generateTestUserId('targetPublicGroup'), 'public', 'no', [], [], function(err, _targetPublicGroup) {
+                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetLoggedinGroup'), TestsUtil.generateTestUserId('targetLoggedinGroup'), 'loggedin', 'no', [], [], function(err, _targetLoggedinGroup) {
                             assert.ok(!err);
-                            targetPublicGroup = _targetPublicGroup;
+                            targetLoggedinGroup = _targetLoggedinGroup;
 
-                            RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetLoggedinGroup'), TestsUtil.generateTestUserId('targetLoggedinGroup'), 'loggedin', 'no', [], [], function(err, _targetLoggedinGroup) {
+                            RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPrivateGroup'), TestsUtil.generateTestUserId('targetPrivateGroup'), 'private', 'no', [], [], function(err, _targetPrivateGroup) {
                                 assert.ok(!err);
-                                targetLoggedinGroup = _targetLoggedinGroup;
+                                targetPrivateGroup = _targetPrivateGroup;
 
-                                RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPrivateGroup'), TestsUtil.generateTestUserId('targetPrivateGroup'), 'private', 'no', [], [], function(err, _targetPrivateGroup) {
+                                RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('publicGroupMemberAlias'), TestsUtil.generateTestUserId('publicGroupMemberAlias'), 'public', 'no', [], [], function(err, _publicGroupMember) {
                                     assert.ok(!err);
-                                    targetPrivateGroup = _targetPrivateGroup;
+                                    publicGroupMember = _publicGroupMember;
 
-                                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('publicGroupMemberAlias'), TestsUtil.generateTestUserId('publicGroupMemberAlias'), 'public', 'no', [], [], function(err, _publicGroupMember) {
+                                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('privateGroupMemberAlias'), TestsUtil.generateTestUserId('privateGroupMemberAlias'), 'public', 'no', [], [], function(err, _privateGroupMember) {
                                         assert.ok(!err);
-                                        publicGroupMember = _publicGroupMember;
+                                        privateGroupMember = _privateGroupMember;
 
-                                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('privateGroupMemberAlias'), TestsUtil.generateTestUserId('privateGroupMemberAlias'), 'public', 'no', [], [], function(err, _privateGroupMember) {
+                                        var memberships = {};
+                                        memberships[publicGroupMember.id] = 'member';
+                                        memberships[privateGroupMember.id] = 'member';
+                                        memberships[publicUserMember.id] = 'member';
+                                        memberships[loggedinUserMember.id] = 'member';
+                                        memberships[privateUserMember.id] = 'member';
+
+                                        // Set the members of the groups with the cam admin since they are the only ones with access to make the private
+                                        // user a member
+                                        RestAPI.Group.setGroupMembers(camAdminRestContext, targetPublicGroup.id, memberships, function(err) {
                                             assert.ok(!err);
-                                            privateGroupMember = _privateGroupMember;
 
-                                            var memberships = {};
-                                            memberships[publicGroupMember.id] = 'member';
-                                            memberships[privateGroupMember.id] = 'member';
-                                            memberships[publicUserMember.id] = 'member';
-                                            memberships[loggedinUserMember.id] = 'member';
-                                            memberships[privateUserMember.id] = 'member';
-
-                                            // Set the members of the groups with the cam admin since they are the only ones with access to make the private
-                                            // user a member
-                                            RestAPI.Group.setGroupMembers(camAdminRestContext, targetPublicGroup.id, memberships, function(err) {
+                                            RestAPI.Group.setGroupMembers(camAdminRestContext, targetLoggedinGroup.id, memberships, function(err) {
                                                 assert.ok(!err);
 
-                                                RestAPI.Group.setGroupMembers(camAdminRestContext, targetLoggedinGroup.id, memberships, function(err) {
+                                                RestAPI.Group.setGroupMembers(camAdminRestContext, targetPrivateGroup.id, memberships, function(err) {
                                                     assert.ok(!err);
-
-                                                    RestAPI.Group.setGroupMembers(camAdminRestContext, targetPrivateGroup.id, memberships, function(err) {
-                                                        assert.ok(!err);
-                                                        callback();
-                                                    });
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -183,32 +172,63 @@ describe('Members Search', function() {
     });
 
     /**
-     * Test that verifies the member visibility of a group members search.
+     * Test that verifies the member visibility of a group members search
      */
     it('verify public group members visibility', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-        var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-        RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 var changes = {};
-                changes[jack.id] = 'member';
+                changes[jack.user.id] = 'member';
                 RestAPI.Group.setGroupMembers(doerRestContext, targetPublicGroup.id, changes, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                    // Verify results and visibility for anonymous user
+                    SearchTestsUtil.searchAll(anonymousRestContext, 'members', [targetPublicGroup.id], null, function(err, results) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        var publicUserResult = _getDocById(results, publicUserMember.id);
+                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
+                        var privateUserResult = _getDocById(results, privateUserMember.id);
+                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
+                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                        // Verify results and visibility for anonymous user
-                        SearchTestsUtil.searchAll(anonymousRestContext, 'members', [targetPublicGroup.id], null, function(err, results) {
+                        // Verify anonymous sees all.
+                        assert.ok(publicUserResult);
+                        assert.ok(loggedinUserResult);
+                        assert.ok(privateUserResult);
+                        assert.ok(privateGroupResult);
+                        assert.ok(publicGroupResult);
+
+                        // Verify user visibility. Loggedin and private should have their publicAlias swapped into the title
+                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
+                        assert.equal(loggedinUserResult.displayName, loggedinUserMember.publicAlias);
+                        assert.equal(loggedinUserResult.extra, undefined);
+                        assert.equal(loggedinUserResult._extra, undefined);
+                        assert.equal(loggedinUserResult.q_high, undefined);
+                        assert.equal(loggedinUserResult.q_low, undefined);
+                        assert.equal(loggedinUserResult.sort, undefined);
+                        assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
+                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+                        assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
+
+                        // Verify that the correct resourceTypes are set
+                        assert.equal(publicUserResult.resourceType, 'user');
+                        assert.equal(loggedinUserResult.resourceType, 'user');
+                        assert.equal(privateUserResult.resourceType, 'user');
+                        assert.equal(publicGroupResult.resourceType, 'group');
+                        assert.equal(privateGroupResult.resourceType, 'group');
+
+                        // Verify that the correct profilePaths are set
+                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
+                        assert.equal(loggedinUserResult.profilePath, undefined);
+                        assert.equal(privateUserResult.profilePath, undefined);
+                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+                        assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
+
+                        // Verify results and visibility for cross-tenant user
+                        SearchTestsUtil.searchAll(darthVader.restContext, 'members', [targetPublicGroup.id], null, function(err, results) {
                             assert.ok(!err);
                             var publicUserResult = _getDocById(results, publicUserMember.id);
                             var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
@@ -216,7 +236,7 @@ describe('Members Search', function() {
                             var privateGroupResult = _getDocById(results, privateGroupMember.id);
                             var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                            // Verify anonymous sees all.
+                            // Verify cross-tenant user sees all users
                             assert.ok(publicUserResult);
                             assert.ok(loggedinUserResult);
                             assert.ok(privateUserResult);
@@ -249,8 +269,8 @@ describe('Members Search', function() {
                             assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
                             assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                            // Verify results and visibility for cross-tenant user
-                            SearchTestsUtil.searchAll(darthVaderRestContext, 'members', [targetPublicGroup.id], null, function(err, results) {
+                            // Verify results and visibility for loggedin user
+                            SearchTestsUtil.searchAll(jane.restContext, 'members', [targetPublicGroup.id], null, function(err, results) {
                                 assert.ok(!err);
                                 var publicUserResult = _getDocById(results, publicUserMember.id);
                                 var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
@@ -258,17 +278,20 @@ describe('Members Search', function() {
                                 var privateGroupResult = _getDocById(results, privateGroupMember.id);
                                 var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                // Verify cross-tenant user sees all users
+                                // Verify user sees all members
                                 assert.ok(publicUserResult);
                                 assert.ok(loggedinUserResult);
                                 assert.ok(privateUserResult);
                                 assert.ok(privateGroupResult);
                                 assert.ok(publicGroupResult);
 
-                                // Verify user visibility. Loggedin and private should have their publicAlias swapped into the title
+                                // Verify user visibility. Private should have their publicAlias swapped into the title
                                 assert.equal(publicUserResult.displayName, publicUserMember.displayName);
-                                assert.equal(loggedinUserResult.displayName, loggedinUserMember.publicAlias);
-                                assert.equal(loggedinUserResult.extra, undefined);
+                                assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
+
+                                // There should be no extra right now because we haven't added extension properties
+                                assert.ok(!loggedinUserResult.extra);
+
                                 assert.equal(loggedinUserResult._extra, undefined);
                                 assert.equal(loggedinUserResult.q_high, undefined);
                                 assert.equal(loggedinUserResult.q_low, undefined);
@@ -286,13 +309,13 @@ describe('Members Search', function() {
 
                                 // Verify that the correct profilePaths are set
                                 assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
-                                assert.equal(loggedinUserResult.profilePath, undefined);
+                                assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
                                 assert.equal(privateUserResult.profilePath, undefined);
                                 assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
                                 assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                                // Verify results and visibility for loggedin user
-                                SearchTestsUtil.searchAll(janeRestContext, 'members', [targetPublicGroup.id], null, function(err, results) {
+                                // Verify results and visibility for member user
+                                SearchTestsUtil.searchAll(jack.restContext, 'members', [targetPublicGroup.id], null, function(err, results) {
                                     assert.ok(!err);
                                     var publicUserResult = _getDocById(results, publicUserMember.id);
                                     var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
@@ -300,7 +323,7 @@ describe('Members Search', function() {
                                     var privateGroupResult = _getDocById(results, privateGroupMember.id);
                                     var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                    // Verify user sees all members
+                                    // Verify user sees all.
                                     assert.ok(publicUserResult);
                                     assert.ok(loggedinUserResult);
                                     assert.ok(privateUserResult);
@@ -336,53 +359,7 @@ describe('Members Search', function() {
                                     assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
                                     assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                                    // Verify results and visibility for member user
-                                    SearchTestsUtil.searchAll(jackRestContext, 'members', [targetPublicGroup.id], null, function(err, results) {
-                                        assert.ok(!err);
-                                        var publicUserResult = _getDocById(results, publicUserMember.id);
-                                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
-                                        var privateUserResult = _getDocById(results, privateUserMember.id);
-                                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
-                                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
-
-                                        // Verify user sees all.
-                                        assert.ok(publicUserResult);
-                                        assert.ok(loggedinUserResult);
-                                        assert.ok(privateUserResult);
-                                        assert.ok(privateGroupResult);
-                                        assert.ok(publicGroupResult);
-
-                                        // Verify user visibility. Private should have their publicAlias swapped into the title
-                                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
-                                        assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
-
-                                        // There should be no extra right now because we haven't added extension properties
-                                        assert.ok(!loggedinUserResult.extra);
-
-                                        assert.equal(loggedinUserResult._extra, undefined);
-                                        assert.equal(loggedinUserResult.q_high, undefined);
-                                        assert.equal(loggedinUserResult.q_low, undefined);
-                                        assert.equal(loggedinUserResult.sort, undefined);
-                                        assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
-                                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
-                                        assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
-
-                                        // Verify that the correct resourceTypes are set
-                                        assert.equal(publicUserResult.resourceType, 'user');
-                                        assert.equal(loggedinUserResult.resourceType, 'user');
-                                        assert.equal(privateUserResult.resourceType, 'user');
-                                        assert.equal(publicGroupResult.resourceType, 'group');
-                                        assert.equal(privateGroupResult.resourceType, 'group');
-
-                                        // Verify that the correct profilePaths are set
-                                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
-                                        assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
-                                        assert.equal(privateUserResult.profilePath, undefined);
-                                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
-                                        assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });
@@ -396,41 +373,75 @@ describe('Members Search', function() {
      * Test that verifies that anonymous and cross-tenant users cannot see the group members of a loggedin group
      */
     it('verify loggedin group members access', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-        var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-        RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 var changes = {};
-                changes[jack.id] = 'member';
+                changes[jack.user.id] = 'member';
                 RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
-                        assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                    // Verify anonymous cannot see loggedin group
+                    SearchTestsUtil.searchAll(anonymousRestContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
+                        assert.ok(!results);
 
-                        // Verify anonymous cannot see loggedin group
-                        SearchTestsUtil.searchAll(anonymousRestContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
+                        // Verify results and visibility for cross-tenant user. Cross-tenant user cannot see memberships of 'loggedin' groups from other tenants
+                        SearchTestsUtil.searchAll(darthVader.restContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
                             assert.ok(!results);
 
-                            // Verify results and visibility for cross-tenant user. Cross-tenant user cannot see memberships of 'loggedin' groups from other tenants
-                            SearchTestsUtil.searchAll(darthVaderRestContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
-                                assert.ok(err);
-                                assert.equal(err.code, 401);
-                                assert.ok(!results);
+                            // Verify results and visibility for loggedin user
+                            SearchTestsUtil.searchAll(jane.restContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
+                                assert.ok(!err);
+                                var publicUserResult = _getDocById(results, publicUserMember.id);
+                                var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
+                                var privateUserResult = _getDocById(results, privateUserMember.id);
+                                var privateGroupResult = _getDocById(results, privateGroupMember.id);
+                                var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                // Verify results and visibility for loggedin user
-                                SearchTestsUtil.searchAll(janeRestContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
+                                // Verify all members are returned
+                                assert.ok(publicUserResult);
+                                assert.ok(loggedinUserResult);
+                                assert.ok(privateUserResult);
+                                assert.ok(privateGroupResult);
+                                assert.ok(publicGroupResult);
+
+                                // Verify user visibility. Private should have their publicAlias swapped into the title
+                                assert.equal(publicUserResult.displayName, publicUserMember.displayName);
+                                assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
+
+                                // There should be no extra right now because we haven't added extension properties
+                                assert.ok(!loggedinUserResult.extra);
+
+                                assert.equal(loggedinUserResult._extra, undefined);
+                                assert.equal(loggedinUserResult.q_high, undefined);
+                                assert.equal(loggedinUserResult.q_low, undefined);
+                                assert.equal(loggedinUserResult.sort, undefined);
+                                assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
+                                assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+                                assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
+
+                                // Verify that the correct resourceTypes are set
+                                assert.equal(publicUserResult.resourceType, 'user');
+                                assert.equal(loggedinUserResult.resourceType, 'user');
+                                assert.equal(privateUserResult.resourceType, 'user');
+                                assert.equal(publicGroupResult.resourceType, 'group');
+                                assert.equal(privateGroupResult.resourceType, 'group');
+
+                                // Verify that the correct profilePaths are set
+                                assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
+                                assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
+                                assert.equal(privateUserResult.profilePath, undefined);
+                                assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+                                assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
+
+                                // Verify results and visibility for member user
+                                SearchTestsUtil.searchAll(jack.restContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
                                     assert.ok(!err);
                                     var publicUserResult = _getDocById(results, publicUserMember.id);
                                     var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
@@ -438,7 +449,7 @@ describe('Members Search', function() {
                                     var privateGroupResult = _getDocById(results, privateGroupMember.id);
                                     var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                    // Verify all members are returned
+                                    // Verify member sees all
                                     assert.ok(publicUserResult);
                                     assert.ok(loggedinUserResult);
                                     assert.ok(privateUserResult);
@@ -474,53 +485,7 @@ describe('Members Search', function() {
                                     assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
                                     assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                                    // Verify results and visibility for member user
-                                    SearchTestsUtil.searchAll(jackRestContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
-                                        assert.ok(!err);
-                                        var publicUserResult = _getDocById(results, publicUserMember.id);
-                                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
-                                        var privateUserResult = _getDocById(results, privateUserMember.id);
-                                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
-                                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
-
-                                        // Verify member sees all
-                                        assert.ok(publicUserResult);
-                                        assert.ok(loggedinUserResult);
-                                        assert.ok(privateUserResult);
-                                        assert.ok(privateGroupResult);
-                                        assert.ok(publicGroupResult);
-
-                                        // Verify user visibility. Private should have their publicAlias swapped into the title
-                                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
-                                        assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
-
-                                        // There should be no extra right now because we haven't added extension properties
-                                        assert.ok(!loggedinUserResult.extra);
-
-                                        assert.equal(loggedinUserResult._extra, undefined);
-                                        assert.equal(loggedinUserResult.q_high, undefined);
-                                        assert.equal(loggedinUserResult.q_low, undefined);
-                                        assert.equal(loggedinUserResult.sort, undefined);
-                                        assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
-                                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
-                                        assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
-
-                                        // Verify that the correct resourceTypes are set
-                                        assert.equal(publicUserResult.resourceType, 'user');
-                                        assert.equal(loggedinUserResult.resourceType, 'user');
-                                        assert.equal(privateUserResult.resourceType, 'user');
-                                        assert.equal(publicGroupResult.resourceType, 'group');
-                                        assert.equal(privateGroupResult.resourceType, 'group');
-
-                                        // Verify that the correct profilePaths are set
-                                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
-                                        assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
-                                        assert.equal(privateUserResult.profilePath, undefined);
-                                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
-                                        assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });
@@ -534,92 +499,80 @@ describe('Members Search', function() {
      * Test that verifies only members can search the group members of a private group.
      */
     it('verify private group members access', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-        var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-        RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 var changes = {};
-                changes[jack.id] = 'member';
+                changes[jack.user.id] = 'member';
                 RestAPI.Group.setGroupMembers(doerRestContext, targetPrivateGroup.id, changes, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
-                        assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                    // Verify anonymous cannot see members of private group
+                    SearchTestsUtil.searchAll(anonymousRestContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
+                        assert.ok(!results);
 
-                        // Verify anonymous cannot see members of private group
-                        SearchTestsUtil.searchAll(anonymousRestContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
+                        // Verify cross-tenant user cannot see members of private group
+                        SearchTestsUtil.searchAll(darthVader.restContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
                             assert.ok(!results);
 
-                            // Verify cross-tenant user cannot see members of private group
-                            SearchTestsUtil.searchAll(darthVaderRestContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
+                            // Verify loggedin user cannot see members of private group
+                            SearchTestsUtil.searchAll(jane.restContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
                                 assert.ok(err);
                                 assert.equal(err.code, 401);
                                 assert.ok(!results);
 
-                                // Verify loggedin user cannot see members of private group
-                                SearchTestsUtil.searchAll(janeRestContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
-                                    assert.ok(!results);
+                                // Verify results and visibility for member user
+                                SearchTestsUtil.searchAll(jack.restContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
+                                    assert.ok(!err);
+                                    var publicUserResult = _getDocById(results, publicUserMember.id);
+                                    var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
+                                    var privateUserResult = _getDocById(results, privateUserMember.id);
+                                    var privateGroupResult = _getDocById(results, privateGroupMember.id);
+                                    var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                    // Verify results and visibility for member user
-                                    SearchTestsUtil.searchAll(jackRestContext, 'members', [targetPrivateGroup.id], null, function(err, results) {
-                                        assert.ok(!err);
-                                        var publicUserResult = _getDocById(results, publicUserMember.id);
-                                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
-                                        var privateUserResult = _getDocById(results, privateUserMember.id);
-                                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
-                                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
+                                    // Verify member sees all.
+                                    assert.ok(publicUserResult);
+                                    assert.ok(loggedinUserResult);
+                                    assert.ok(privateUserResult);
+                                    assert.ok(privateGroupResult);
+                                    assert.ok(publicGroupResult);
 
-                                        // Verify member sees all.
-                                        assert.ok(publicUserResult);
-                                        assert.ok(loggedinUserResult);
-                                        assert.ok(privateUserResult);
-                                        assert.ok(privateGroupResult);
-                                        assert.ok(publicGroupResult);
+                                    // Verify user visibility. Private should have their publicAlias swapped into the title
+                                    assert.equal(publicUserResult.displayName, publicUserMember.displayName);
+                                    assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
 
-                                        // Verify user visibility. Private should have their publicAlias swapped into the title
-                                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
-                                        assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
+                                    // There should be no extra right now because we haven't added extension properties
+                                    assert.ok(!loggedinUserResult.extra);
 
-                                        // There should be no extra right now because we haven't added extension properties
-                                        assert.ok(!loggedinUserResult.extra);
+                                    assert.equal(loggedinUserResult._extra, undefined);
+                                    assert.equal(loggedinUserResult.q_high, undefined);
+                                    assert.equal(loggedinUserResult.q_low, undefined);
+                                    assert.equal(loggedinUserResult.sort, undefined);
+                                    assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
+                                    assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+                                    assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
 
-                                        assert.equal(loggedinUserResult._extra, undefined);
-                                        assert.equal(loggedinUserResult.q_high, undefined);
-                                        assert.equal(loggedinUserResult.q_low, undefined);
-                                        assert.equal(loggedinUserResult.sort, undefined);
-                                        assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
-                                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
-                                        assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
+                                    // Verify that the correct resourceTypes are set
+                                    assert.equal(publicUserResult.resourceType, 'user');
+                                    assert.equal(loggedinUserResult.resourceType, 'user');
+                                    assert.equal(privateUserResult.resourceType, 'user');
+                                    assert.equal(publicGroupResult.resourceType, 'group');
+                                    assert.equal(privateGroupResult.resourceType, 'group');
 
-                                        // Verify that the correct resourceTypes are set
-                                        assert.equal(publicUserResult.resourceType, 'user');
-                                        assert.equal(loggedinUserResult.resourceType, 'user');
-                                        assert.equal(privateUserResult.resourceType, 'user');
-                                        assert.equal(publicGroupResult.resourceType, 'group');
-                                        assert.equal(privateGroupResult.resourceType, 'group');
+                                    // Verify that the correct profilePaths are set
+                                    assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
+                                    assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
+                                    assert.equal(privateUserResult.profilePath, undefined);
+                                    assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+                                    assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                                        // Verify that the correct profilePaths are set
-                                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
-                                        assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
-                                        assert.equal(privateUserResult.profilePath, undefined);
-                                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
-                                        assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });
@@ -633,39 +586,30 @@ describe('Members Search', function() {
      * Test that verifies when a member is removed from a group, that principal no longer turns up in the members search.
      */
     it('verify remove from group reflects in members', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-
-        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
             var changes = {};
-            changes[jack.id] = 'member';
+            changes[jack.user.id] = 'member';
             RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                // Verify jack exists for jane
+                SearchTestsUtil.searchAll(jane.restContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                    var jackDoc = _getDocById(results, jack.user.id);
+                    assert.ok(jackDoc);
 
-                    // Verify jack exists for jane
-                    SearchTestsUtil.searchAll(janeRestContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
+                    // Remove jack and verify he no longer returns in searches
+                    changes[jack.user.id] = false;
+                    RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                         assert.ok(!err);
-                        var jackDoc = _getDocById(results, jack.id);
-                        assert.ok(jackDoc);
 
-                        // Remove jack and verify he no longer returns in searches
-                        changes[jack.id] = false;
-                        RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
+                        SearchTestsUtil.searchAll(jane.restContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
                             assert.ok(!err);
-
-                            SearchTestsUtil.searchAll(janeRestContext, 'members', [targetLoggedinGroup.id], null, function(err, results) {
-                                assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
-                                assert.ok(!jackDoc);
-                                callback();
-                            });
+                            var jackDoc = _getDocById(results, jack.user.id);
+                            assert.ok(!jackDoc);
+                            return callback();
                         });
                     });
                 });
@@ -677,50 +621,42 @@ describe('Members Search', function() {
      * Test that verifies paging in the members search feed
      */
     it('verify paging works correcly in the members search', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-
-        // Create 2 users and add them as members to the group to test
-        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
 
-            RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+            var changes = {};
+            changes[jack.user.id] = 'member';
+            changes[jane.user.id] = 'member';
+            RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                 assert.ok(!err);
 
-                var changes = {};
-                changes[jack.id] = 'member';
-                changes[jane.id] = 'member';
-                RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
+                // Grab the first 2 members of the group, we will page these 2
+                SearchTestsUtil.searchRefreshed(doerRestContext, 'members', [targetLoggedinGroup.id], {'limit': 2, 'start': 0}, function(err, results) {
                     assert.ok(!err);
+                    assert.ok(results.results);
+                    assert.equal(results.results.length, 2);
 
-                    // Grab the first 2 members of the group, we will page these 2
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'members', [targetLoggedinGroup.id], {'limit': 2, 'start': 0}, function(err, results) {
+                    // Get the ids of the first 2 expected results.
+                    var firstId = results.results[0].id;
+                    var secondId = results.results[1].id;
+
+                    assert.ok(firstId);
+                    assert.ok(secondId);
+
+                    // Get the first page, ensure it is the first document. We don't need refreshing because we haven't updated anything since the previous refresh.
+                    RestAPI.Search.search(doerRestContext, 'members', [targetLoggedinGroup.id], {'limit': 1, 'start': 0}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(results.results);
-                        assert.equal(results.results.length, 2);
+                        assert.equal(results.results.length, 1);
+                        assert.equal(results.results[0].id, firstId);
 
-                        // Get the ids of the first 2 expected results.
-                        var firstId = results.results[0].id;
-                        var secondId = results.results[1].id;
-
-                        assert.ok(firstId);
-                        assert.ok(secondId);
-
-                        // Get the first page, ensure it is the first document. We don't need refreshing because we haven't updated anything since the previous refresh.
-                        RestAPI.Search.search(doerRestContext, 'members', [targetLoggedinGroup.id], {'limit': 1, 'start': 0}, function(err, results) {
+                        // Get the second page, ensure it is the second document
+                        RestAPI.Search.search(doerRestContext, 'members', [targetLoggedinGroup.id], {'limit': 1, 'start': 1}, function(err, results) {
                             assert.ok(!err);
                             assert.ok(results.results);
                             assert.equal(results.results.length, 1);
-                            assert.equal(results.results[0].id, firstId);
-
-                            // Get the second page, ensure it is the second document
-                            RestAPI.Search.search(doerRestContext, 'members', [targetLoggedinGroup.id], {'limit': 1, 'start': 1}, function(err, results) {
-                                assert.ok(!err);
-                                assert.ok(results.results);
-                                assert.equal(results.results.length, 1);
-                                assert.equal(results.results[0].id, secondId);
-                                callback();
-                            });
+                            assert.equal(results.results[0].id, secondId);
+                            return callback();
                         });
                     });
                 });

--- a/node_modules/oae-principals/tests/test-search.js
+++ b/node_modules/oae-principals/tests/test-search.js
@@ -65,47 +65,39 @@ describe('Search', function() {
          * item.
          */
         it('verify indexing without full user item', function(callback) {
-            var username = TestsUtil.generateTestUserId('user');
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create the user we will test with
-                RestAPI.User.createUser(camAdminRestContext, username, username, username, null, function(err, user) {
+                // Verify the content item exists
+                SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                     assert.ok(!err);
+                    var userDoc = _getDocById(results, jack.user.id);
+                    assert.ok(userDoc);
 
-                    // Verify the content item exists
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'user', 'q': username}, function(err, results) {
+                    // Delete the content item from the index under the hood, this is to avoid the automatic index events invalidating the test
+                    ElasticSearch.del('resource', jack.user.id, function(err) {
                         assert.ok(!err);
-                        var userDoc = _getDocById(results, user.id);
-                        assert.ok(userDoc);
 
-                        // Delete the content item from the index under the hood, this is to avoid the automatic index events invalidating the test
-                        ElasticSearch.del('resource', user.id, function(err) {
+                        // Verify the content item no longer exists
+                        SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
+                            var userDoc = _getDocById(results, jack.user.id);
+                            assert.ok(!userDoc);
 
-                            // Verify the content item no longer exists
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'user', 'q': username}, function(err, results) {
+                            // Fire off an indexing task using just the user id
+                            SearchAPI.postIndexTask('user', [{'id': jack.user.id}], {'resource': true}, function(err) {
                                 assert.ok(!err);
-                                var userDoc = _getDocById(results, user.id);
-                                assert.ok(!userDoc);
 
-                                // Fire off an indexing task using just the user id
-                                SearchAPI.postIndexTask('user', [{'id': user.id}], {'resource': true}, function(err) {
+                                // Ensure that the full content item is now back in the search index
+                                SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-
-                                    // Ensure that the full content item is now back in the search index
-                                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'user', 'q': username}, function(err, results) {
-                                        assert.ok(!err);
-                                        var userDoc = _getDocById(results, user.id);
-                                        assert.ok(userDoc);
-                                        assert.ok(_.isObject(userDoc.tenant));
-                                        assert.equal(_.keys(userDoc.tenant).length, 2);
-                                        assert.equal(userDoc.tenant.displayName, global.oaeTests.tenants.cam.displayName);
-                                        assert.equal(userDoc.tenant.alias, global.oaeTests.tenants.cam.alias);
-                                        callback();
-                                    });
+                                    var userDoc = _getDocById(results, jack.user.id);
+                                    assert.ok(userDoc);
+                                    assert.ok(_.isObject(userDoc.tenant));
+                                    assert.equal(_.keys(userDoc.tenant).length, 2);
+                                    assert.equal(userDoc.tenant.displayName, global.oaeTests.tenants.cam.displayName);
+                                    assert.equal(userDoc.tenant.alias, global.oaeTests.tenants.cam.alias);
+                                    return callback();
                                 });
                             });
                         });
@@ -120,17 +112,16 @@ describe('Search', function() {
          * item.
          */
         it('verify indexing without full group item', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
                 // Create the group we will test with
                 var groupText = TestsUtil.generateTestUserId('group');
-                RestAPI.Group.createGroup(doerRestContext, groupText, groupText, 'public', 'no', [], [], function(err, group) {
+                RestAPI.Group.createGroup(doer.restContext, groupText, groupText, 'public', 'no', [], [], function(err, group) {
                     assert.ok(!err);
 
                     // Verify the content item exists
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
                         assert.ok(!err);
                         var groupDoc = _getDocById(results, group.id);
                         assert.ok(groupDoc);
@@ -140,7 +131,7 @@ describe('Search', function() {
                             assert.ok(!err);
 
                             // Verify the content item no longer exists
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
+                            SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
                                 assert.ok(!err);
                                 var groupDoc = _getDocById(results, group.id);
                                 assert.ok(!groupDoc);
@@ -149,7 +140,7 @@ describe('Search', function() {
                                 SearchAPI.postIndexTask('group', [{'id': group.id}], {'resource': true}, function(err) {
 
                                     // Ensure that the full content item is now back in the search index
-                                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
+                                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
                                         assert.ok(!err);
                                         var groupDoc = _getDocById(results, group.id);
                                         assert.ok(groupDoc);

--- a/node_modules/oae-principals/tests/test-terms-and-conditions.js
+++ b/node_modules/oae-principals/tests/test-terms-and-conditions.js
@@ -92,14 +92,15 @@ describe('Terms and Conditions', function() {
 
                 // Not passing in acceptedTC: true should result in a 400
                 var username = TestsUtil.generateRandomText(5);
-                RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', null, function(err, userObj) {
+                var email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {}, function(err, userObj) {
                     assert.equal(err.code, 400);
-                    RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', {'acceptedTC': false}, function(err, userObj) {
+                    RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {'acceptedTC': false}, function(err, userObj) {
                         assert.equal(err.code, 400);
-                        RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', {'acceptedTC': 'wrong'}, function(err, userObj) {
+                        RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {'acceptedTC': 'wrong'}, function(err, userObj) {
                             assert.equal(err.code, 400);
 
-                            RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', {'acceptedTC': true}, function(err, userObj) {
+                            RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {'acceptedTC': true}, function(err, userObj) {
                                 assert.ok(!err);
                                 assert.equal(typeof userObj.acceptedTC, 'number');
                                 assert.ok(userObj.acceptedTC <= Date.now());

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -1662,15 +1662,9 @@ describe('Users', function() {
                         'visibility': 'private',
                         'locale': 'nl_NL'
                     };
-                    RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function (err, user) {
-                        assert.ok(!err);
-                        assert.ok(user);
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(jack.restContext, jack.user.id, updateValues, function(user) {
                         assert.ok(user.lastModified <= Date.now());
                         assert.ok(user.lastModified >= timeBeforeUpdate);
-                        assert.equal(user.visibility, 'private');
-                        assert.equal(user.displayName, 'displayname');
-                        assert.equal(user.publicAlias, 'publicalias');
-                        assert.equal(user.locale, 'nl_NL');
                         assert.equal(user.resourceType, 'user');
                         assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
                         assert.ok(!user.picture.largeUri);
@@ -1698,23 +1692,7 @@ describe('Users', function() {
                             assert.ok(!me.picture.smallUri);
                             assert.ok(me.picture.small);
 
-                            // Get the user's basic profile
-                            RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, user) {
-                                assert.ok(!err);
-                                assert.ok(user);
-                                assert.equal(user.visibility, 'private');
-                                assert.equal(user.displayName, 'displayname');
-                                assert.equal(user.publicAlias, 'publicalias');
-                                assert.equal(user.resourceType, 'user');
-                                assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
-                                assert.ok(!user.picture.largeUri);
-                                assert.ok(user.picture.large);
-                                assert.ok(!user.picture.mediumUri);
-                                assert.ok(user.picture.medium);
-                                assert.ok(!user.picture.smallUri);
-                                assert.ok(user.picture.small);
-                                return callback();
-                            });
+                            return callback();
                         });
                     });
                 });
@@ -1738,16 +1716,9 @@ describe('Users', function() {
                     'locale': 'nl_NL',
                     'emailPreference': 'weekly'
                 };
-                RestAPI.User.updateUser(globalAdminRestContext, jack.user.id, updateValues, function (err, user) {
-                    assert.ok(!err);
-                    assert.ok(user);
+                PrincipalsTestUtil.assertUpdateUserSucceeds(globalAdminRestContext, jack.user.id, updateValues, function(user) {
                     assert.ok(user.lastModified <= Date.now());
                     assert.ok(user.lastModified >= timeBeforeUpdate);
-                    assert.equal(user.visibility, 'private');
-                    assert.equal(user.displayName, 'displayname');
-                    assert.equal(user.publicAlias, 'publicalias');
-                    assert.equal(user.locale, 'nl_NL');
-                    assert.equal(user.emailPreference, 'weekly');
                     assert.equal(user.resourceType, 'user');
                     assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
 
@@ -1764,65 +1735,34 @@ describe('Users', function() {
                         assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
                         assert.equal(meObj.lastModified, user.lastModified);
 
-                        // Ensure the user's basic profile contains the updated information
-                        RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, userObj) {
-                            assert.ok(!err);
-                            assert.ok(userObj);
-                            assert.equal(userObj.visibility, 'private');
-                            assert.equal(userObj.displayName, 'displayname');
-                            assert.equal(userObj.publicAlias, 'publicalias');
-                            assert.equal(userObj.resourceType, 'user');
-                            assert.equal(userObj.emailPreference, 'weekly');
-                            assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
+                        // Verify that a tenant admin can also update a user's basic profile
+                        updateValues = {
+                            'displayName': 'Test User',
+                            'publicAlias': 'updatedalias',
+                            'visibility': 'public',
+                            'locale': 'en_GB',
+                            'emailPreference': 'daily'
+                        };
+                        PrincipalsTestUtil.assertUpdateUserSucceeds(camAdminRestContext, jack.user.id, updateValues, function(user) {
+                            assert.ok(user.lastModified <= Date.now());
+                            assert.ok(user.lastModified >= timeBeforeUpdate);
+                            assert.equal(user.resourceType, 'user');
+                            assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
 
-                            // Verify that a tenant admin can also update a user's basic profile
-                            updateValues = {
-                                'displayName': 'Test User',
-                                'publicAlias': 'updatedalias',
-                                'visibility': 'public',
-                                'locale': 'en_GB',
-                                'emailPreference': 'daily'
-                            };
-                            RestAPI.User.updateUser(camAdminRestContext, jack.user.id, updateValues, function (err, user) {
+                            // Ensure the user's `me` feed contains the updated information
+                            RestAPI.User.getMe(jack.restContext, function(err, meObj) {
                                 assert.ok(!err);
-                                assert.ok(user);
-                                assert.ok(user.lastModified <= Date.now());
-                                assert.ok(user.lastModified >= timeBeforeUpdate);
-                                assert.equal(user.visibility, 'public');
-                                assert.equal(user.displayName, 'Test User');
-                                assert.equal(user.publicAlias, 'updatedalias');
-                                assert.equal(user.locale, 'en_GB');
-                                assert.equal(user.emailPreference, 'daily');
-                                assert.equal(user.resourceType, 'user');
-                                assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
+                                assert.ok(meObj);
+                                assert.equal(meObj.visibility, 'public');
+                                assert.equal(meObj.displayName, 'Test User');
+                                assert.equal(meObj.publicAlias, 'updatedalias');
+                                assert.equal(meObj.locale, 'en_GB');
+                                assert.equal(meObj.emailPreference, 'daily');
+                                assert.equal(meObj.resourceType, 'user');
+                                assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
+                                assert.equal(meObj.lastModified, user.lastModified);
 
-                                // Ensure the user's `me` feed contains the updated information
-                                RestAPI.User.getMe(jack.restContext, function(err, meObj) {
-                                    assert.ok(!err);
-                                    assert.ok(meObj);
-                                    assert.equal(meObj.visibility, 'public');
-                                    assert.equal(meObj.displayName, 'Test User');
-                                    assert.equal(meObj.publicAlias, 'updatedalias');
-                                    assert.equal(meObj.locale, 'en_GB');
-                                    assert.equal(meObj.emailPreference, 'daily');
-                                    assert.equal(meObj.resourceType, 'user');
-                                    assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
-                                    assert.equal(meObj.lastModified, user.lastModified);
-
-                                    // Ensure the user's basic profile contains the updated information
-                                    RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, userObj) {
-                                        assert.ok(!err);
-                                        assert.ok(userObj);
-                                        assert.equal(userObj.visibility, 'public');
-                                        assert.equal(userObj.displayName, 'Test User');
-                                        assert.equal(userObj.publicAlias, 'updatedalias');
-                                        assert.equal(userObj.resourceType, 'user');
-                                        assert.equal(userObj.emailPreference, 'daily');
-                                        assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
-
-                                        return callback();
-                                    });
-                                });
+                                return callback();
                             });
                         });
                     });
@@ -1834,23 +1774,16 @@ describe('Users', function() {
          * Test that verifies that it is not possible for a user to be updated with restricted fields being set
          */
         it('verify cannot update user to tenant admin', function(callback) {
-            // Create a test user
             TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
 
-                // Update the user
-                var updateValues = {
-                    'admin:tenant': 'true'
-                };
-                RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function (err) {
-                    assert.ok(err);
+                // Verify a user cannot promote themselves to a tenant administrator
+                PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'admin:tenant': 'true'}, 400, function() {
 
-                    updateValues = {
-                        'admin:global': 'true'
-                    };
-                    RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function (err) {
-                        assert.ok(err);
+                    // Verify a user cannot promote themselves to a global administrator
+                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'admin:global': 'true'}, 400, function() {
 
+                        // Sanity check the user has not been promoted
                         PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, userObj) {
                             assert.ok(!err);
                             assert.ok(userObj);
@@ -1876,57 +1809,35 @@ describe('Users', function() {
                 assert.ok(!err);
 
                 // Ensure the user id must be a valid principal id
-                RestAPI.User.updateUser(camAdminRestContext, 'notavalidid', {'displayName': 'Casper, the friendly horse'}, function(err) {
-                    assert.ok(err);
-                    assert.equal(err.code, 400);
+                PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, 'notavalidid',  {'displayName': 'Casper, the friendly horse'}, 400, function() {
 
                     // Update a non-existing variation of a valid user id (so we know it is a valid id)
-                    RestAPI.User.updateUser(camAdminRestContext, jack.user.id+'nonexisting', {'displayName': 'Casper, the friendly horse'}, function(err) {
-                        assert.ok(err);
-                        assert.equal(err.code, 404);
+                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id + 'nonexisting',  {'displayName': 'Casper, the friendly horse'}, 401, function() {
 
                         // Try to update the user's profile without parameters
-                        var updateValues = {};
-                        RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 400);
+                        PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {}, 400, function() {
 
-                        // Try to update the user's profile as a different user
-                            updateValues = {
-                                'displayName': 'Stinky Jack LOL'
-                            };
-                            RestAPI.User.updateUser(jane.restContext, jack.user.id, updateValues, function(err) {
-                                assert.ok(err);
-                                assert.equal(err.code, 401);
+                            // Try to update the user's profile as a different user
+                            PrincipalsTestUtil.assertUpdateUserFails(jane.restContext, jack.user.id,  {'displayName': 'Stinky Jack LOL'}, 401, function() {
 
                                 // Try to update the user's profile as the anonymous user
-                                RestAPI.User.updateUser(anonymousRestContext, jack.user.id, updateValues, function(err) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
+                                PrincipalsTestUtil.assertUpdateUserFails(anonymousRestContext, jack.user.id,  {'displayName': 'Stinky Jack LOL'}, 401, function() {
 
                                      // Create user with displayName that is longer than the maximum allowed size
                                     var longDisplayName = TestsUtil.generateRandomText(100);
-                                    RestAPI.User.updateUser(jack.restContext, jack.user.id, {'displayName': longDisplayName}, function(err) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 400);
-                                        assert.ok(err.msg.indexOf('1000') > 0);
+                                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'displayName': longDisplayName}, 400, function() {
 
                                         // Create user with an empty displayName
-                                        RestAPI.User.updateUser(jack.restContext, jack.user.id, {'displayName': '\n'}, function(err) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 400);
+                                        PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'displayName': '\n'}, 400, function() {
 
                                             // Verify an incorrect visibility is invalid
-                                            RestAPI.User.updateUser(jack.restContext, jack.user.id, {'visibility': 'so incorrect'}, function(err) {
-                                                assert.equal(err.code, 400);
+                                            PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'visibility': 'so incorrect'}, 400, function() {
 
                                                 // Verify an incorrect email preference is invalid
-                                                RestAPI.User.updateUser(jack.restContext, jack.user.id, {'emailPreference': 'so incorrect'}, function(err) {
-                                                    assert.equal(err.code, 400);
+                                                PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'emailPreference': 'so incorrect'}, 400, function() {
 
                                                     // Verify an incorrect email is invalid
-                                                    RestAPI.User.updateUser(jack.restContext, jack.user.id, {'email': 'so incorrect'}, function(err) {
-                                                        assert.equal(err.code, 400);
+                                                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id, {'email': 'so incorrect'}, 400, function() {
 
                                                         // Make sure that the user's basic profile is unchanged
                                                         RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, userObj) {
@@ -1943,6 +1854,39 @@ describe('Users', function() {
                                             });
                                         });
                                     });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that users can update their email address
+         */
+        it('verify updating a user their email address', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
+                assert.ok(!err);
+
+                // Jack should not be able to use Jane's email address
+                PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id, {'email': jane.user.email}, 400, function() {
+
+                    // Jack should be able to use a new email address
+                    var email = TestsUtil.generateTestEmailAddress();
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(jack.restContext, jack.user.id, {'email': email}, function(user) {
+
+                        // Jack should be able to make a request and use the same email address (as it already belongs to him)
+                        PrincipalsTestUtil.assertUpdateUserSucceeds(jack.restContext, jack.user.id, {'email': email}, function(user) {
+
+                            // Jane shouldn't be able to use this new email address
+                            PrincipalsTestUtil.assertUpdateUserFails(jane.restContext, jane.user.id, {'email': email}, 400, function() {
+
+                                // Jane should be able to use Jack's OLD email address however
+                                // TODO: When email verification lands, this can only happen when Jack has confirmed
+                                // his new email address as that should be the moment when we remove the mapping
+                                PrincipalsTestUtil.assertUpdateUserSucceeds(jane.restContext, jane.user.id, {'email': jack.user.email}, function(user) {
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -31,7 +31,6 @@ var TZ = require('oae-util/lib/tz');
 
 var PrincipalsAPI = require('oae-principals');
 var PrincipalsTestUtil = require('oae-principals/lib/test/util');
-var User = require('oae-principals/lib/model.user').User;
 
 
 describe('Users', function() {
@@ -53,7 +52,7 @@ describe('Users', function() {
     };
 
     /**
-     * Function that will fill up the anonymous and the tenant admin context
+     * Function that will fill up the REST and admin contexts
      */
     before(function(callback) {
         // Fill up the request contexts
@@ -61,14 +60,9 @@ describe('Users', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
-
-        var globalTenant = new Tenant('admin', 'Global tenant', 'localhost:2000');
-        var mockUserId = 'u:' + globalTenant.alias + ':admin';
-        globalAdminContext = new Context(globalTenant, new User(globalTenant.alias, mockUserId, 'The global admin user', { isGlobalAdmin: true }));
-
+        globalAdminContext = TestsUtil.createGlobalAdminContext();
         anonymousGlobalRestContext = TestsUtil.createGlobalRestContext();
-
-        callback();
+        return callback();
     });
 
     describe('Full User Profile Decorators', function() {
@@ -180,29 +174,32 @@ describe('Users', function() {
                 ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, recaptchaTenantAlias, {'oae-principals/recaptcha/enabled': true}, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(recaptchaAnonymousRestContext, username, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                    var email = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(recaptchaAnonymousRestContext, username, 'password', 'Test User', email, {'visibility': 'public'}, function(err, userObj) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
                         assert.ok(!userObj);
 
-                        RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public'}, function(err, createdUser) {
+                        RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {'visibility': 'public'}, function(err, createdUser) {
                             assert.ok(!err);
                             assert.ok(createdUser);
                             assert.equal(createdUser.displayName, 'Test User');
                             assert.equal(createdUser.publicAlias, 'Test User');
                             assert.equal(createdUser.visibility, 'public');
                             assert.equal(createdUser.resourceType, 'user');
+                            assert.equal(createdUser.email, email);
                             assert.equal(createdUser.profilePath, '/user/' + createdUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(createdUser.id).resourceId);
                             var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                             // Try creating a user with the same username, which should fail
-                            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, userObj) {
+                            var email2 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email2, {}, function(err, userObj) {
                                 assert.ok(err);
                                 assert.ok(!userObj);
 
                                 // Try creating a new user as the created user
                                 var newUsername = TestsUtil.generateTestUserId();
-                                RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', email2, {}, function(err, userObj) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
 
@@ -211,13 +208,14 @@ describe('Users', function() {
                                         assert.ok(!err);
 
                                         // Try creating the user again
-                                        RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                        RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', email2, {}, function(err, userObj) {
                                             assert.ok(!err);
                                             assert.ok(userObj);
 
                                             // Create a user on a tenant as the global administrator
                                             newUsername = TestsUtil.generateTestUserId();
-                                            RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                                            var email3 = TestsUtil.generateTestEmailAddress();
+                                            RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email3, {'visibility': 'public'}, function(err, userObj) {
                                                 assert.ok(!err);
                                                 assert.ok(userObj);
                                                 assert.equal(userObj.displayName, 'Test User');
@@ -228,25 +226,27 @@ describe('Users', function() {
 
                                                 // Create a user on the global tenant as the global administrator
                                                 newUsername = TestsUtil.generateTestUserId();
-                                                RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                                                var email4 = TestsUtil.generateTestEmailAddress();
+                                                RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email4, {'visibility': 'public'}, function(err, userObj) {
                                                     assert.ok(!err);
                                                     assert.ok(userObj);
 
                                                     // Verify we cannot create a user on the global admin tenant as an anonymous user
                                                     newUsername = TestsUtil.generateTestUserId();
-                                                    RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, 'admin', newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                                    var email5 = TestsUtil.generateTestEmailAddress();
+                                                    RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, 'admin', newUsername, 'password', 'Test User', email5, {}, function(err, userObj) {
                                                         assert.ok(err);
                                                         assert.equal(err.code, 401);
 
                                                         // Verify we cannot create a user on another tenant as global admin anonymous user
-                                                        RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                                        RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email5, {}, function(err, userObj) {
                                                             assert.ok(err);
                                                             assert.equal(err.code, 401);
 
                                                             // Verify we cannot create a user on another tenant as a tenant admin. We check for a 404 because at the moment there is no
                                                             // such endpoint bound to the user tenant
                                                             newUsername = TestsUtil.generateTestUserId();
-                                                            RestAPI.User.createUserOnTenant(camAdminRestContext, global.oaeTests.tenants.gt.alias, newUsername, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                                                            RestAPI.User.createUserOnTenant(camAdminRestContext, global.oaeTests.tenants.gt.alias, newUsername, 'password', 'Test User', email5, {'visibility': 'public'}, function(err, userObj) {
                                                                 assert.ok(err);
                                                                 assert.strictEqual(err.code, 404);
                                                                 return callback();
@@ -266,13 +266,44 @@ describe('Users', function() {
         });
 
         /**
+         * Test that verifies that an email address cannot be re-used
+         */
+        it('verify an email address cannot be re-used', function(callback) {
+            var tenantAlias = TenantsTestUtil.generateTestTenantAlias();
+
+            // Disable reCaptcha on a new tenant
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantAlias, tenantAlias, function(err, recaptchaTenant) {
+                assert.ok(!err);
+                var anonymousRestContext = TestsUtil.createTenantRestContext(tenantAlias);
+
+                // Enable recaptcha for this tenant
+                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAlias, {'oae-principals/recaptcha/enabled': false}, function(err) {
+                    assert.ok(!err);
+
+                    var username1 = TestsUtil.generateTestUserId();
+                    var username2 = TestsUtil.generateTestUserId();
+                    var email = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(anonymousRestContext, username1, 'password', 'Test User', email, {'visibility': 'public'}, function(err, createdUser) {
+                        assert.ok(!err);
+                        RestAPI.User.createUser(anonymousRestContext, username2, 'password', 'Test User', email, {'visibility': 'public'}, function(err, createdUser) {
+                            assert.ok(err);
+                            assert.strictEqual(err.code, 400);
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies that the default tenant user visibility is used when creating a user without a visibility
          */
         it('verify user visibility defaults to the tenant default when created', function(callback) {
             var camTenantAlias = global.oaeTests.tenants.cam.alias;
 
             // Create a user to ensure the default user visibility of the tenant starts as public
-            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bart', null, function(err, createdUser) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bart', email1, {}, function(err, createdUser) {
                 assert.ok(!err);
                 assert.equal(createdUser.visibility, 'public');
 
@@ -281,7 +312,8 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create a user to ensure its visibility defaults to loggedin
-                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', null, function(err, createdUser) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', email2, {}, function(err, createdUser) {
                         assert.ok(!err);
                         assert.equal(createdUser.visibility, 'loggedin');
 
@@ -290,7 +322,8 @@ describe('Users', function() {
                             assert.ok(!err);
 
                             // Ensure a user's visibility can be overridden when they are created
-                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', {'visibility': 'private'}, function(err, createdUser) {
+                            var email3 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', email3, {'visibility': 'private'}, function(err, createdUser) {
                                 assert.ok(!err);
                                 assert.equal(createdUser.visibility, 'private');
                                 return callback();
@@ -308,7 +341,8 @@ describe('Users', function() {
             var camTenantAlias = global.oaeTests.tenants.cam.alias;
 
             // Create a user to ensure the default user email preference of the tenant starts as immediate
-            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bert', null, function(err, createdUser) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bert', email1, {}, function(err, createdUser) {
                 assert.ok(!err);
                 assert.equal(createdUser.emailPreference, 'immediate');
 
@@ -317,7 +351,8 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create a user to ensure its email preference defaults to weekly
-                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', null, function(err, createdUser) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', email2, {}, function(err, createdUser) {
                         assert.ok(!err);
                         assert.equal(createdUser.emailPreference, 'weekly');
 
@@ -326,7 +361,8 @@ describe('Users', function() {
                             assert.ok(!err);
 
                             // Ensure a user's email preference can be overridden when they are created
-                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', {'emailPreference': 'daily'}, function(err, createdUser) {
+                            var email3 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', email3, {'emailPreference': 'daily'}, function(err, createdUser) {
                                 assert.ok(!err);
                                 assert.equal(createdUser.emailPreference, 'daily');
                                 return callback();
@@ -346,13 +382,15 @@ describe('Users', function() {
             var lowerCasedUsername = username.toLowerCase();
             var upperCasedUsername = username.toUpperCase();
 
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, createdUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                 assert.ok(!err);
 
                 // Verify we cannot create another user account where the username only differs in the casing
-                RestAPI.User.createUser(camAdminRestContext, lowerCasedUsername, 'password', 'Test User', null, function(err) {
+                var email2 = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(camAdminRestContext, lowerCasedUsername, 'password', 'Test User', email2, {}, function(err) {
                     assert.equal(err.code, 400);
-                    RestAPI.User.createUser(camAdminRestContext, upperCasedUsername, 'password', 'Test User', null, function(err) {
+                    RestAPI.User.createUser(camAdminRestContext, upperCasedUsername, 'password', 'Test User', email2, {}, function(err) {
                         assert.equal(err.code, 400);
 
                         // When logging in with the same username but in lower case we should succesfully log in
@@ -389,7 +427,8 @@ describe('Users', function() {
             var userId3 = TestsUtil.generateTestUserId();
 
             // Create user without locale
-            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User 1', null, function(err, createdUser1) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User 1', email1, {}, function(err, createdUser1) {
                 assert.ok(!err);
                 assert.ok(createdUser1);
                 // Check that the user has been given the default locale
@@ -400,7 +439,8 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create user without locale
-                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Test User 2', null, function(err, createdUser2) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Test User 2', email2, {}, function(err, createdUser2) {
                         assert.ok(!err);
                         assert.ok(createdUser2);
                         // Check that the user has been given the new default locale
@@ -412,7 +452,10 @@ describe('Users', function() {
                             'additionalHeaders': { 'Accept-Language': 'en-us' }
                         });
                         ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-principals/recaptcha/enabled': false}, function(err) {
-                            RestAPI.User.createUser(acceptLanguageRestContext, userId3, 'password', 'Test User 3', null, function(err, createdUser3) {
+                            assert.ok(!err);
+
+                            var email3 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(acceptLanguageRestContext, userId3, 'password', 'Test User 3', email3, {}, function(err, createdUser3) {
                                 assert.ok(!err);
                                 assert.ok(createdUser3);
                                 assert.equal(createdUser3.locale, 'en_US');
@@ -527,39 +570,51 @@ describe('Users', function() {
          */
         it('verify validation', function(callback) {
             var userId = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Create user with no user id
-            RestAPI.User.createUser(camAdminRestContext, null, 'password', 'Test User', null, function(err, userObj) {
+            RestAPI.User.createUser(camAdminRestContext, null, 'password', 'Test User', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.ok(!userObj);
 
                 // Create user with empty password
-                RestAPI.User.createUser(camAdminRestContext, userId, null, 'Test User', null, function(err, userObj) {
+                RestAPI.User.createUser(camAdminRestContext, userId, null, 'Test User', email, {}, function(err, userObj) {
                     assert.ok(err);
                     assert.ok(!userObj);
 
                     // Create user with short password
-                    RestAPI.User.createUser(camAdminRestContext, userId, 'short', 'Test User', null, function(err, userObj) {
+                    RestAPI.User.createUser(camAdminRestContext, userId, 'short', 'Test User', email, {}, function(err, userObj) {
                         assert.ok(err);
                         assert.ok(!userObj);
 
                         // Create user with no display name
-                        RestAPI.User.createUser(camAdminRestContext, userId, 'password', null, null, function(err, userObj) {
+                        RestAPI.User.createUser(camAdminRestContext, userId, 'password', null, email, {}, function(err, userObj) {
                             assert.ok(err);
                             assert.ok(!userObj);
 
                             // Create user with unkown visibility setting
-                            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', {'visibility': 'unknown'}, function(err, userObj) {
+                            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', email, {'visibility': 'unknown'}, function(err, userObj) {
                                 assert.ok(err);
                                 assert.ok(!userObj);
 
                                 // Create user with displayName that is longer than the maximum allowed size
                                 var longDisplayName = TestsUtil.generateRandomText(100);
-                                RestAPI.User.createUser(camAdminRestContext, userId, 'password', longDisplayName, {}, function(err, userObj) {
+                                RestAPI.User.createUser(camAdminRestContext, userId, 'password', longDisplayName, email, {}, function(err, userObj) {
                                     assert.ok(err);
                                     assert.equal(err.code, 400);
-                                    assert.ok(!userObj);
-                                    return callback();
+
+                                    // Create a user with no email address
+                                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test user', null, {}, function(err, userObj) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 400);
+
+                                        // Create a user with an invalid email address
+                                        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test user', 'not an email address', {}, function(err, userObj) {
+                                            assert.ok(err);
+                                            assert.equal(err.code, 400);
+                                            return callback();
+                                        });
+                                    });
                                 });
                             });
                         });
@@ -613,29 +668,29 @@ describe('Users', function() {
                 assert.ok(!err);
 
                 // Import users as a global admin using a local authentication strategy
-                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password-displayname.csv'), 'local', null, function(err) {
                     assert.ok(!err);
 
                     // Verify that all imported users have been created
                     // First user in the csv
                     var nicolaasRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-zfdHliPLa', 'password1');
                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                         // User with missing first name
                         var simonRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-HlKKreaDP', 'password4');
                         RestAPI.User.getMe(simonRestContext, function(err, simonMeObj) {
-                            _verifyUser(err, simonMeObj, 'Gaeremynck', 'Gaeremynck', 'simon@test.com');
+                            _verifyUser(err, simonMeObj, 'Gaeremynck', 'Gaeremynck', 'simon@displayname.test.com');
 
                             // User with more complex display name
                             var stuartRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-IrewPDSAw', 'password5');
                             RestAPI.User.getMe(stuartRestContext, function(err, stuartMeObj) {
-                                _verifyUser(err, stuartMeObj, 'Stuart D. Freeman', 'Stuart D. Freeman', 'stuart@test.com');
+                                _verifyUser(err, stuartMeObj, 'Stuart D. Freeman', 'Stuart D. Freeman', 'stuart@displayname.test.com');
 
                                 // Last user in the csv
                                 var stephenRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-bbLwAWxpd', 'password26');
                                 RestAPI.User.getMe(stephenRestContext, function(err, stephenMeObj) {
-                                    _verifyUser(err, stephenMeObj, 'Stephen Thomas', 'Stephen Thomas', 'stephen@test.com');
+                                    _verifyUser(err, stephenMeObj, 'Stephen Thomas', 'Stephen Thomas', 'stephen@displayname.test.com');
 
                                     // Update a user's display name to be the same as its external id
                                     RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'displayName': 'user-zfdHliPLa'}, function (err, user) {
@@ -646,16 +701,16 @@ describe('Users', function() {
 
                                         // Verify that the update is reflected in the me feed
                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                            _verifyUser(err, nicolaasMeObj, 'user-zfdHliPLa', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                            _verifyUser(err, nicolaasMeObj, 'user-zfdHliPLa', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                             // Re-import the users to verify that the displayName is reverted back to the display name
                                             // provided in the CSV file. This time, the import is attempted as a tenant admin
-                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', null, function(err) {
                                                 assert.ok(!err);
 
                                                 // Verify that the display name is correctly reverted
                                                 RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                    _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                    _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                     // Update the user's display name to a different real display name
                                                     RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'displayName': 'N. Matthijs'}, function (err, user) {
@@ -666,25 +721,25 @@ describe('Users', function() {
 
                                                         // Verify that the update is reflected in the me feed
                                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                            _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                            _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                             // Re-import the users as a tenant admin to verify that the displayName is not reverted
                                                             // back to the display name provided in the CSV file
-                                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', null, function(err) {
                                                                 assert.ok(!err);
 
                                                                 // Verify that the display name has not been reverted
                                                                 RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                    _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                    _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                                     // Re-import the users using the `forceProfileUpdate` flag to verify that the displayName is reverted to
                                                                     // the display name provided in the CSV file
-                                                                    PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                                    PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', true, function(err) {
                                                                         assert.ok(!err);
 
                                                                         // Verify that the display name is correctly reverted
                                                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                                             // Update the user's display name to be the same as its external id
                                                                             RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'displayName': 'user-zfdHliPLa'}, function (err, user) {
@@ -695,12 +750,12 @@ describe('Users', function() {
 
                                                                                 // Re-import the users using the `forceProfileUpdate` flag to verify that the displayName is correctly reverted to
                                                                                 // the display name provided in the CSV file when providing the flag
-                                                                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', true, function(err) {
                                                                                     assert.ok(!err);
 
                                                                                     // Verify that the display name is correctly reverted
                                                                                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
                                                                                         return callback();
                                                                                     });
                                                                                 });
@@ -734,85 +789,42 @@ describe('Users', function() {
                 assert.ok(!err);
 
                 // Import users as a global admin using a local authentication strategy
-                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password-email.csv'), 'local', null, function(err) {
                     assert.ok(!err);
 
                     var nicolaasRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-zfdHliPLa', 'password1');
                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@email.test.com');
 
-                        // Empty a user's email address
-                        RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'email': ''}, function (err, user) {
+                        // Update the user's email address to a different real one
+                        RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'email': 'nicolaas@my.other.mail.address.com'}, function (err, user) {
                             assert.ok(!err);
                             assert.ok(user);
                             assert.equal(user.id, nicolaasMeObj.id);
-                            assert.equal(user.email, '');
+                            assert.equal(user.email, 'nicolaas@my.other.mail.address.com');
 
                             // Verify that the update is reflected in the me feed
                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', '');
+                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
 
-                                // Re-import the users to verify that the email address is reverted back to the one
-                                // provided in the CSV file. This time, the import is attempted as a tenant admin
-                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                // Re-import the users as a tenant admin to verify that the email adress is not reverted
+                                // back to the email address provided in the CSV file
+                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-email.csv'), 'local', null, function(err) {
                                     assert.ok(!err);
 
-                                    // Verify that the email address is correctly reverted
+                                    // Verify that the email address has not been reverted
                                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
 
-                                        // Update the user's email address to a different real one
-                                        RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'email': 'nicolaas@my.other.mail.address.com'}, function (err, user) {
+                                        // Re-import the users using the `forceProfileUpdate` flag to verify that the email address is reverted to
+                                        // the email address provided in the CSV file
+                                        PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-email.csv'), 'local', true, function(err) {
                                             assert.ok(!err);
-                                            assert.ok(user);
-                                            assert.equal(user.id, nicolaasMeObj.id);
-                                            assert.equal(user.email, 'nicolaas@my.other.mail.address.com');
 
-                                            // Verify that the update is reflected in the me feed
+                                            // Verify that the email address is correctly reverted
                                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
-
-                                                // Re-import the users as a tenant admin to verify that the email adress is not reverted
-                                                // back to the email address provided in the CSV file
-                                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
-                                                    assert.ok(!err);
-
-                                                    // Verify that the email address has not been reverted
-                                                    RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
-
-                                                        // Re-import the users using the `forceProfileUpdate` flag to verify that the email address is reverted to
-                                                        // the email address provided in the CSV file
-                                                        PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
-                                                            assert.ok(!err);
-
-                                                            // Verify that the email address is correctly reverted
-                                                            RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
-
-                                                                // Empty the user's email address
-                                                                RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'email': ''}, function (err, user) {
-                                                                    assert.ok(!err);
-                                                                    assert.ok(user);
-                                                                    assert.equal(user.id, nicolaasMeObj.id);
-                                                                    assert.equal(user.email, '');
-
-                                                                    // Re-import the users using the `forceProfileUpdate` flag to verify that the email address is correctly reverted to
-                                                                    // the email address provided in the CSV file when providing the flag
-                                                                    PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
-                                                                        assert.ok(!err);
-
-                                                                        // Verify that the email address is correctly reverted
-                                                                        RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
-                                                                            return callback();
-                                                                        });
-                                                                    });
-                                                                });
-                                                            });
-                                                        });
-                                                    });
-                                                });
+                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@email.test.com');
+                                                return callback();
                                             });
                                         });
                                     });
@@ -835,12 +847,12 @@ describe('Users', function() {
                 assert.ok(!err);
 
                 // Import users as a global admin using a local authentication strategy
-                PrincipalsTestUtil.importUsers(globalAdminRestContext, global.oaeTests.tenants.cam.alias, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                PrincipalsTestUtil.importUsers(globalAdminRestContext, global.oaeTests.tenants.cam.alias, getDataFileStream('users-with-password-alias.csv'), 'local', null, function(err) {
                     assert.ok(!err);
 
                     var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, 'user-zfdHliPLa', 'password1');
                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
 
                         // Empty a user's public alias
                         RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'publicAlias': ''}, function (err, user) {
@@ -851,16 +863,16 @@ describe('Users', function() {
 
                             // Verify that the update is reflected in the me feed
                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', '', 'nicolaas@test.com');
+                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', '', 'nicolaas@alias.test.com');
 
                                 // Re-import the users to verify that the public alias is reverted back to the display name
                                 // provided in the CSV file. This time, the import is attempted as a tenant admin
-                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', null, function(err) {
                                     assert.ok(!err);
 
                                     // Verify that the public alias is correctly reverted
                                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
 
                                         // Update the user's public alias to a different real one
                                         RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'publicAlias': 'Nico'}, function (err, user) {
@@ -871,25 +883,25 @@ describe('Users', function() {
 
                                             // Verify that the update is reflected in the me feed
                                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@test.com');
+                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@alias.test.com');
 
                                                 // Re-import the users as a tenant admin to verify that the public alias is not reverted
                                                 // back to the display name provided in the CSV file
-                                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', null, function(err) {
                                                     assert.ok(!err);
 
                                                     // Verify that the public alias has not been reverted
                                                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@test.com');
+                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@alias.test.com');
 
                                                         // Re-import the users using the `forceProfileUpdate` flag to verify that the public alias is reverted to
                                                         // the display name provided in the CSV file
-                                                        PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                        PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', true, function(err) {
                                                             assert.ok(!err);
 
                                                             // Verify that the public alias is correctly reverted
                                                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
 
                                                                 // Empty the user's public alias
                                                                 RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'publicAlias': ''}, function (err, user) {
@@ -900,12 +912,12 @@ describe('Users', function() {
 
                                                                     // Re-import the users using the `forceProfileUpdate` flag to verify that the public alias is correctly reverted to
                                                                     // the display name provided in the CSV file when providing the flag
-                                                                    PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                                    PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', true, function(err) {
                                                                         assert.ok(!err);
 
                                                                         // Verify that the public alias is correctly reverted
                                                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
                                                                             return callback();
                                                                         });
                                                                     });
@@ -1184,15 +1196,11 @@ describe('Users', function() {
                     assert.ok(err.code, 401);
 
                     // Create a non-admin user on a user tenant
-                    var userId = TestsUtil.generateTestUserId();
-                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', {'visibility': 'public'}, function(err, createdUser) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                         assert.ok(!err);
-                        assert.ok(createdUser);
-                        assert.equal(createdUser.displayName, 'Test User');
-                        var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
 
                         // Verify that an authenticated non-admin user on a user tenant cannot import users
-                        PrincipalsTestUtil.importUsers(userRestContext, null, getDataFileStream('users-without-password.csv'), 'cas', null, function(err) {
+                        PrincipalsTestUtil.importUsers(jack.restContext, null, getDataFileStream('users-without-password.csv'), 'cas', null, function(err) {
                             assert.ok(err);
                             assert.ok(err.code, 401);
                             callback();
@@ -1210,22 +1218,15 @@ describe('Users', function() {
          */
         it('verify get user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            var opts = {'visibility': 'public'};
-
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', opts, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                assert.equal(userObj.displayName, 'Test User');
-                assert.equal(userObj.resourceType, 'user');
-                assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
 
                 // Get the user on the global admin tenant
-                RestAPI.User.getUser(globalAdminRestContext, userObj.id, function(err, retrievedUser) {
+                RestAPI.User.getUser(globalAdminRestContext, jack.user.id, function(err, retrievedUser) {
                     assert.ok(!err);
                     assert.ok(retrievedUser);
-                    assert.equal(retrievedUser.visibility, 'public');
-                    assert.equal(retrievedUser.displayName, 'Test User');
+                    assert.equal(retrievedUser.visibility, jack.user.visibility);
+                    assert.equal(retrievedUser.displayName, jack.user.displayName);
                     assert.equal(retrievedUser.resourceType, 'user');
                     assert.equal(retrievedUser.profilePath, '/user/' + retrievedUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser.id).resourceId);
                     assert.ok(_.isObject(retrievedUser.tenant));
@@ -1234,11 +1235,11 @@ describe('Users', function() {
                     assert.equal(retrievedUser.tenant.alias, global.oaeTests.tenants.cam.alias);
 
                     // Get the user
-                    RestAPI.User.getUser(anonymousRestContext, userObj.id, function(err, retrievedUser) {
+                    RestAPI.User.getUser(anonymousRestContext, jack.user.id, function(err, retrievedUser) {
                         assert.ok(!err);
                         assert.ok(retrievedUser);
-                        assert.equal(retrievedUser.visibility, 'public');
-                        assert.equal(retrievedUser.displayName, 'Test User');
+                        assert.equal(retrievedUser.visibility, jack.user.visibility);
+                        assert.equal(retrievedUser.displayName, jack.user.displayName);
                         assert.equal(retrievedUser.resourceType, 'user');
                         assert.equal(retrievedUser.profilePath, '/user/' + retrievedUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser.id).resourceId);
                         assert.ok(_.isObject(retrievedUser.tenant));
@@ -1247,10 +1248,9 @@ describe('Users', function() {
                         assert.equal(retrievedUser.tenant.alias, global.oaeTests.tenants.cam.alias);
 
                         // Upload a profile picture for the user so we can verify its data on the user profile model
-                        var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
-                        PrincipalsTestUtil.uploadAndCropPicture(userRestContext, userObj.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
+                        PrincipalsTestUtil.uploadAndCropPicture(jack.restContext, jack.user.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
                             // Get the user
-                            RestAPI.User.getUser(anonymousRestContext, userObj.id, function(err, retrievedUser) {
+                            RestAPI.User.getUser(anonymousRestContext, jack.user.id, function(err, retrievedUser) {
                                 assert.ok(!err);
 
                                 // Ensure the profile picture URL is signed, and back-end URIs are not returned
@@ -1262,11 +1262,11 @@ describe('Users', function() {
                                 assert.ok(!retrievedUser.picture.largeUri);
 
                                 // Ensure we can get the user from the global admin tenant
-                                RestAPI.User.getUser(globalAdminRestContext, userObj.id, function(err, retrievedUser) {
+                                RestAPI.User.getUser(globalAdminRestContext, jack.user.id, function(err, retrievedUser) {
                                     assert.ok(!err);
                                     assert.ok(retrievedUser);
-                                    assert.equal(retrievedUser.visibility, 'public');
-                                    assert.equal(retrievedUser.displayName, 'Test User');
+                                    assert.equal(retrievedUser.visibility, jack.user.visibility);
+                                    assert.equal(retrievedUser.displayName, jack.user.displayName);
                                     assert.equal(retrievedUser.resourceType, 'user');
                                     assert.equal(retrievedUser.profilePath, '/user/' + retrievedUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser.id).resourceId);
                                     assert.ok(_.isObject(retrievedUser.tenant));
@@ -1336,7 +1336,7 @@ describe('Users', function() {
                                 assert.strictEqual(meData.tenant.displayName, privateTenant1.tenant.displayName);
                                 assert.strictEqual(meData.tenant.alias, privateTenant1.tenant.alias);
                                 assert.strictEqual(meData.tenant.isPrivate, true);
-                        
+
                                 return callback();
                             });
                         });
@@ -1576,7 +1576,8 @@ describe('Users', function() {
         it('verify get user by ugly username', function(callback) {
             // Create a test user with an ugly user name
             var userId1 = TestsUtil.generateTestUserId('some.weird@`user\\name');
-            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User', {'visibility': 'public'},  function(err, userObj1) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User', email1, {'visibility': 'public'},  function(err, userObj1) {
                 assert.ok(!err);
                 assert.ok(userObj1);
 
@@ -1591,7 +1592,8 @@ describe('Users', function() {
 
                     // Create a test user with a UTF-8 username
                     var userId2 = TestsUtil.generateTestUserId('стремился');
-                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Кругом шумел', {'visibility': 'public'}, function(err, userObj2) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Кругом шумел', email2, {'visibility': 'public'}, function(err, userObj2) {
                         assert.ok(!err);
                         assert.ok(userObj2);
 
@@ -1603,7 +1605,7 @@ describe('Users', function() {
                             assert.equal(retrievedUser2.displayName, 'Кругом шумел');
                             assert.equal(retrievedUser2.resourceType, 'user');
                             assert.equal(retrievedUser2.profilePath, '/user/' + retrievedUser2.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser2.id).resourceId);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1646,19 +1648,11 @@ describe('Users', function() {
          */
         it('verify update user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public', 'locale': 'en_GB', 'timezone': 'Europe/London'}, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(user);
-                assert.equal(user.visibility, 'public');
-                assert.equal(user.displayName, 'Test User');
-                assert.equal(user.locale, 'en_GB');
-                assert.equal(user.resourceType, 'user');
-                assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                 // Set a profile picture
-                PrincipalsTestUtil.uploadAndCropPicture(testUserRestContext, user.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
+                PrincipalsTestUtil.uploadAndCropPicture(jack.restContext, jack.user.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
                     var timeBeforeUpdate = Date.now();
 
                     // Update the user
@@ -1668,7 +1662,7 @@ describe('Users', function() {
                         'visibility': 'private',
                         'locale': 'nl_NL'
                     };
-                    RestAPI.User.updateUser(testUserRestContext, user.id, updateValues, function (err, user) {
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function (err, user) {
                         assert.ok(!err);
                         assert.ok(user);
                         assert.ok(user.lastModified <= Date.now());
@@ -1687,7 +1681,7 @@ describe('Users', function() {
                         assert.ok(user.picture.small);
 
                         // Get the user's me feed
-                        RestAPI.User.getMe(testUserRestContext, function(err, me) {
+                        RestAPI.User.getMe(jack.restContext, function(err, me) {
                             assert.ok(!err);
                             assert.ok(me);
                             assert.equal(me.visibility, 'private');
@@ -1705,7 +1699,7 @@ describe('Users', function() {
                             assert.ok(me.picture.small);
 
                             // Get the user's basic profile
-                            RestAPI.User.getUser(testUserRestContext, user.id, function(err, user) {
+                            RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, user) {
                                 assert.ok(!err);
                                 assert.ok(user);
                                 assert.equal(user.visibility, 'private');
@@ -1732,18 +1726,8 @@ describe('Users', function() {
          */
         it('verify admin update other user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public', 'locale': 'en_GB', 'emailPreference': 'never'}, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                assert.equal(userObj.visibility, 'public');
-                assert.equal(userObj.displayName, 'Test User');
-                assert.equal(userObj.locale, 'en_GB');
-                assert.equal(userObj.emailPreference, 'never');
-                assert.equal(userObj.resourceType, 'user');
-                assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
-
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
                 var timeBeforeUpdate = Date.now();
 
                 // Update the user as a global admin
@@ -1754,7 +1738,7 @@ describe('Users', function() {
                     'locale': 'nl_NL',
                     'emailPreference': 'weekly'
                 };
-                RestAPI.User.updateUser(globalAdminRestContext, userObj.id, updateValues, function (err, user) {
+                RestAPI.User.updateUser(globalAdminRestContext, jack.user.id, updateValues, function (err, user) {
                     assert.ok(!err);
                     assert.ok(user);
                     assert.ok(user.lastModified <= Date.now());
@@ -1768,7 +1752,7 @@ describe('Users', function() {
                     assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
 
                     // Ensure the user's `me` feed contains the updated information
-                    RestAPI.User.getMe(testUserRestContext, function(err, meObj) {
+                    RestAPI.User.getMe(jack.restContext, function(err, meObj) {
                         assert.ok(!err);
                         assert.ok(meObj);
                         assert.equal(meObj.visibility, 'private');
@@ -1781,7 +1765,7 @@ describe('Users', function() {
                         assert.equal(meObj.lastModified, user.lastModified);
 
                         // Ensure the user's basic profile contains the updated information
-                        RestAPI.User.getUser(testUserRestContext, userObj.id, function(err, userObj) {
+                        RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, userObj) {
                             assert.ok(!err);
                             assert.ok(userObj);
                             assert.equal(userObj.visibility, 'private');
@@ -1799,7 +1783,7 @@ describe('Users', function() {
                                 'locale': 'en_GB',
                                 'emailPreference': 'daily'
                             };
-                            RestAPI.User.updateUser(camAdminRestContext, userObj.id, updateValues, function (err, user) {
+                            RestAPI.User.updateUser(camAdminRestContext, jack.user.id, updateValues, function (err, user) {
                                 assert.ok(!err);
                                 assert.ok(user);
                                 assert.ok(user.lastModified <= Date.now());
@@ -1813,7 +1797,7 @@ describe('Users', function() {
                                 assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
 
                                 // Ensure the user's `me` feed contains the updated information
-                                RestAPI.User.getMe(testUserRestContext, function(err, meObj) {
+                                RestAPI.User.getMe(jack.restContext, function(err, meObj) {
                                     assert.ok(!err);
                                     assert.ok(meObj);
                                     assert.equal(meObj.visibility, 'public');
@@ -1826,7 +1810,7 @@ describe('Users', function() {
                                     assert.equal(meObj.lastModified, user.lastModified);
 
                                     // Ensure the user's basic profile contains the updated information
-                                    RestAPI.User.getUser(testUserRestContext, userObj.id, function(err, userObj) {
+                                    RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, userObj) {
                                         assert.ok(!err);
                                         assert.ok(userObj);
                                         assert.equal(userObj.visibility, 'public');
@@ -1851,38 +1835,27 @@ describe('Users', function() {
          */
         it('verify cannot update user to tenant admin', function(callback) {
             // Create a test user
-
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public', 'locale': 'en_GB'}, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                assert.equal(userObj.visibility, 'public');
-                assert.equal(userObj.displayName, 'Test User');
-                assert.equal(userObj.locale, 'en_GB');
-                assert.equal(userObj.resourceType, 'user');
-                assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
-                var testUserRestContext =  TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                 // Update the user
                 var updateValues = {
                     'admin:tenant': 'true'
                 };
-
-                RestAPI.User.updateUser(testUserRestContext, userObj.id, updateValues, function (err) {
+                RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function (err) {
                     assert.ok(err);
 
                     updateValues = {
                         'admin:global': 'true'
                     };
-
-                    RestAPI.User.updateUser(testUserRestContext, userObj.id, updateValues, function (err) {
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function (err) {
                         assert.ok(err);
 
-                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), userObj.id, function(err, userObj) {
+                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, userObj) {
                             assert.ok(!err);
                             assert.ok(userObj);
                             assert.ok(!userObj.isTenantAdmin(global.oaeTests.tenants.cam.alias), 'Expected user to not be update-able to tenant or global admin');
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1899,11 +1872,8 @@ describe('Users', function() {
          */
         it('verify validation of updating a user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                 // Ensure the user id must be a valid principal id
                 RestAPI.User.updateUser(camAdminRestContext, 'notavalidid', {'displayName': 'Casper, the friendly horse'}, function(err) {
@@ -1911,60 +1881,59 @@ describe('Users', function() {
                     assert.equal(err.code, 400);
 
                     // Update a non-existing variation of a valid user id (so we know it is a valid id)
-                    RestAPI.User.updateUser(camAdminRestContext, userObj.id+'nonexisting', {'displayName': 'Casper, the friendly horse'}, function(err) {
+                    RestAPI.User.updateUser(camAdminRestContext, jack.user.id+'nonexisting', {'displayName': 'Casper, the friendly horse'}, function(err) {
                         assert.ok(err);
                         assert.equal(err.code, 404);
 
                         // Try to update the user's profile without parameters
                         var updateValues = {};
-                        RestAPI.User.updateUser(testUserRestContext, userObj.id, updateValues, function(err) {
+                        RestAPI.User.updateUser(jack.restContext, jack.user.id, updateValues, function(err) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
 
-                            // Try to update the user's profile as a different user. Create this user first
-                            var updaterUserId = TestsUtil.generateTestUserId();
-                            RestAPI.User.createUser(camAdminRestContext, updaterUserId, 'password', 'Test User', null, function(err, updaterUserObj) {
-                                assert.ok(!err);
-                                assert.ok(updaterUserObj);
-                                var updateUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, updaterUserId, 'password');
-                                updateValues = {
-                                    'displayName': 'Stinky John LOL'
-                                };
-                                RestAPI.User.updateUser(updateUserRestContext, userObj.id, updateValues, function(err) {
+                        // Try to update the user's profile as a different user
+                            updateValues = {
+                                'displayName': 'Stinky Jack LOL'
+                            };
+                            RestAPI.User.updateUser(jane.restContext, jack.user.id, updateValues, function(err) {
+                                assert.ok(err);
+                                assert.equal(err.code, 401);
+
+                                // Try to update the user's profile as the anonymous user
+                                RestAPI.User.updateUser(anonymousRestContext, jack.user.id, updateValues, function(err) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
 
-                                    // Try to update the user's profile as the anonymous user
-                                    RestAPI.User.updateUser(anonymousRestContext, userObj.id, updateValues, function(err) {
+                                     // Create user with displayName that is longer than the maximum allowed size
+                                    var longDisplayName = TestsUtil.generateRandomText(100);
+                                    RestAPI.User.updateUser(jack.restContext, jack.user.id, {'displayName': longDisplayName}, function(err) {
                                         assert.ok(err);
-                                        assert.equal(err.code, 401);
+                                        assert.equal(err.code, 400);
+                                        assert.ok(err.msg.indexOf('1000') > 0);
 
-                                         // Create user with displayName that is longer than the maximum allowed size
-                                        var longDisplayName = TestsUtil.generateRandomText(100);
-                                        RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'displayName': longDisplayName}, function(err) {
+                                        // Create user with an empty displayName
+                                        RestAPI.User.updateUser(jack.restContext, jack.user.id, {'displayName': '\n'}, function(err) {
                                             assert.ok(err);
                                             assert.equal(err.code, 400);
-                                            assert.ok(err.msg.indexOf('1000') > 0);
 
-                                            // Create user with an empty displayName
-                                            RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'displayName': '\n'}, function(err) {
-                                                assert.ok(err);
+                                            // Verify an incorrect visibility is invalid
+                                            RestAPI.User.updateUser(jack.restContext, jack.user.id, {'visibility': 'so incorrect'}, function(err) {
                                                 assert.equal(err.code, 400);
 
-                                                // Verify an incorrect visibility is invalid
-                                                RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'visibility': 'so incorrect'}, function(err) {
+                                                // Verify an incorrect email preference is invalid
+                                                RestAPI.User.updateUser(jack.restContext, jack.user.id, {'emailPreference': 'so incorrect'}, function(err) {
                                                     assert.equal(err.code, 400);
 
-                                                    // Verify an incorrect email preference is invalid
-                                                    RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'emailPreference': 'so incorrect'}, function(err) {
+                                                    // Verify an incorrect email is invalid
+                                                    RestAPI.User.updateUser(jack.restContext, jack.user.id, {'email': 'so incorrect'}, function(err) {
                                                         assert.equal(err.code, 400);
 
                                                         // Make sure that the user's basic profile is unchanged
-                                                        RestAPI.User.getUser(testUserRestContext, userObj.id, function(err, userObj) {
+                                                        RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, userObj) {
                                                             assert.ok(!err);
                                                             assert.ok(userObj);
-                                                            assert.equal(userObj.visibility, 'public');
-                                                            assert.equal(userObj.displayName, 'Test User');
+                                                            assert.equal(userObj.visibility, jack.user.visibility);
+                                                            assert.equal(userObj.displayName, jack.user.displayName);
                                                             assert.equal(userObj.resourceType, 'user');
                                                             assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
                                                             return callback();
@@ -2017,25 +1986,27 @@ describe('Users', function() {
         };
 
         /**
-         * Test that verifies that user visibility settings work as expected. Public users should be visibile to everyone. Loggedin users should be
-         * visible to all users, other than the anonymous user. Private user should only be visibile to the user himself. When a user is not visible,
+         * Test that verifies that user visibility settings work as expected. Public users should be visible to everyone. Loggedin users should be
+         * visible to all users, other than the anonymous user. Private user should only be visible to the user himself. When a user is not visible,
          * only the display name should be visible
          */
         it('verify user permissions', function(callback) {
             // Create 2 public test users
             var jackUserId = TestsUtil.generateTestUserId();
+            var jackEmail = TestsUtil.generateTestEmailAddress();
             var jackOpts = {
                 'visibility': 'public',
                 'publicAlias': 'Jack'
             };
 
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', jackOpts, function(err, jack) {
+            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', jackEmail, jackOpts, function(err, jack) {
                 assert.ok(!err);
                 assert.ok(jack);
                 var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
                 var janeUserId = TestsUtil.generateTestUserId();
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', {'visibility': 'public'}, function(err, jane) {
+                var janeEmail = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', janeEmail, {'visibility': 'public'}, function(err, jane) {
                     assert.ok(!err);
                     assert.ok(jane);
                     var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
@@ -2095,20 +2066,12 @@ describe('Users', function() {
          * Test that verifies that a public user's profile is fully visible beyond the tenant scope.
          */
         it('verify public user is visible beyond tenant scope', function(callback) {
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', {'visibility': 'public'}, function(err, userA) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
-
-                // Create user B in GT tenant
-                RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, jane) {
                     assert.ok(!err);
-                    var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
-                    verifyProfilePermissions(restCtxB, userA.id, true, userA.displayName, undefined, 'public', callback);
+                    verifyProfilePermissions(jane.restContext, jack.user.id, true, jack.user.displayName, undefined, 'public', callback);
                 });
             });
         });
@@ -2126,13 +2089,15 @@ describe('Users', function() {
                 'visibility': 'loggedin',
                 'publicAlias': 'A user.'
             };
+            var email = TestsUtil.generateTestEmailAddress();
 
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'LoggedIn User', loggedInUserOpts, function(err, userA) {
+            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'LoggedIn User', email, loggedInUserOpts, function(err, userA) {
                 assert.ok(!err);
                 var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
                 // Create user B in GT tenant
-                RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', email, {}, function(err, userB) {
                     assert.ok(!err);
                     var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
@@ -2150,89 +2115,79 @@ describe('Users', function() {
          */
         it('verify making someone an admin', function(callback) {
             // Create 2 test users
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                assert.ok(jack);
-                var jackContext = new Context(global.oaeTests.tenants.cam, jack);
+                jack.context = new Context(global.oaeTests.tenants.cam, jack.user);
 
-                var janeUserId = TestsUtil.generateTestUserId('jane');
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
-                    assert.ok(!err);
-                    assert.ok(jane);
-                    var janeContext = new Context(global.oaeTests.tenants.cam, jane);
+                // Verify an anonymous user cannot promote someone to global admin
+                PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), jack.user.id, true, function(err) {
+                    assert.ok(err);
+                    assert.equal(err.code, 401);
 
-                    // Verify an anonymous user cannot promote someone to global admin
-                    PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), jack.id, true, function(err) {
+                    // Verify an anonymous user-tenant user cannot promote someone to tenant admin
+                    RestAPI.User.setTenantAdmin(anonymousRestContext, jack.user.id, true, function(err) {
                         assert.ok(err);
                         assert.equal(err.code, 401);
 
-                        // Verify an anonymous user-tenant user cannot promote someone to tenant admin
-                        RestAPI.User.setTenantAdmin(anonymousRestContext, jack.id, true, function(err) {
+                        // Verify that anonymous admin-tenant users cannot make users tenant-admin
+                        RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jack.user.id, true, function(err) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
 
-                            // Verify that anonymous admin-tenant users cannot make users tenant-admin
-                            RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jack.id, true, function(err) {
+                            // Jack will try to make himself and Jane an admin. Both should fail.
+                            PrincipalsAPI.setGlobalAdmin(jack.context, jack.user.id, true, function(err) {
                                 assert.ok(err);
                                 assert.equal(err.code, 401);
-
-                                // Jack will try to make himself and Jane an admin. Both should fail.
-                                PrincipalsAPI.setGlobalAdmin(jackContext, jack.id, true, function(err) {
+                                PrincipalsAPI.setGlobalAdmin(jack.context, jane.user.id, true, function(err) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
-                                    PrincipalsAPI.setGlobalAdmin(jackContext, jane.id, true, function(err) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 401);
 
-                                        // We make Jack a global admin
-                                        PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.id, true, function(err) {
+                                    // We make Jack a global admin
+                                    PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.user.id, true, function(err) {
+                                        assert.ok(!err);
+                                        // Verify that Jack is a global admin
+                                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                             assert.ok(!err);
-                                            // Verify that Jack is a global admin
-                                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                                            assert.equal(user.isGlobalAdmin(), true);
+                                            assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                                            assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                            jack.context = new Context(global.oaeTests.tenants.cam, user);
+
+                                            // Jack will make Jane a global admin
+                                            PrincipalsAPI.setGlobalAdmin(jack.context, jane.user.id, true, function(err) {
                                                 assert.ok(!err);
-                                                assert.equal(user.isGlobalAdmin(), true);
-                                                assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                                assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                var jackContext = new Context(global.oaeTests.tenants.cam, user);
 
-                                                // Jack will make Jane a global admin
-                                                PrincipalsAPI.setGlobalAdmin(jackContext, jane.id, true, function(err) {
+                                                // Check that Jane is a global admin
+                                                PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.user.id, function(err, user) {
                                                     assert.ok(!err);
+                                                    assert.equal(user.isGlobalAdmin(), true);
+                                                    assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                                                    assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
 
-                                                    // Check that Jane is a global admin
-                                                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.id, function(err, user) {
+                                                    // Revoke Jack's global admin rights
+                                                    PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.user.id, false, function(err) {
                                                         assert.ok(!err);
-                                                        assert.equal(user.isGlobalAdmin(), true);
-                                                        assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                                        assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                        janeContext = new Context(global.oaeTests.tenants.cam, user);
 
-                                                        // Revoke Jack's global admin rights
-                                                        PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.id, false, function(err) {
+                                                        // Check that Jack is no longer an admin
+                                                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                                             assert.ok(!err);
+                                                            assert.equal(user.isGlobalAdmin(), false);
+                                                            assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                            assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                            jack.context = new Context(global.oaeTests.tenants.cam, user);
 
-                                                            // Check that Jack is no longer an admin
-                                                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
-                                                                assert.ok(!err);
-                                                                assert.equal(user.isGlobalAdmin(), false);
-                                                                assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                                assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                                jackContext = new Context(global.oaeTests.tenants.cam, user);
+                                                            // Make sure that Jack can no longer revoke the admin rights of Jane
+                                                            PrincipalsAPI.setGlobalAdmin(jack.context, jane.user.id, false, function(err) {
+                                                                assert.ok(err);
+                                                                assert.equal(err.code, 401);
 
-                                                                // Make sure that Jack can no longer revoke the admin rights of Jane
-                                                                PrincipalsAPI.setGlobalAdmin(jackContext, jane.id, false, function(err) {
-                                                                    assert.ok(err);
-                                                                    assert.equal(err.code, 401);
-
-                                                                    // Make sure that Jane is still an admin
-                                                                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.id, function(err, user) {
-                                                                        assert.ok(!err);
-                                                                        assert.equal(user.isGlobalAdmin(), true);
-                                                                        assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                                                        assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                                        callback();
-                                                                    });
+                                                                // Make sure that Jane is still an admin
+                                                                PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.user.id, function(err, user) {
+                                                                    assert.ok(!err);
+                                                                    assert.equal(user.isGlobalAdmin(), true);
+                                                                    assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                                                                    assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                                    return callback();
                                                                 });
                                                             });
                                                         });
@@ -2254,77 +2209,65 @@ describe('Users', function() {
          */
         it('verify revoking admin rights access restrictions', function(callback) {
             // Create 3 test users
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, sam) {
                 assert.ok(!err);
 
-                var janeUserId = TestsUtil.generateTestUserId('jane');
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Make jane a tenant admin and verify it worked
+                RestAPI.User.setTenantAdmin(globalAdminRestContext, jane.user.id, true, function(err) {
                     assert.ok(!err);
 
-                    var samUserId = TestsUtil.generateTestUserId('sam');
-                    RestAPI.User.createUser(camAdminRestContext, samUserId, 'password', 'Jane Doe', null, function(err, sam) {
+                    PrincipalsAPI.getUser(globalAdminContext, jane.user.id, function(err, user) {
                         assert.ok(!err);
+                        assert.ok(user.isTenantAdmin(global.oaeTests.tenants.cam.alias));
 
-                        // Make jane a tenant admin and verify it worked
-                        RestAPI.User.setTenantAdmin(globalAdminRestContext, jane.id, true, function(err) {
+                        // Make sam a global admin and verify it worked
+                        PrincipalsAPI.setGlobalAdmin(globalAdminContext, sam.user.id, true, function(err) {
                             assert.ok(!err);
 
-                            PrincipalsAPI.getUser(globalAdminContext, jane.id, function(err, jane) {
+                            PrincipalsAPI.getUser(globalAdminContext, sam.user.id, function(err, user) {
                                 assert.ok(!err);
-                                assert.ok(jane.isTenantAdmin(global.oaeTests.tenants.cam.alias));
+                                assert.ok(user.isGlobalAdmin());
 
-                                // Make sam a global admin and verify it worked
-                                PrincipalsAPI.setGlobalAdmin(globalAdminContext, sam.id, true, function(err) {
+                                // Get jack's API user so we can build an API context later
+                                PrincipalsAPI.getUser(globalAdminContext, jack.user.id, function(err, user) {
                                     assert.ok(!err);
+                                    jack.context = new Context(global.oaeTests.tenants.cam, user);
 
-                                    PrincipalsAPI.getUser(globalAdminContext, sam.id, function(err, sam) {
-                                        assert.ok(!err);
-                                        assert.ok(sam.isGlobalAdmin());
+                                    // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke jane's tenant-admin rights
+                                    RestAPI.User.setTenantAdmin(anonymousRestContext, jane.user.id, false, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
 
-                                        // Get jack's API user so we can build an API context later
-                                        PrincipalsAPI.getUser(globalAdminContext, jack.id, function(err, jack) {
-                                            assert.ok(!err);
-                                            var jackCtx = new Context(global.oaeTests.tenants.cam, jack);
-                                            var jackRestCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
+                                        RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jane.user.id, false, function(err) {
+                                            assert.ok(err);
+                                            assert.equal(err.code, 401);
 
-                                            // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke jane's tenant-admin rights
-                                            RestAPI.User.setTenantAdmin(anonymousRestContext, jane.id, false, function(err) {
+                                            RestAPI.User.setTenantAdmin(jack.restContext, jane.user.id, false, function(err) {
                                                 assert.ok(err);
                                                 assert.equal(err.code, 401);
 
-                                                RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jane.id, false, function(err) {
+                                                // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke sam's global-admin rights
+                                                PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), sam.user.id, false, function(err) {
                                                     assert.ok(err);
                                                     assert.equal(err.code, 401);
 
-                                                    RestAPI.User.setTenantAdmin(jackRestCtx, jane.id, false, function(err) {
+                                                    PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.global), sam.user.id, false, function(err) {
                                                         assert.ok(err);
                                                         assert.equal(err.code, 401);
 
-                                                        // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke sam's global-admin rights
-                                                        PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), sam.id, false, function(err) {
+                                                        PrincipalsAPI.setGlobalAdmin(jack.context, sam.user.id, false, function(err) {
                                                             assert.ok(err);
                                                             assert.equal(err.code, 401);
 
-                                                            PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.global), sam.id, false, function(err) {
-                                                                assert.ok(err);
-                                                                assert.equal(err.code, 401);
+                                                            // Ensure jane and sam have their admin rights
+                                                            PrincipalsAPI.getUser(globalAdminContext, jane.user.id, function(err, user) {
+                                                                assert.ok(!err);
+                                                                assert.ok(user.isTenantAdmin(global.oaeTests.tenants.cam.alias));
 
-                                                                PrincipalsAPI.setGlobalAdmin(jackCtx, sam.id, false, function(err) {
-                                                                    assert.ok(err);
-                                                                    assert.equal(err.code, 401);
-
-                                                                    // Ensure jane and sam have their admin rights
-                                                                    PrincipalsAPI.getUser(globalAdminContext, jane.id, function(err, jane) {
-                                                                        assert.ok(!err);
-                                                                        assert.ok(jane.isTenantAdmin(global.oaeTests.tenants.cam.alias));
-
-                                                                        PrincipalsAPI.getUser(globalAdminContext, sam.id, function(err, sam) {
-                                                                            assert.ok(!err);
-                                                                            assert.ok(sam.isGlobalAdmin());
-                                                                            return callback();
-                                                                        });
-                                                                    });
+                                                                PrincipalsAPI.getUser(globalAdminContext, sam.user.id, function(err, user) {
+                                                                    assert.ok(!err);
+                                                                    assert.ok(user.isGlobalAdmin());
+                                                                    return callback();
                                                                 });
                                                             });
                                                         });
@@ -2346,34 +2289,31 @@ describe('Users', function() {
          */
         it('verify tenant admin restrictions', function(callback) {
             // Create a test user
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(jack);
-                var jackContext = new Context(global.oaeTests.tenants.cam, jack);
 
                 // We make Jack a tenant admin
-                RestAPI.User.setTenantAdmin(globalAdminRestContext, jack.id, true, function(err) {
+                RestAPI.User.setTenantAdmin(globalAdminRestContext, jack.user.id, true, function(err) {
                     assert.ok(!err);
                     // Verify that Jack is a tenant admin
-                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                         assert.ok(!err);
                         assert.equal(user.isGlobalAdmin(), false);
                         assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
                         assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
-                        jackContext = new Context(global.oaeTests.tenants.cam, user);
+                        jack.context = new Context(global.oaeTests.tenants.cam, user);
 
                         // Jack will try to make herself a global admin. This should fail
-                        PrincipalsAPI.setGlobalAdmin(jackContext, jack.id, true, function(err) {
+                        PrincipalsAPI.setGlobalAdmin(jack.context, jack.user.id, true, function(err) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
                             // Verify that Jack is not a global admin
-                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                 assert.ok(!err);
                                 assert.equal(user.isGlobalAdmin(), false);
                                 assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
                                 assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -2412,75 +2352,64 @@ describe('Users', function() {
             // We create 3 users: jack, jane and joe. Jack and Joe are in tenant A, Jane is in tenant B.
             // We promote John to a tenant admin (for A) and try to update the profile info for Jack and Jane.
             // It should only work for Jack.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, joe) {
                 assert.ok(!err);
-                assert.ok(jack);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                var joeUserId = TestsUtil.generateTestUserId('joe');
-                RestAPI.User.createUser(camAdminRestContext, joeUserId, 'password', 'Joe Doe', null, function(err, joe) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, jane) {
                     assert.ok(!err);
-                    assert.ok(joe);
-                    var joeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, joeUserId, 'password');
 
-                    var janeUserId = TestsUtil.generateTestUserId('jane');
-                    RestAPI.User.createUser(gtAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                    // Make Jack a tenant admin
+                    RestAPI.User.setTenantAdmin(camAdminRestContext, jack.user.id, true, function(err) {
                         assert.ok(!err);
-                        assert.ok(jane);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, janeUserId, 'password');
 
-                        // Make Jack a tenant admin
-                        RestAPI.User.setTenantAdmin(camAdminRestContext, jack.id, true, function(err) {
+                        // Verify that Jack is a tenant admin
+                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                             assert.ok(!err);
-                            // Verify that Jack is a tenant admin
-                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                            assert.equal(user.isGlobalAdmin(), false);
+                            assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                            assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
+
+                            // Update Joe
+                            var updateData = {
+                                'locale': 'en_CA',
+                                'displayName': 'Foo Bar'
+                            };
+                            RestAPI.User.updateUser(jack.restContext, joe.user.id, updateData, function(err) {
                                 assert.ok(!err);
-                                assert.equal(user.isGlobalAdmin(), false);
-                                assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
-                                var jackContext = new Context(global.oaeTests.tenants.cam, user);
-
-                                // Update Joe
-                                var updateData = {
-                                    'locale': 'en_CA',
-                                    'displayName': 'Foo Bar'
-                                };
-                                RestAPI.User.updateUser(jackRestContext, joe.id, updateData, function(err) {
+                                // Verify that the update has worked
+                                RestAPI.User.getMe(joe.restContext, function(err, meObj) {
                                     assert.ok(!err);
-                                    // Verify that the update has worked
-                                    RestAPI.User.getMe(joeRestContext, function(err, meObj) {
-                                        assert.ok(!err);
-                                        assert.ok(meObj);
-                                        assert.equal(meObj.displayName, 'Foo Bar');
-                                        assert.equal(meObj.locale, 'en_CA');
-                                        assert.equal(meObj.resourceType, 'user');
-                                        assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
+                                    assert.ok(meObj);
+                                    assert.equal(meObj.displayName, 'Foo Bar');
+                                    assert.equal(meObj.locale, 'en_CA');
+                                    assert.equal(meObj.resourceType, 'user');
+                                    assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
 
-                                        // Try to update Jane
-                                        RestAPI.User.updateUser(jackRestContext, jane.id, updateData, function(err) {
-                                            assert.ok(err);
-                                            // Verify that the update has not happened
-                                            RestAPI.User.getMe(janeRestContext, function(err, meObj) {
+                                    // Try to update Jane
+                                    RestAPI.User.updateUser(jack.restContext, jane.user.id, updateData, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
+
+                                        // Verify that the update has not happened
+                                        RestAPI.User.getMe(jane.restContext, function(err, meObj) {
+                                            assert.ok(!err);
+                                            assert.ok(meObj);
+                                            assert.equal(meObj.displayName, jane.user.displayName);
+                                            assert.equal(meObj.locale, jane.user.locale);
+                                            assert.equal(meObj.resourceType, 'user');
+                                            assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
+
+                                            // Disable Jack's admin status
+                                            RestAPI.User.setTenantAdmin(camAdminRestContext, jack.user.id, false, function(err) {
                                                 assert.ok(!err);
-                                                assert.ok(meObj);
-                                                assert.equal(meObj.displayName, 'Jane Doe');
-                                                assert.equal(meObj.locale, 'en_GB');
-                                                assert.equal(meObj.resourceType, 'user');
-                                                assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
 
-                                                // Disable Jack's admin status
-                                                RestAPI.User.setTenantAdmin(camAdminRestContext, jack.id, false, function(err) {
+                                                // Verify he is no longer an admin
+                                                PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                                     assert.ok(!err);
-
-                                                    // Verify he is no longer an admin
-                                                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
-                                                        assert.ok(!err);
-                                                        assert.equal(user.isGlobalAdmin(), false);
-                                                        assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                        assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                        callback();
-                                                    });
+                                                    assert.equal(user.isGlobalAdmin(), false);
+                                                    assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                    assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                    return callback();
                                                 });
                                             });
                                         });

--- a/node_modules/oae-principals/tests/test-util.js
+++ b/node_modules/oae-principals/tests/test-util.js
@@ -37,15 +37,14 @@ describe('Principals', function() {
     before(function(callback) {
         // Fill up global admin rest context
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+
         // Fill up the rest context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            // Add the full user id onto the REST context for use inside of this test
-            johnRestContext.id = createdUser.id;
-            // We get John's me feed so he is logged in for creating users and groups
-            RestAPI.User.getMe(johnRestContext, function() {
-                callback();
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+            assert.ok(!err);
+            johnRestContext = john.restContext;
+            RestAPI.User.getMe(johnRestContext, function(err) {
+                assert.ok(!err);
+                return callback();
             });
         });
     });
@@ -74,7 +73,8 @@ describe('Principals', function() {
                         }
                     });
                 } else {
-                    RestAPI.User.createUser(camAdminRestContext, principalId, 'password', metadata, null, function(err, userObj) {
+                    var email = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, principalId, 'password', metadata, email, {}, function(err, userObj) {
                         assert.ok(!err);
                         var userContext = new Context(global.oaeTests.tenants.cam, userObj);
                         createdPrincipals[identifier] = userContext;
@@ -213,8 +213,11 @@ describe('Principals', function() {
             assert.ok(!PrincipalsUtil.isUser(id));
         });
 
+        /**
+         * Test that verifies the createUpdatedUser function
+         */
         it('verify createUpdatedUser', function() {
-            var source = new User('camtest', 'u:camtest:sourceId', 'sourceDisplayName', {
+            var source = new User('camtest', 'u:camtest:sourceId', 'sourceDisplayName', 'sourceEmail', {
                 'visibility': 'sourceVisibility',
                 'locale': 'sourceLocale',
                 'publicAlias': 'sourcePublicAlias'

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -184,14 +184,13 @@ describe('General Search', function() {
          * Test that verifies the search index is updated when a group is updated.
          */
         it('verify index updated group', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                TestsUtil.generateTestGroups(doerRestContext, 1, function(xyzTeam) {
+                TestsUtil.generateTestGroups(doer.restContext, 1, function(xyzTeam) {
 
                     // Verify that the group does not match on the term 'testverifyindexupdatedgroup', this is to sanity check the search before searching for a valid post-update hit later
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': xyzTeam.group.displayName}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': xyzTeam.group.displayName}, function(err, results) {
                         assert.ok(!err);
 
                         var doc = _getDocById(results, xyzTeam.group.id);
@@ -202,11 +201,11 @@ describe('General Search', function() {
 
                         // Update name match the term
                         var displayName = 'Team testverifyindexupdatedgroup' + xyzTeam.group.id;
-                        RestAPI.Group.updateGroup(doerRestContext, xyzTeam.group.id, {'displayName': displayName}, function(err) {
+                        RestAPI.Group.updateGroup(doer.restContext, xyzTeam.group.id, {'displayName': displayName}, function(err) {
                             assert.ok(!err);
 
                             // Verify that the group now appears with the search term 'testverifyindexupdatedgroup'
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': displayName}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': displayName}, function(err, results) {
                                 assert.ok(!err);
 
                                 var doc = _getDocById(results, xyzTeam.group.id);
@@ -229,15 +228,14 @@ describe('General Search', function() {
          * Test that verifies that a content item can be searched after it has been created.
          */
         it('verify index created content', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Verify search term Apereo matches the document
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'Apereo'}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'Apereo'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
                         callback();
@@ -250,24 +248,23 @@ describe('General Search', function() {
          * Test that verifies the search index is updated after a content item is updated.
          */
         it('verify index updated content', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Verify search term OAE does not match the content
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(!_getDocById(results, content.id));
 
                         // Update the content
-                        RestAPI.Content.updateContent(doerRestContext, content.id, {'displayName': 'OAE Project'}, function(err) {
+                        RestAPI.Content.updateContent(doer.restContext, content.id, {'displayName': 'OAE Project'}, function(err) {
                             assert.ok(!err);
 
                             // Verify OAE now matches the updated content item
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(_getDocById(results, content.id));
                                 callback();
@@ -588,65 +585,63 @@ describe('General Search', function() {
             };
 
             // Ensure at least one user, group and content item exists
-            var uniqueString = TestsUtil.generateTestUserId('resourcetype-test');
-            RestAPI.User.createUser(camAdminRestContext, uniqueString, 'password', uniqueString, null, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, uniqueString, 'password');
 
-                RestAPI.Group.createGroup(jackRestContext, uniqueString, uniqueString, 'public', 'no', [], [], function(err, group) {
+                RestAPI.Group.createGroup(jack.restContext, jack.user.displayName, jack.user.displayName, 'public', 'no', [], [], function(err, group) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(jackRestContext, uniqueString, uniqueString, 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                    RestAPI.Content.createLink(jack.restContext, jack.user.displayName, jack.user.displayName, 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                         assert.ok(!err);
 
                         // Verify unspecified resourceTypes searches all
-                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
                             _verifyHasResourceTypes(results, true, true, true);
 
                             // Verify empty resourceTypes searches all
-                            RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': '', 'q': uniqueString}, function(err, results) {
+                            RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': '', 'q': jack.user.displayName}, function(err, results) {
                                 assert.ok(!err);
                                 _verifyHasResourceTypes(results, true, true, true);
 
                                 // Verify non-matching single resource type returns nothing
-                                RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'not-matching-anything', 'q': uniqueString}, function(err, results) {
+                                RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'not-matching-anything', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
                                     assert.equal(results.results.length, 0);
 
                                     // Verify each single resourceType searches just that one
-                                    RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
                                         _verifyHasResourceTypes(results, true, false, false);
 
-                                        RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
+                                        RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
                                             _verifyHasResourceTypes(results, false, true, false);
 
-                                            RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'content'}, function(err, results) {
+                                            RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'content'}, function(err, results) {
                                                 assert.ok(!err);
                                                 _verifyHasResourceTypes(results, false, false, true);
 
                                                 // Verify searching 2 returns just the 2 types
-                                                RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['group', 'content'], 'q': uniqueString}, function(err, results) {
+                                                RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['group', 'content'], 'q': jack.user.displayName}, function(err, results) {
                                                     assert.ok(!err);
                                                     _verifyHasResourceTypes(results, false, true, true);
 
                                                     // Verify searching one with garbage commas returns just the one
-                                                    RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['', '', 'content', ''], 'q': uniqueString}, function(err, results) {
+                                                    RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['', '', 'content', ''], 'q': jack.user.displayName}, function(err, results) {
                                                         assert.ok(!err);
                                                         _verifyHasResourceTypes(results, false, false, true);
 
                                                         // Verify searching two with garbage commas returns just the two
-                                                        RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['', '', 'user', 'content', '', ''], 'q': uniqueString}, function(err, results) {
+                                                        RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['', '', 'user', 'content', '', ''], 'q': jack.user.displayName}, function(err, results) {
                                                             assert.ok(!err);
                                                             _verifyHasResourceTypes(results, true, false, true);
 
                                                             // Verify searching with garbage commas and non-matching values still returns by the valid resources types
-                                                            RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['', '', 'non-matching', '', 'group', 'user'], 'q': uniqueString}, function(err, results) {
+                                                            RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['', '', 'non-matching', '', 'group', 'user'], 'q': jack.user.displayName}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 _verifyHasResourceTypes(results, true, true, false);
-                                                                callback();
+                                                                return callback();
                                                             });
                                                         });
                                                     });
@@ -669,19 +664,18 @@ describe('General Search', function() {
          * Test that verifies that the 'start' property properly pages search results
          */
         it('verify search paging', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
                 // Make sure we have at least 2 content items to page with, their actual information is not important for this test
-                RestAPI.Content.createLink(doerRestContext, 'OAE Project', 'Link to OAE Project Website', 'public', 'http://www.oaeproject.org', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(doer.restContext, 'OAE Project', 'Link to OAE Project Website', 'public', 'http://www.oaeproject.org', [], [], [], function(err, link) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(doerRestContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         // Search once and grab the first document id
-                        SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'limit': 1}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'limit': 1}, function(err, results) {
                             assert.ok(!err);
                             assert.ok(results);
                             assert.ok(results.results);
@@ -691,7 +685,7 @@ describe('General Search', function() {
                             assert.ok(firstDocId);
 
                             // Perform the same search, but with start=0, and make sure the first document is still the same. Verifies default paging
-                            RestAPI.Search.search(doerRestContext, 'general', null, {'limit': 1, 'start': 0}, function(err, results) {
+                            RestAPI.Search.search(doer.restContext, 'general', null, {'limit': 1, 'start': 0}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(results);
                                 assert.ok(results.results);
@@ -699,7 +693,7 @@ describe('General Search', function() {
                                 assert.equal(results.results[0].id, firstDocId);
 
                                 // Search again with start=1 and verify the first document id of the previous search is not the same as the first document id of this search
-                                RestAPI.Search.search(doerRestContext, 'general', null, {'limit': 1, 'start': 1}, function(err, results) {
+                                RestAPI.Search.search(doer.restContext, 'general', null, {'limit': 1, 'start': 1}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(results);
                                     assert.ok(results.results);
@@ -709,7 +703,7 @@ describe('General Search', function() {
                                     assert.ok(secondDocId);
 
                                     assert.notEqual(firstDocId, secondDocId);
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });
@@ -1041,26 +1035,25 @@ describe('General Search', function() {
          * Test that verifies deleted content is removed from the search index.
          */
         it('verify deleted content is unsearchable', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var uniqueString = TestsUtil.generateTestUserId('unsearchable-content');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, uniqueString, uniqueString, 'public', 'http://www.oaeproject.org', [], [], [], function(err, content) {
+                var uniqueString = TestsUtil.generateTestUserId('unsearchable-content');
+                RestAPI.Content.createLink(doer.restContext, uniqueString, uniqueString, 'public', 'http://www.oaeproject.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Verify search term Apereo does not match the content
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
 
-                        RestAPI.Content.deleteContent(doerRestContext, content.id, function(err) {
+                        RestAPI.Content.deleteContent(doer.restContext, content.id, function(err) {
                             assert.ok(!err);
 
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(!_getDocById(results, content.id));
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -1072,50 +1065,73 @@ describe('General Search', function() {
          * Test that verifies that public content is searchable by all users.
          */
         it('verify public content searchable by everyone', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('public-searchable-content');
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                        assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
+                    TestsUtil.generateTestGroups(doer.restContext, 5, function() {
+                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                        // Give jack access via group
+                        TestsUtil.generateGroupHierarchy(doer.restContext, groupIds, 'member', function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            TestsUtil.generateTestGroups(doerRestContext, 5, function() {
-                                var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+                            TestsUtil.generateGroupHierarchy(doer.restContext, [groupIds[4], jack.user.id], 'member', function(err) {
+                                assert.ok(!err);
 
-                                // Give jack access via group
-                                TestsUtil.generateGroupHierarchy(doerRestContext, groupIds, 'member', function(err) {
+                                var uniqueString = TestsUtil.generateTestUserId('public-searchable-content');
+                                RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
                                     assert.ok(!err);
 
-                                    TestsUtil.generateGroupHierarchy(doerRestContext, [groupIds[4], jack.id], 'member', function(err) {
+                                    // Verify anonymous can see it
+                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                         assert.ok(!err);
 
-                                        RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
+                                        var contentDoc = _getDocById(results, contentObj.id);
+                                        assert.ok(contentDoc);
+                                        assert.equal(contentDoc.resourceSubType, 'link');
+                                        assert.equal(contentDoc.displayName, contentObj.displayName);
+                                        assert.equal(contentDoc.tenantAlias, 'camtest');
+                                        assert.equal(contentDoc.visibility, contentObj.visibility);
+                                        assert.equal(contentDoc.resourceType, 'content');
+                                        assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                        assert.equal(contentDoc.id, contentObj.id);
+                                        assert.equal(contentDoc._extra, undefined);
+                                        assert.equal(contentDoc._type, undefined);
+                                        assert.equal(contentDoc.q_high, undefined);
+                                        assert.equal(contentDoc.q_low, undefined);
+                                        assert.equal(contentDoc.sort, undefined);
+
+                                        // Verify tenant admin can see it
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                             assert.ok(!err);
 
-                                            // Verify anonymous can see it
-                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                            var contentDoc = _getDocById(results, contentObj.id);
+                                            assert.ok(contentDoc);
+                                            assert.equal(contentDoc.resourceSubType, 'link');
+                                            assert.equal(contentDoc.displayName, contentObj.displayName);
+                                            assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                            assert.equal(contentDoc.visibility, contentObj.visibility);
+                                            assert.equal(contentDoc.resourceType, 'content');
+                                            assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                            assert.equal(contentDoc.id, contentObj.id);
+                                            assert.equal(contentDoc._extra, undefined);
+                                            assert.equal(contentDoc._type, undefined);
+                                            assert.equal(contentDoc.q_high, undefined);
+                                            assert.equal(contentDoc.q_low, undefined);
+                                            assert.equal(contentDoc.sort, undefined);
+
+                                            // Verify same-tenant loggedin user can see it
+                                            SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                 assert.ok(!err);
 
                                                 var contentDoc = _getDocById(results, contentObj.id);
                                                 assert.ok(contentDoc);
                                                 assert.equal(contentDoc.resourceSubType, 'link');
                                                 assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                assert.equal(contentDoc.tenantAlias, 'camtest');
+                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
                                                 assert.equal(contentDoc.visibility, contentObj.visibility);
                                                 assert.equal(contentDoc.resourceType, 'content');
                                                 assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
@@ -1126,8 +1142,8 @@ describe('General Search', function() {
                                                 assert.equal(contentDoc.q_low, undefined);
                                                 assert.equal(contentDoc.sort, undefined);
 
-                                                // Verify tenant admin can see it
-                                                SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                // Verify same-tenant loggedin user can see it
+                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                     assert.ok(!err);
 
                                                     var contentDoc = _getDocById(results, contentObj.id);
@@ -1145,8 +1161,8 @@ describe('General Search', function() {
                                                     assert.equal(contentDoc.q_low, undefined);
                                                     assert.equal(contentDoc.sort, undefined);
 
-                                                    // Verify same-tenant loggedin user can see it
-                                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                    // Verify permitted user can see it
+                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                         assert.ok(!err);
 
                                                         var contentDoc = _getDocById(results, contentObj.id);
@@ -1164,47 +1180,7 @@ describe('General Search', function() {
                                                         assert.equal(contentDoc.q_low, undefined);
                                                         assert.equal(contentDoc.sort, undefined);
 
-                                                        // Verify same-tenant loggedin user can see it
-                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                            assert.ok(!err);
-
-                                                            var contentDoc = _getDocById(results, contentObj.id);
-                                                            assert.ok(contentDoc);
-                                                            assert.equal(contentDoc.resourceSubType, 'link');
-                                                            assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                            assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                            assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                            assert.equal(contentDoc.resourceType, 'content');
-                                                            assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                            assert.equal(contentDoc.id, contentObj.id);
-                                                            assert.equal(contentDoc._extra, undefined);
-                                                            assert.equal(contentDoc._type, undefined);
-                                                            assert.equal(contentDoc.q_high, undefined);
-                                                            assert.equal(contentDoc.q_low, undefined);
-                                                            assert.equal(contentDoc.sort, undefined);
-
-                                                            // Verify permitted user can see it
-                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                assert.ok(!err);
-
-                                                                var contentDoc = _getDocById(results, contentObj.id);
-                                                                assert.ok(contentDoc);
-                                                                assert.equal(contentDoc.resourceSubType, 'link');
-                                                                assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                assert.equal(contentDoc.resourceType, 'content');
-                                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                assert.equal(contentDoc.id, contentObj.id);
-                                                                assert.equal(contentDoc._extra, undefined);
-                                                                assert.equal(contentDoc._type, undefined);
-                                                                assert.equal(contentDoc.q_high, undefined);
-                                                                assert.equal(contentDoc.q_low, undefined);
-                                                                assert.equal(contentDoc.sort, undefined);
-
-                                                                callback();
-                                                            });
-                                                        });
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -1222,53 +1198,172 @@ describe('General Search', function() {
          * Test that verifies loggedin content items are only search by users authenticated to the content item's parent tenant.
          */
         it('verify loggedin content search not searchable by anonymous or cross-tenant', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('loggedin-searchable-content');
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                        assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
+                    TestsUtil.generateTestGroups(doer.restContext, 5, function() {
+                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                        // Give jack access via group
+                        TestsUtil.generateGroupHierarchy(doer.restContext, groupIds, 'member', function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            TestsUtil.generateTestGroups(doerRestContext, 5, function() {
-                                var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+                            TestsUtil.generateGroupHierarchy(doer.restContext, [groupIds[4], jack.user.id], 'member', function(err) {
+                                assert.ok(!err);
 
-                                // Give jack access via group
-                                TestsUtil.generateGroupHierarchy(doerRestContext, groupIds, 'member', function(err) {
+                                var uniqueString = TestsUtil.generateTestUserId('loggedin-searchable-content');
+                                RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 1', 'loggedin', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
                                     assert.ok(!err);
 
-                                    TestsUtil.generateGroupHierarchy(doerRestContext, [groupIds[4], jack.id], 'member', function(err) {
+                                    // Verify anonymous cannot see it
+                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                         assert.ok(!err);
+                                        assert.ok(!_getDocById(results, contentObj.id));
 
-                                        RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 1', 'loggedin', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
+                                        // Verify cross-tenant user cannot see it
+                                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
                                             assert.ok(!err);
+                                            assert.ok(!_getDocById(results, contentObj.id));
 
-                                            // Verify anonymous cannot see it
-                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                            // Verify tenant admin can see it
+                                            SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.ok(!_getDocById(results, contentObj.id));
 
-                                                // Verify cross-tenant user cannot see it
-                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                                var contentDoc = _getDocById(results, contentObj.id);
+                                                assert.ok(contentDoc);
+                                                assert.equal(contentDoc.resourceSubType, 'link');
+                                                assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                assert.equal(contentDoc.resourceType, 'content');
+                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                assert.equal(contentDoc.id, contentObj.id);
+                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                assert.equal(contentDoc._extra, undefined);
+                                                assert.equal(contentDoc._type, undefined);
+                                                assert.equal(contentDoc.q_high, undefined);
+                                                assert.equal(contentDoc.q_low, undefined);
+                                                assert.equal(contentDoc.sort, undefined);
+
+                                                // Verify same-tenant loggedin user can see it
+                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                    assert.ok(!err);
+
+                                                    var contentDoc = _getDocById(results, contentObj.id);
+                                                    assert.ok(contentDoc);
+                                                    assert.equal(contentDoc.resourceSubType, 'link');
+                                                    assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                    assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                    assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                    assert.equal(contentDoc.resourceType, 'content');
+                                                    assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                    assert.equal(contentDoc.id, contentObj.id);
+                                                    assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                    assert.equal(contentDoc._extra, undefined);
+                                                    assert.equal(contentDoc._type, undefined);
+                                                    assert.equal(contentDoc.q_high, undefined);
+                                                    assert.equal(contentDoc.q_low, undefined);
+                                                    assert.equal(contentDoc.sort, undefined);
+
+                                                    // Verify permitted user can see it
+                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                        assert.ok(!err);
+                                                        assert.ok(_getDocById(results, contentObj.id));
+
+                                                        var contentDoc = _getDocById(results, contentObj.id);
+                                                        assert.ok(contentDoc);
+                                                        assert.equal(contentDoc.resourceSubType, 'link');
+                                                        assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                        assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                        assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                        assert.equal(contentDoc.resourceType, 'content');
+                                                        assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                        assert.equal(contentDoc.id, contentObj.id);
+                                                        assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                        assert.equal(contentDoc._extra, undefined);
+                                                        assert.equal(contentDoc._type, undefined);
+                                                        assert.equal(contentDoc.q_high, undefined);
+                                                        assert.equal(contentDoc.q_low, undefined);
+                                                        assert.equal(contentDoc.sort, undefined);
+
+                                                        return callback();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that private content is not searchable by anyone but admins and members.
+         */
+        it('verify private content search not searchable by anyone but admin and privileged users', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
+                    assert.ok(!err);
+
+                    TestsUtil.generateTestGroups(doer.restContext, 5, function() {
+                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+
+                        // Give jack access via group
+                        TestsUtil.generateGroupHierarchy(doer.restContext, groupIds, 'member', function(err) {
+                            assert.ok(!err);
+
+                            TestsUtil.generateGroupHierarchy(doer.restContext, [groupIds[4], jack.user.id], 'member', function(err) {
+                                assert.ok(!err);
+
+                                var uniqueString = TestsUtil.generateTestUserId('private-searchable-content');
+                                RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 1', 'private', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
+                                    assert.ok(!err);
+
+                                    // Verify anonymous cannot see it
+                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                        assert.ok(!err);
+                                        assert.ok(!_getDocById(results, contentObj.id));
+
+                                        // Verify cross-tenant user cannot see it
+                                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                            assert.ok(!err);
+                                            assert.ok(!_getDocById(results, contentObj.id));
+
+                                            // Verify tenant admin can see it
+                                            SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                assert.ok(!err);
+
+                                                var contentDoc = _getDocById(results, contentObj.id);
+                                                assert.ok(contentDoc);
+                                                assert.equal(contentDoc.resourceSubType, 'link');
+                                                assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                assert.equal(contentDoc.resourceType, 'content');
+                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                assert.equal(contentDoc.id, contentObj.id);
+                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                assert.equal(contentDoc._extra, undefined);
+                                                assert.equal(contentDoc._type, undefined);
+                                                assert.equal(contentDoc.q_high, undefined);
+                                                assert.equal(contentDoc.q_low, undefined);
+                                                assert.equal(contentDoc.sort, undefined);
+
+                                                // Verify same-tenant loggedin user cannot see it
+                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.ok(!_getDocById(results, contentObj.id));
 
-                                                    // Verify tenant admin can see it
-                                                    SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                    // Verify permitted user can see it
+                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                         assert.ok(!err);
 
                                                         var contentDoc = _getDocById(results, contentObj.id);
@@ -1287,8 +1382,8 @@ describe('General Search', function() {
                                                         assert.equal(contentDoc.q_low, undefined);
                                                         assert.equal(contentDoc.sort, undefined);
 
-                                                        // Verify same-tenant loggedin user can see it
-                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                        // Verify global admin on a different tenant can see it
+                                                        SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
                                                             assert.ok(!err);
 
                                                             var contentDoc = _getDocById(results, contentObj.id);
@@ -1307,178 +1402,25 @@ describe('General Search', function() {
                                                             assert.equal(contentDoc.q_low, undefined);
                                                             assert.equal(contentDoc.sort, undefined);
 
-                                                            // Verify permitted user can see it
-                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.ok(_getDocById(results, contentObj.id));
+                                                            // Generate a new group, make Jack a member of it, create a piece of content and
+                                                            // share it with the group. All of this is done so we can check the direct membership
+                                                            // filter is NOT cached
+                                                            TestsUtil.generateTestGroups(doer.restContext, 1, function(anotherGroup) {
 
-                                                                var contentDoc = _getDocById(results, contentObj.id);
-                                                                assert.ok(contentDoc);
-                                                                assert.equal(contentDoc.resourceSubType, 'link');
-                                                                assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                assert.equal(contentDoc.resourceType, 'content');
-                                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                assert.equal(contentDoc.id, contentObj.id);
-                                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                                assert.equal(contentDoc._extra, undefined);
-                                                                assert.equal(contentDoc._type, undefined);
-                                                                assert.equal(contentDoc.q_high, undefined);
-                                                                assert.equal(contentDoc.q_low, undefined);
-                                                                assert.equal(contentDoc.sort, undefined);
-
-                                                                callback();
-                                                            });
-                                                        });
-                                                    });
-                                                });
-                                            });
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-
-        /**
-         * Test that verifies that private content is not searchable by anyone but admins and members.
-         */
-        it('verify private content search not searchable by anyone but admin and privileged users', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('private-searchable-content');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
-                    assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                        assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
-
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
-                            assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
-
-                            TestsUtil.generateTestGroups(doerRestContext, 5, function() {
-                                var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
-
-                                // Give jack access via group
-                                TestsUtil.generateGroupHierarchy(doerRestContext, groupIds, 'member', function(err) {
-                                    assert.ok(!err);
-
-                                    TestsUtil.generateGroupHierarchy(doerRestContext, [groupIds[4], jack.id], 'member', function(err) {
-                                        assert.ok(!err);
-
-                                        RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 1', 'private', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
-                                            assert.ok(!err);
-
-                                            // Verify anonymous cannot see it
-                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                assert.ok(!err);
-                                                assert.ok(!_getDocById(results, contentObj.id));
-
-                                                // Verify cross-tenant user cannot see it
-                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.ok(!_getDocById(results, contentObj.id));
-
-                                                    // Verify tenant admin can see it
-                                                    SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                        assert.ok(!err);
-
-                                                        var contentDoc = _getDocById(results, contentObj.id);
-                                                        assert.ok(contentDoc);
-                                                        assert.equal(contentDoc.resourceSubType, 'link');
-                                                        assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                        assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                        assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                        assert.equal(contentDoc.resourceType, 'content');
-                                                        assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                        assert.equal(contentDoc.id, contentObj.id);
-                                                        assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                        assert.equal(contentDoc._extra, undefined);
-                                                        assert.equal(contentDoc._type, undefined);
-                                                        assert.equal(contentDoc.q_high, undefined);
-                                                        assert.equal(contentDoc.q_low, undefined);
-                                                        assert.equal(contentDoc.sort, undefined);
-
-                                                        // Verify same-tenant loggedin user cannot see it
-                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.ok(!_getDocById(results, contentObj.id));
-
-                                                            // Verify permitted user can see it
-                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                assert.ok(!err);
-
-                                                                var contentDoc = _getDocById(results, contentObj.id);
-                                                                assert.ok(contentDoc);
-                                                                assert.equal(contentDoc.resourceSubType, 'link');
-                                                                assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                assert.equal(contentDoc.resourceType, 'content');
-                                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                assert.equal(contentDoc.id, contentObj.id);
-                                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                                assert.equal(contentDoc._extra, undefined);
-                                                                assert.equal(contentDoc._type, undefined);
-                                                                assert.equal(contentDoc.q_high, undefined);
-                                                                assert.equal(contentDoc.q_low, undefined);
-                                                                assert.equal(contentDoc.sort, undefined);
-
-                                                                // Verify global admin on a different tenant can see it
-                                                                SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                                                var permissions = {};
+                                                                permissions[jack.user.id] = 'member';
+                                                                RestAPI.Group.setGroupMembers(doer.restContext, anotherGroup.group.id, permissions, function(err) {
                                                                     assert.ok(!err);
 
-                                                                    var contentDoc = _getDocById(results, contentObj.id);
-                                                                    assert.ok(contentDoc);
-                                                                    assert.equal(contentDoc.resourceSubType, 'link');
-                                                                    assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                    assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                    assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                    assert.equal(contentDoc.resourceType, 'content');
-                                                                    assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                    assert.equal(contentDoc.id, contentObj.id);
-                                                                    assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                                    assert.equal(contentDoc._extra, undefined);
-                                                                    assert.equal(contentDoc._type, undefined);
-                                                                    assert.equal(contentDoc.q_high, undefined);
-                                                                    assert.equal(contentDoc.q_low, undefined);
-                                                                    assert.equal(contentDoc.sort, undefined);
+                                                                    RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 2', 'private', 'http://www.oaeproject.org/',  [], [anotherGroup.group.id], [], function(err, link2) {
+                                                                        assert.ok(!err);
 
-                                                                    // Generate a new group, make Jack a member of it, create a piece of content and
-                                                                    // share it with the group. All of this is done so we can check the direct membership
-                                                                    // filter is NOT cached
-                                                                    TestsUtil.generateTestGroups(doerRestContext, 1, function(anotherGroup) {
-
-                                                                        var permissions = {};
-                                                                        permissions[jack.id] = 'member';
-                                                                        RestAPI.Group.setGroupMembers(doerRestContext, anotherGroup.group.id, permissions, function(err) {
+                                                                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                                             assert.ok(!err);
 
-                                                                            RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 2', 'private', 'http://www.oaeproject.org/',  [], [anotherGroup.group.id], [], function(err, link2) {
-                                                                                assert.ok(!err);
-
-                                                                                SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                                    assert.ok(!err);
-
-                                                                                    var contentDoc = _getDocById(results, link2.id);
-                                                                                    assert.ok(contentDoc);
-                                                                                    return callback();
-                                                                                });
-                                                                            });
+                                                                            var contentDoc = _getDocById(results, link2.id);
+                                                                            assert.ok(contentDoc);
+                                                                            return callback();
                                                                         });
                                                                     });
                                                                 });
@@ -1538,46 +1480,37 @@ describe('General Search', function() {
          * Test that verifies public user search results are not hidden from anyone.
          */
         it('verify public user profile visible to everyone', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('user-public-profile');
-
-            // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                var jackOpts = {
-                    'visibility': 'public',
-                    'publicAlias': 'I was hidden'
-                };
-
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', uniqueString, jackOpts, function(err, jack) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                    var jackOpts = {
+                        'visibility': 'public',
+                        'publicAlias': 'I was hidden'
+                    };
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, jackOpts, function(err, jackUser) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        jack.user = jackUser;
 
                         // Verify hidden for cross-tenant user on internal search
-                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            var jackDoc = _getDocById(results, jack.id);
+                            var jackDoc = _getDocById(results, jack.user.id);
                             assert.ok(!jackDoc);
 
                             // Verify visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
+                                var jackDoc = _getDocById(results, jack.user.id);
                                 assert.ok(jackDoc);
-                                assert.equal(jackDoc.id, jack.id);
+                                assert.equal(jackDoc.id, jack.user.id);
                                 assert.equal(jackDoc.resourceType, 'user');
                                 assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                assert.equal(jackDoc.displayName, jack.displayName);
-                                assert.equal(jackDoc.visibility, jack.visibility);
+                                assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                assert.equal(jackDoc.displayName, jack.user.displayName);
+                                assert.equal(jackDoc.visibility, jack.user.visibility);
                                 assert.equal(jackDoc._extra, undefined);
                                 assert.equal(jackDoc.extra, undefined);
                                 assert.equal(jackDoc.q_high, undefined);
@@ -1586,16 +1519,16 @@ describe('General Search', function() {
                                 assert.equal(jackDoc._type, undefined);
 
                                 // Verify not hidden for anonymous
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-                                    var jackDoc = _getDocById(results, jack.id);
+                                    var jackDoc = _getDocById(results, jack.user.id);
                                     assert.ok(jackDoc);
-                                    assert.equal(jackDoc.id, jack.id);
+                                    assert.equal(jackDoc.id, jack.user.id);
                                     assert.equal(jackDoc.resourceType, 'user');
                                     assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                    assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                    assert.equal(jackDoc.displayName, jack.displayName);
-                                    assert.equal(jackDoc.visibility, jack.visibility);
+                                    assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                    assert.equal(jackDoc.displayName, jack.user.displayName);
+                                    assert.equal(jackDoc.visibility, jack.user.visibility);
                                     assert.equal(jackDoc._extra, undefined);
                                     assert.equal(jackDoc.extra, undefined);
                                     assert.equal(jackDoc.q_high, undefined);
@@ -1604,16 +1537,16 @@ describe('General Search', function() {
                                     assert.equal(jackDoc._type, undefined);
 
                                     // Verify not hidden for other in-tenant loggedin user
-                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
-                                        var jackDoc = _getDocById(results, jack.id);
+                                        var jackDoc = _getDocById(results, jack.user.id);
                                         assert.ok(jackDoc);
-                                        assert.equal(jackDoc.id, jack.id);
+                                        assert.equal(jackDoc.id, jack.user.id);
                                         assert.equal(jackDoc.resourceType, 'user');
                                         assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                        assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                        assert.equal(jackDoc.displayName, jack.displayName);
-                                        assert.equal(jackDoc.visibility, jack.visibility);
+                                        assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                        assert.equal(jackDoc.displayName, jack.user.displayName);
+                                        assert.equal(jackDoc.visibility, jack.user.visibility);
                                         assert.equal(jackDoc._extra, undefined);
                                         assert.equal(jackDoc.extra, undefined);
                                         assert.equal(jackDoc.q_high, undefined);
@@ -1622,16 +1555,16 @@ describe('General Search', function() {
                                         assert.equal(jackDoc._type, undefined);
 
                                         // Verify not hidden for admin
-                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
-                                            var jackDoc = _getDocById(results, jack.id);
+                                            var jackDoc = _getDocById(results, jack.user.id);
                                             assert.ok(jackDoc);
-                                            assert.equal(jackDoc.id, jack.id);
+                                            assert.equal(jackDoc.id, jack.user.id);
                                             assert.equal(jackDoc.resourceType, 'user');
                                             assert.equal(jackDoc.profilePath, '/user/'  + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                            assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                            assert.equal(jackDoc.displayName, jack.displayName);
-                                            assert.equal(jackDoc.visibility, jack.visibility);
+                                            assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                            assert.equal(jackDoc.displayName, jack.user.displayName);
+                                            assert.equal(jackDoc.visibility, jack.user.visibility);
                                             assert.equal(jackDoc._extra, undefined);
                                             assert.equal(jackDoc.extra, undefined);
                                             assert.equal(jackDoc.q_high, undefined);
@@ -1639,7 +1572,7 @@ describe('General Search', function() {
                                             assert.equal(jackDoc.sort, undefined);
                                             assert.equal(jackDoc._type, undefined);
 
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1654,58 +1587,49 @@ describe('General Search', function() {
          * Test that verifies loggedin user search results are hidden to users who are not authenticated to the user's tenant
          */
         it('verify loggedin user profile not visibile cross-tenant or to anonymous', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('user-loggedin-profile');
-
-            // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                var jackOpts = {
-                    'visibility': 'loggedin',
-                    'publicAlias': 'I was hidden'
-                };
-
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', uniqueString, jackOpts, function(err, jack) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                    var jackOpts = {
+                        'visibility': 'loggedin',
+                        'publicAlias': 'I was hidden'
+                    };
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, jackOpts, function(err, jackUser) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        jack.user = jackUser;
 
                         // Verify hidden for cross-tenant user on internal search
-                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            var jackDoc = _getDocById(results, jack.id);
+                            var jackDoc = _getDocById(results, jack.user.id);
                             assert.ok(!jackDoc);
 
                             // Verify not visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
+                                var jackDoc = _getDocById(results, jack.user.id);
                                 assert.ok(!jackDoc);
 
                                 // Verify not visible for anonymous
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-                                    var jackDoc = _getDocById(results, jack.id);
+                                    var jackDoc = _getDocById(results, jack.user.id);
                                     assert.ok(!jackDoc);
 
                                     // Verify visible for other in-tenant loggedin user
-                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
-                                        var jackDoc = _getDocById(results, jack.id);
+                                        var jackDoc = _getDocById(results, jack.user.id);
                                         assert.ok(jackDoc);
-                                        assert.equal(jackDoc.id, jack.id);
+                                        assert.equal(jackDoc.id, jack.user.id);
                                         assert.equal(jackDoc.resourceType, 'user');
                                         assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                        assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                        assert.equal(jackDoc.displayName, jack.displayName);
-                                        assert.equal(jackDoc.visibility, jack.visibility);
+                                        assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                        assert.equal(jackDoc.displayName, jack.user.displayName);
+                                        assert.equal(jackDoc.visibility, jack.user.visibility);
                                         assert.equal(jackDoc._extra, undefined);
                                         assert.equal(jackDoc.extra, undefined);
                                         assert.equal(jackDoc.q_high, undefined);
@@ -1714,16 +1638,16 @@ describe('General Search', function() {
                                         assert.equal(jackDoc._type, undefined);
 
                                         // Verify not hidden for admin
-                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
-                                            var jackDoc = _getDocById(results, jack.id);
+                                            var jackDoc = _getDocById(results, jack.user.id);
                                             assert.ok(jackDoc);
-                                            assert.equal(jackDoc.id, jack.id);
+                                            assert.equal(jackDoc.id, jack.user.id);
                                             assert.equal(jackDoc.resourceType, 'user');
                                             assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                            assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                            assert.equal(jackDoc.displayName, jack.displayName);
-                                            assert.equal(jackDoc.visibility, jack.visibility);
+                                            assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                            assert.equal(jackDoc.displayName, jack.user.displayName);
+                                            assert.equal(jackDoc.visibility, jack.user.visibility);
                                             assert.equal(jackDoc._extra, undefined);
                                             assert.equal(jackDoc.extra, undefined);
                                             assert.equal(jackDoc.q_high, undefined);
@@ -1731,7 +1655,7 @@ describe('General Search', function() {
                                             assert.equal(jackDoc.sort, undefined);
                                             assert.equal(jackDoc._type, undefined);
 
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1746,65 +1670,56 @@ describe('General Search', function() {
          * Test that verifies that private user profiles are hidden from everyone.
          */
         it('verify private user profile not visibile to anyone but admin users and the user themself', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('user-private-profile');
-
-            // Create a user from another tenant, a private user from the same tenant, and a user from the same tenant that has access
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                var jackOpts = {
-                    'visibility': 'private',
-                    'publicAlias': 'I was hidden'
-                };
-
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', uniqueString, jackOpts, function(err, jack) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                    var jackOpts = {
+                        'visibility': 'private',
+                        'publicAlias': 'I was hidden'
+                    };
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, jackOpts, function(err, jackUser) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        jack.user = jackUser;
 
                         // Verify hidden for cross-tenant user on internal search
-                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            var jackDoc = _getDocById(results, jack.id);
+                            var jackDoc = _getDocById(results, jack.user.id);
                             assert.ok(!jackDoc);
 
                             // Verify not visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
+                                var jackDoc = _getDocById(results, jack.user.id);
                                 assert.ok(!jackDoc);
 
                                 // Verify not visible for anonymous
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-                                    var jackDoc = _getDocById(results, jack.id);
+                                    var jackDoc = _getDocById(results, jack.user.id);
                                     assert.ok(!jackDoc);
 
                                     // Verify not visible for other in-tenant loggedin user
-                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
-                                        var jackDoc = _getDocById(results, jack.id);
+                                        var jackDoc = _getDocById(results, jack.user.id);
                                         assert.ok(!jackDoc);
 
                                         // Verify not hidden for tenant admin
-                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
 
-                                            var jackDoc = _getDocById(results, jack.id);
+                                            var jackDoc = _getDocById(results, jack.user.id);
                                             assert.ok(jackDoc);
-                                            assert.equal(jackDoc.id, jack.id);
+                                            assert.equal(jackDoc.id, jack.user.id);
                                             assert.equal(jackDoc.resourceType, 'user');
                                             assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                            assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                            assert.equal(jackDoc.displayName, jack.displayName);
-                                            assert.equal(jackDoc.visibility, jack.visibility);
+                                            assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                            assert.equal(jackDoc.displayName, jack.user.displayName);
+                                            assert.equal(jackDoc.visibility, jack.user.visibility);
                                             assert.equal(jackDoc._extra, undefined);
                                             assert.equal(jackDoc.extra, undefined);
                                             assert.equal(jackDoc.q_high, undefined);
@@ -1814,17 +1729,17 @@ describe('General Search', function() {
 
 
                                             // Verify not hidden for global admin authenticated to a different tenant
-                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                                 assert.ok(!err);
 
-                                                var jackDoc = _getDocById(results, jack.id);
+                                                var jackDoc = _getDocById(results, jack.user.id);
                                                 assert.ok(jackDoc);
-                                                assert.equal(jackDoc.id, jack.id);
+                                                assert.equal(jackDoc.id, jack.user.id);
                                                 assert.equal(jackDoc.resourceType, 'user');
                                                 assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                                assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                                assert.equal(jackDoc.displayName, jack.displayName);
-                                                assert.equal(jackDoc.visibility, jack.visibility);
+                                                assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                                assert.equal(jackDoc.displayName, jack.user.displayName);
+                                                assert.equal(jackDoc.visibility, jack.user.visibility);
                                                 assert.equal(jackDoc._extra, undefined);
                                                 assert.equal(jackDoc.extra, undefined);
                                                 assert.equal(jackDoc.q_high, undefined);
@@ -1851,36 +1766,53 @@ describe('General Search', function() {
          * Test that verifies public groups are searchable by everyone
          */
         it('verify public group is searchable by everyone', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-            var uniqueString = TestsUtil.generateTestUserId('public-group-visibility');
-
-            // Create 2 users from a different tenant than the group, one of which is a member of the group
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy Sitherson', null, function(err, sith) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                     assert.ok(!err);
-                    var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
 
-                    // Create 2 users from the same tenant as the group
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    // Create the group, including sith as a user
+                    var uniqueString = TestsUtil.generateTestUserId('public-group-visibility');
+                    RestAPI.Group.createGroup(jack.restContext, uniqueString, uniqueString, 'public', 'no', [], [sith.user.id], function(err, group) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                        // Verify anonymous user search can access it
+                        SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                            var groupDoc = _getDocById(results, group.id);
+                            assert.ok(groupDoc);
+                            assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                            assert.equal(groupDoc.resourceType, 'group');
+                            assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                            assert.equal(groupDoc.id, group.id);
+                            assert.equal(groupDoc.displayName, group.displayName);
+                            assert.equal(groupDoc.visibility, group.visibility);
+                            assert.equal(groupDoc._extra, undefined);
+                            assert.equal(groupDoc._type, undefined);
+                            assert.equal(groupDoc.q_high, undefined);
+                            assert.equal(groupDoc.q_low, undefined);
+                            assert.equal(groupDoc.sort, undefined);
 
-                            // Create the group, including sith as a user
-                            RestAPI.Group.createGroup(jackRestContext, uniqueString, uniqueString, 'public', 'no', [], [sith.id], function(err, group) {
+                            // Verify cross-tenant user can query the group
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
+                                var groupDoc = _getDocById(results, group.id);
+                                assert.ok(groupDoc);
+                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                assert.equal(groupDoc.resourceType, 'group');
+                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                                assert.equal(groupDoc.id, group.id);
+                                assert.equal(groupDoc.displayName, group.displayName);
+                                assert.equal(groupDoc.visibility, group.visibility);
+                                assert.equal(groupDoc._extra, undefined);
+                                assert.equal(groupDoc._type, undefined);
+                                assert.equal(groupDoc.q_high, undefined);
+                                assert.equal(groupDoc.q_low, undefined);
+                                assert.equal(groupDoc.sort, undefined);
 
-                                // Verify anonymous user search can access it
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
+                                // Verify cross-tenant *member* can query the group
+                                SearchTestsUtil.searchRefreshed(sith.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_tenant'}, function(err, results) {
                                     assert.ok(!err);
                                     var groupDoc = _getDocById(results, group.id);
                                     assert.ok(groupDoc);
@@ -1896,8 +1828,8 @@ describe('General Search', function() {
                                     assert.equal(groupDoc.q_low, undefined);
                                     assert.equal(groupDoc.sort, undefined);
 
-                                    // Verify cross-tenant user can query the group
-                                    SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                    // Verify another same-tenant loggedin user can query it
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                                         assert.ok(!err);
                                         var groupDoc = _getDocById(results, group.id);
                                         assert.ok(groupDoc);
@@ -1913,8 +1845,8 @@ describe('General Search', function() {
                                         assert.equal(groupDoc.q_low, undefined);
                                         assert.equal(groupDoc.sort, undefined);
 
-                                        // Verify cross-tenant *member* can query the group
-                                        SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_tenant'}, function(err, results) {
+                                        // Verify member user can query it
+                                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                                             assert.ok(!err);
                                             var groupDoc = _getDocById(results, group.id);
                                             assert.ok(groupDoc);
@@ -1930,43 +1862,7 @@ describe('General Search', function() {
                                             assert.equal(groupDoc.q_low, undefined);
                                             assert.equal(groupDoc.sort, undefined);
 
-                                            // Verify another same-tenant loggedin user can query it
-                                            SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
-                                                assert.ok(!err);
-                                                var groupDoc = _getDocById(results, group.id);
-                                                assert.ok(groupDoc);
-                                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
-                                                assert.equal(groupDoc.resourceType, 'group');
-                                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                assert.equal(groupDoc.id, group.id);
-                                                assert.equal(groupDoc.displayName, group.displayName);
-                                                assert.equal(groupDoc.visibility, group.visibility);
-                                                assert.equal(groupDoc._extra, undefined);
-                                                assert.equal(groupDoc._type, undefined);
-                                                assert.equal(groupDoc.q_high, undefined);
-                                                assert.equal(groupDoc.q_low, undefined);
-                                                assert.equal(groupDoc.sort, undefined);
-
-                                                // Verify member user can query it
-                                                SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
-                                                    assert.ok(!err);
-                                                    var groupDoc = _getDocById(results, group.id);
-                                                    assert.ok(groupDoc);
-                                                    assert.equal(groupDoc.tenantAlias, group.tenant.alias);
-                                                    assert.equal(groupDoc.resourceType, 'group');
-                                                    assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                    assert.equal(groupDoc.id, group.id);
-                                                    assert.equal(groupDoc.displayName, group.displayName);
-                                                    assert.equal(groupDoc.visibility, group.visibility);
-                                                    assert.equal(groupDoc._extra, undefined);
-                                                    assert.equal(groupDoc._type, undefined);
-                                                    assert.equal(groupDoc.q_high, undefined);
-                                                    assert.equal(groupDoc.q_low, undefined);
-                                                    assert.equal(groupDoc.sort, undefined);
-
-                                                    return callback();
-                                                });
-                                            });
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1985,11 +1881,6 @@ describe('General Search', function() {
          * will not be able to join the group, so there is no point in showing it in the results.
          */
         it('verify loggedin group search visibility', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-            var lukeSkywalkerUsername = TestsUtil.generateTestUserId('lukeSkywalker');
             var privateTenantAlias = TenantsTestUtil.generateTestTenantAlias('privateTenant');
             var uniqueStringA = TestsUtil.generateTestUserId('loggedin-group-visibility');
             var uniqueStringB = TestsUtil.generateTestUserId('loggedin-group-visibility');
@@ -2003,63 +1894,84 @@ describe('General Search', function() {
                 ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, privateTenantAlias, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(privateTenantAdminRestContext, lukeSkywalkerUsername, 'password', 'Luke Skywalker', null, function(err, lukeSkywalker) {
+                    TestsUtil.generateTestUsers(privateTenantAdminRestContext, 1, function(err, users, lukeSkywalker) {
                         assert.ok(!err);
-                        var lukeSkywalkerRestContext = TestsUtil.createTenantRestContext(privateTenantAlias, lukeSkywalkerUsername, 'password');
 
-                        RestAPI.Group.createGroup(lukeSkywalkerRestContext, uniqueStringC, uniqueStringC, 'loggedin', 'yes', [], [], function(err, privateTenantGroup) {
+                        RestAPI.Group.createGroup(lukeSkywalker.restContext, uniqueStringC, uniqueStringC, 'loggedin', 'yes', [], [], function(err, privateTenantGroup) {
                             assert.ok(!err);
 
                             // Create 2 users from another public tenant tenant (gt), one of which has access to the group, and 2 users from the same tenant
-                            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                            TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                                 assert.ok(!err);
-                                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                                // Create another user, this user will also be a member of the group
-                                RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy Sitherson', null, function(err, sith) {
-                                    assert.ok(!err);
-                                    var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
+                                TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
 
-                                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                                    // Create the group, including sith as a user
+                                    RestAPI.Group.createGroup(jack.restContext, uniqueStringA, uniqueStringA, 'loggedin', 'no', [], [sith.user.id], function(err, group) {
                                         assert.ok(!err);
-                                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                                        // Create the joinable group, including sith as a user
+                                        RestAPI.Group.createGroup(jack.restContext, uniqueStringB, uniqueStringB, 'loggedin', 'request', [], [sith.user.id], function(err, groupJoinable) {
                                             assert.ok(!err);
-                                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                                            // Create the group, including sith as a user
-                                            RestAPI.Group.createGroup(jackRestContext, uniqueStringA, uniqueStringA, 'loggedin', 'no', [], [sith.id], function(err, group) {
+                                            // Verify anonymous user search cannot access either
+                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                 assert.ok(!err);
+                                                var groupDoc = _getDocById(results, group.id);
+                                                assert.ok(!groupDoc);
 
-                                                // Create the joinable group, including sith as a user
-                                                RestAPI.Group.createGroup(jackRestContext, uniqueStringB, uniqueStringB, 'loggedin', 'request', [], [sith.id], function(err, groupJoinable) {
+                                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB}, function(err, results) {
                                                     assert.ok(!err);
+                                                    var groupDoc = _getDocById(results, groupJoinable.id);
+                                                    assert.ok(!groupDoc);
 
-                                                    // Verify anonymous user search cannot access either
-                                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                    // Verify cross-tenant user cannot query the unjoinable group
+                                                    SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA, 'scope': '_network'}, function(err, results) {
                                                         assert.ok(!err);
                                                         var groupDoc = _getDocById(results, group.id);
                                                         assert.ok(!groupDoc);
 
-                                                        SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB}, function(err, results) {
+                                                        // Verify cross-tenant user cannot query the joinable group
+                                                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
                                                             assert.ok(!err);
-                                                            var groupDoc = _getDocById(results, groupJoinable.id);
-                                                            assert.ok(!groupDoc);
+                                                            assert.ok(!_getDocById(results, groupJoinable.id));
 
-                                                            // Verify cross-tenant user cannot query the unjoinable group
-                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA, 'scope': '_network'}, function(err, results) {
+                                                            // Verify cross-tenant member can query the unjoinable group
+                                                            SearchTestsUtil.searchRefreshed(sith.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 var groupDoc = _getDocById(results, group.id);
-                                                                assert.ok(!groupDoc);
+                                                                assert.ok(groupDoc);
+                                                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                                                assert.equal(groupDoc.resourceType, 'group');
+                                                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                                                                assert.equal(groupDoc.id, group.id);
+                                                                assert.equal(groupDoc.displayName, group.displayName);
+                                                                assert.equal(groupDoc.visibility, group.visibility);
+                                                                assert.equal(groupDoc._extra, undefined);
+                                                                assert.equal(groupDoc._type, undefined);
+                                                                assert.equal(groupDoc.q_high, undefined);
+                                                                assert.equal(groupDoc.q_low, undefined);
+                                                                assert.equal(groupDoc.sort, undefined);
 
-                                                                // Verify cross-tenant user cannot query the joinable group
-                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
+                                                                // Verify another same-tenant loggedin user can query it
+                                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                                     assert.ok(!err);
-                                                                    assert.ok(!_getDocById(results, groupJoinable.id));
+                                                                    var groupDoc = _getDocById(results, group.id);
+                                                                    assert.ok(groupDoc);
+                                                                    assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                                                    assert.equal(groupDoc.resourceType, 'group');
+                                                                    assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                                                                    assert.equal(groupDoc.id, group.id);
+                                                                    assert.equal(groupDoc.displayName, group.displayName);
+                                                                    assert.equal(groupDoc.visibility, group.visibility);
+                                                                    assert.equal(groupDoc._extra, undefined);
+                                                                    assert.equal(groupDoc._type, undefined);
+                                                                    assert.equal(groupDoc.q_high, undefined);
+                                                                    assert.equal(groupDoc.q_low, undefined);
+                                                                    assert.equal(groupDoc.sort, undefined);
 
-                                                                    // Verify cross-tenant member can query the unjoinable group
-                                                                    SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                                    // Verify member user can query it
+                                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                                         assert.ok(!err);
                                                                         var groupDoc = _getDocById(results, group.id);
                                                                         assert.ok(groupDoc);
@@ -2075,71 +1987,35 @@ describe('General Search', function() {
                                                                         assert.equal(groupDoc.q_low, undefined);
                                                                         assert.equal(groupDoc.sort, undefined);
 
-                                                                        // Verify another same-tenant loggedin user can query it
-                                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                                        // Sanity check luke skywalker's query to own loggedin group
+                                                                        SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC}, function(err, results) {
                                                                             assert.ok(!err);
-                                                                            var groupDoc = _getDocById(results, group.id);
+                                                                            var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                             assert.ok(groupDoc);
-                                                                            assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                                                            assert.equal(groupDoc.tenantAlias, privateTenantGroup.tenant.alias);
                                                                             assert.equal(groupDoc.resourceType, 'group');
                                                                             assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                                            assert.equal(groupDoc.id, group.id);
-                                                                            assert.equal(groupDoc.displayName, group.displayName);
-                                                                            assert.equal(groupDoc.visibility, group.visibility);
+                                                                            assert.equal(groupDoc.id, privateTenantGroup.id);
+                                                                            assert.equal(groupDoc.displayName, privateTenantGroup.displayName);
+                                                                            assert.equal(groupDoc.visibility, privateTenantGroup.visibility);
                                                                             assert.equal(groupDoc._extra, undefined);
                                                                             assert.equal(groupDoc._type, undefined);
                                                                             assert.equal(groupDoc.q_high, undefined);
                                                                             assert.equal(groupDoc.q_low, undefined);
                                                                             assert.equal(groupDoc.sort, undefined);
 
-                                                                            // Verify member user can query it
-                                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                                            // Verify a user from a private tenant cannot query an external loggedin joinable group
+                                                                            SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
                                                                                 assert.ok(!err);
-                                                                                var groupDoc = _getDocById(results, group.id);
-                                                                                assert.ok(groupDoc);
-                                                                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
-                                                                                assert.equal(groupDoc.resourceType, 'group');
-                                                                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                                                assert.equal(groupDoc.id, group.id);
-                                                                                assert.equal(groupDoc.displayName, group.displayName);
-                                                                                assert.equal(groupDoc.visibility, group.visibility);
-                                                                                assert.equal(groupDoc._extra, undefined);
-                                                                                assert.equal(groupDoc._type, undefined);
-                                                                                assert.equal(groupDoc.q_high, undefined);
-                                                                                assert.equal(groupDoc.q_low, undefined);
-                                                                                assert.equal(groupDoc.sort, undefined);
+                                                                                var groupDoc = _getDocById(results, groupJoinable.id);
+                                                                                assert.ok(!groupDoc);
 
-                                                                                // Sanity check luke skywalker's query to own loggedin group
-                                                                                SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC}, function(err, results) {
+                                                                                // Verify that user from a public tenant cannot query a loggedin joinable group that belongs to a private tenant (luke skywalker's tenant and group)
+                                                                                SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC, 'scope': '_network'}, function(err, results) {
                                                                                     assert.ok(!err);
                                                                                     var groupDoc = _getDocById(results, privateTenantGroup.id);
-                                                                                    assert.ok(groupDoc);
-                                                                                    assert.equal(groupDoc.tenantAlias, privateTenantGroup.tenant.alias);
-                                                                                    assert.equal(groupDoc.resourceType, 'group');
-                                                                                    assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                                                    assert.equal(groupDoc.id, privateTenantGroup.id);
-                                                                                    assert.equal(groupDoc.displayName, privateTenantGroup.displayName);
-                                                                                    assert.equal(groupDoc.visibility, privateTenantGroup.visibility);
-                                                                                    assert.equal(groupDoc._extra, undefined);
-                                                                                    assert.equal(groupDoc._type, undefined);
-                                                                                    assert.equal(groupDoc.q_high, undefined);
-                                                                                    assert.equal(groupDoc.q_low, undefined);
-                                                                                    assert.equal(groupDoc.sort, undefined);
-
-                                                                                    // Verify a user from a private tenant cannot query an external loggedin joinable group
-                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
-                                                                                        assert.ok(!err);
-                                                                                        var groupDoc = _getDocById(results, groupJoinable.id);
-                                                                                        assert.ok(!groupDoc);
-
-                                                                                        // Verify that user from a public tenant cannot query a loggedin joinable group that belongs to a private tenant (luke skywalker's tenant and group)
-                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC, 'scope': '_network'}, function(err, results) {
-                                                                                            assert.ok(!err);
-                                                                                            var groupDoc = _getDocById(results, privateTenantGroup.id);
-                                                                                            assert.ok(!groupDoc);
-                                                                                            callback();
-                                                                                        });
-                                                                                    });
+                                                                                    assert.ok(!groupDoc);
+                                                                                    return callback();
                                                                                 });
                                                                             });
                                                                         });
@@ -2165,51 +2041,45 @@ describe('General Search', function() {
          * that it is searchable by authenticated users from other tenants so long as the group's tenant *and* the other tenant are both public.
          */
         it('verify private group search visibility', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-            var lukeSkywalkerUsername = TestsUtil.generateTestUserId('lukeSkywalker');
             var privateTenantAlias = TenantsTestUtil.generateTestTenantAlias('privateTenant');
+            var uniqueStringA = TestsUtil.generateTestUserId('loggedin-group-visibility');
+            var uniqueStringB = TestsUtil.generateTestUserId('loggedin-group-visibility');
+            var uniqueStringC = TestsUtil.generateTestUserId('loggedin-group-visibility-skywalker');
 
-            // Create a private tenant with a user and a private joinable group
+            // Create a private tenant with a user and a loggedin joinable group. These will be used to test searches for cross-tenant private groups where
+            // you do not have access to join the group. In those cases, you should not get the group in the search results.
             TestsUtil.createTenantWithAdmin(privateTenantAlias, privateTenantAlias, function(err, privateTenant, privateTenantAdminRestContext) {
                 assert.ok(!err);
 
                 ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, privateTenantAlias, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(privateTenantAdminRestContext, lukeSkywalkerUsername, 'password', 'Luke Skywalker', null, function(err, lukeSkywalker) {
+                    TestsUtil.generateTestUsers(privateTenantAdminRestContext, 1, function(err, users, lukeSkywalker) {
                         assert.ok(!err);
-                        var lukeSkywalkerRestContext = TestsUtil.createTenantRestContext(privateTenantAlias, lukeSkywalkerUsername, 'password');
 
-                        RestAPI.Group.createGroup(lukeSkywalkerRestContext, TestsUtil.generateTestUserId('privateTenantGroup'), 'A luke skywalker tenant group', 'private', 'yes', [], [], function(err, privateTenantGroup) {
+                        RestAPI.Group.createGroup(lukeSkywalker.restContext, TestsUtil.generateTestUserId('privateTenantGroup'), 'A luke skywalker tenant group', 'private', 'yes', [], [], function(err, privateTenantGroup) {
                             assert.ok(!err);
 
-                            // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                            // Create 2 users from another public tenant tenant (gt), one of which has access to the group, and 2 users from the same tenant
+                            TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                                 assert.ok(!err);
-                                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                                // Create another user, this user will also be a member of the group
-                                RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy Sitherson', null, function(err, sith) {
-                                    assert.ok(!err);
-                                    var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
+                                TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
 
-                                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                                    // Create the group, including sith as a user
+                                    RestAPI.Group.createGroup(jack.restContext, uniqueStringA, uniqueStringA, 'loggedin', 'no', [], [sith.user.id], function(err, group) {
                                         assert.ok(!err);
-                                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                                        // Create the joinable group, including sith as a user
+                                        RestAPI.Group.createGroup(jack.restContext, uniqueStringB, uniqueStringB, 'loggedin', 'request', [], [sith.user.id], function(err, groupJoinable) {
                                             assert.ok(!err);
-                                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
                                             // Create the unjoinable group, including sith as a user
-                                            RestAPI.Group.createGroup(jackRestContext, TestsUtil.generateTestUserId('group'), 'A really awesome group', 'private', 'no', [], [sith.id], function(err, group) {
+                                            RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestUserId('group'), 'A really awesome group', 'private', 'no', [], [sith.user.id], function(err, group) {
                                                 assert.ok(!err);
 
                                                 // Create the joinable group, including sith as a user
-                                                RestAPI.Group.createGroup(jackRestContext, TestsUtil.generateTestUserId('groupJoinable'), 'A really super joinable group', 'private', 'request', [], [sith.id], function(err, groupJoinable) {
+                                                RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestUserId('groupJoinable'), 'A really super joinable group', 'private', 'request', [], [sith.user.id], function(err, groupJoinable) {
                                                     assert.ok(!err);
 
                                                     // Verify anonymous user search cannot access either
@@ -2224,18 +2094,18 @@ describe('General Search', function() {
                                                             assert.ok(!groupDoc);
 
                                                             // Verify cross-tenant user cannot query the unjoinable group
-                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome', 'scope': '_network'}, function(err, results) {
+                                                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome', 'scope': '_network'}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 var groupDoc = _getDocById(results, group.id);
                                                                 assert.ok(!groupDoc);
 
                                                                 // Verify cross-tenant user cannot query the joinable group
-                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
+                                                                SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
                                                                     assert.ok(!err);
                                                                     assert.ok(!_getDocById(results, groupJoinable.id));
 
                                                                     // Verify cross-tenant member can query the unjoinable group
-                                                                    SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
+                                                                    SearchTestsUtil.searchRefreshed(sith.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
                                                                         assert.ok(!err);
 
                                                                         var groupDoc = _getDocById(results, group.id);
@@ -2253,13 +2123,13 @@ describe('General Search', function() {
                                                                         assert.equal(groupDoc.sort, undefined);
 
                                                                         // Verify another same-tenant loggedin user cannot query the unjoinable group
-                                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
+                                                                        SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
                                                                             assert.ok(!err);
                                                                             var groupDoc = _getDocById(results, group.id);
                                                                             assert.ok(!groupDoc);
 
                                                                             // Verify member user can query the unjoinable group
-                                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
+                                                                            SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
                                                                                 assert.ok(!err);
 
                                                                                 var groupDoc = _getDocById(results, group.id);
@@ -2277,7 +2147,7 @@ describe('General Search', function() {
                                                                                 assert.equal(groupDoc.sort, undefined);
 
                                                                                 // Sanity check luke skywalker's query to own group
-                                                                                SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker'}, function(err, results) {
+                                                                                SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker'}, function(err, results) {
                                                                                     assert.ok(!err);
 
                                                                                     var groupDoc = _getDocById(results, privateTenantGroup.id);
@@ -2295,13 +2165,13 @@ describe('General Search', function() {
                                                                                     assert.equal(groupDoc.sort, undefined);
 
                                                                                     // Verify a user from a private tenant cannot query an external private joinable group
-                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
+                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
                                                                                         assert.ok(!err);
                                                                                         var groupDoc = _getDocById(results, groupJoinable.id);
                                                                                         assert.ok(!groupDoc);
 
                                                                                         // Verify that user from a public tenant cannot query a private joinable group that belongs to a private tenant (luke skywalker's tenant and group)
-                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'scope': '_network'}, function(err, results) {
+                                                                                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'scope': '_network'}, function(err, results) {
                                                                                             assert.ok(!err);
                                                                                             var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                                             assert.ok(!groupDoc);
@@ -2356,15 +2226,14 @@ describe('General Search', function() {
          * reasonably well.
          */
         it('verify edgengram analyzer of 3 for auto-suggest', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Search for just the first 3 characters to ensure it matches "Xyzforedgengram"
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'q': 'Xyz'}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'q': 'Xyz'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
                         callback();
@@ -2377,15 +2246,14 @@ describe('General Search', function() {
          * Verifies that the search analyzer is not case-sensitive
          */
         it('verify search indexing is not case-sensitive', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Search using a lowercase querystring on an item that was indexed with upper case
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'q': 'apereo'}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'q': 'apereo'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
                         callback();
@@ -2467,9 +2335,11 @@ describe('General Search', function() {
          * Test that verifies that displayName matches are boosted correctly, even across spaces in the displayName
          */
         it('verify displayName matches are boosted across spaces', function(callback) {
-            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon Gaeremynck', null, function(err, simonGaeremynck) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon Gaeremynck', email, {}, function(err, simonGaeremynck) {
                 assert.ok(!err);
-                RestAPI.User.createUser(gtAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon The Great', null, function(err, simonTheGreat) {
+                email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(gtAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon The Great', email, {}, function(err, simonTheGreat) {
                     assert.ok(!err);
 
                     // When searching for 'Simon G', the 'Simon Gaeremynck' user should
@@ -2494,9 +2364,11 @@ describe('General Search', function() {
             // Generate 2 identical users on 2 tenants
             var username = TestsUtil.generateRandomText(1);
             var displayName = TestsUtil.generateRandomText(2);
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', displayName, null, function(err, camUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, username, 'password', displayName, email, {}, function(err, camUser) {
                 assert.ok(!err);
-                RestAPI.User.createUser(gtAdminRestContext, username, 'password', displayName, null, function(err, gtUser) {
+                email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(gtAdminRestContext, username, 'password', displayName, email, {}, function(err, gtUser) {
                     assert.ok(!err);
 
                     // When searching on the cambridge tenant, the user from the cambridge
@@ -2533,40 +2405,37 @@ describe('General Search', function() {
          * Test that verifies the resourceType parameter in the general search properly filter results by user, group and content.
          */
         it('verify resourceType scope param', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Ensure a user, group and content item exist in the search index to ensure they are not included in resource-scoped searches
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack JickMackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestUserId('group'), 'A group for Jack', 'public', 'no', [], [], function(err, group) {
+                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestUserId('group'), 'A group for ' + jack.user.displayName, 'public', 'no', [], [], function(err, group) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(camAdminRestContext, 'Apereo Foundation', 'Link to Jack', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                    RestAPI.Content.createLink(camAdminRestContext, 'Apereo Foundation', 'Link to ' + jack.user.displayName, 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                         assert.ok(!err);
 
                         // Verify we only get users from a user search
-                        SearchTestsUtil.searchRefreshed(jackCtx, 'general', null, {'resourceTypes': 'user', 'q': 'Jack'}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            assert.ok(_getDocById(results, jack.id));
+                            assert.ok(_getDocById(results, jack.user.id));
                             assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group'; }).length, 0);
                             assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content'; }).length, 0);
 
                             // Verify we only get groups from a group search
-                            SearchTestsUtil.searchRefreshed(jackCtx, 'general', null, {'resourceTypes': 'group', 'q': 'Jack'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': jack.user.displayName}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(_getDocById(results, group.id));
                                 assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user'; }).length, 0);
                                 assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content'; }).length, 0);
 
                                 // Verify we only get content from a content search
-                                SearchTestsUtil.searchRefreshed(jackCtx, 'general', null, {'resourceTypes': 'content', 'q': 'Jack'}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'content', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(_getDocById(results, content.id));
                                     assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user'; }).length, 0);
                                     assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group'; }).length, 0);
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-telemetry/tests/test-telemetry.js
+++ b/node_modules/oae-telemetry/tests/test-telemetry.js
@@ -41,8 +41,6 @@ describe('Telemetry', function() {
     var camAdminRestContext = null;
     // Rest context that can be used every time we need to make a request as a global admin
     var globalAdminRestContext = null;
-    // Rest context for a user that will be used inside of the tests
-    var johnRestContext = null;
 
     /**
      * Function that will fill up the global admin, tenant admin and anymous rest context
@@ -56,12 +54,7 @@ describe('Telemetry', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         // Fill up the global admin rest context
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
-        // Fill up the rest context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            callback();
-        });
+        return callback();
     });
 
     /**
@@ -180,32 +173,35 @@ describe('Telemetry', function() {
          * Test that verifies that only a global admin can request the telemetry data
          */
         it('verify that only a global admin can request the telemetry data', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+                assert.ok(!err);
 
-            // Request the telemetry data using an anonymous tenant user
-            RestAPI.Telemetry.getTelemetryData(anonymousCamRestContext, function(err, res) {
-                assert.ok(err);
-                assert.equal(err.code, 404);
-
-                // Request the telemetry data using an anonymous global user
-                RestAPI.Telemetry.getTelemetryData(anonymousGlobalRestContext, function(err, res) {
+                // Request the telemetry data using an anonymous tenant user
+                RestAPI.Telemetry.getTelemetryData(anonymousCamRestContext, function(err, res) {
                     assert.ok(err);
-                    assert.equal(err.code, 401);
-                    assert.equal(err.msg, 'Only global administrators are allowed to retrieve telemetry data');
+                    assert.equal(err.code, 404);
 
-                    // Request the telemetry data using a tenant user
-                    RestAPI.Telemetry.getTelemetryData(johnRestContext, function(err, res) {
+                    // Request the telemetry data using an anonymous global user
+                    RestAPI.Telemetry.getTelemetryData(anonymousGlobalRestContext, function(err, res) {
                         assert.ok(err);
-                        assert.equal(err.code, 404);
+                        assert.equal(err.code, 401);
+                        assert.equal(err.msg, 'Only global administrators are allowed to retrieve telemetry data');
 
-                        // Request the telemetry data using a tenant admin
-                        RestAPI.Telemetry.getTelemetryData(camAdminRestContext, function(err, res) {
+                        // Request the telemetry data using a tenant user
+                        RestAPI.Telemetry.getTelemetryData(john.restContext, function(err, res) {
                             assert.ok(err);
                             assert.equal(err.code, 404);
 
-                            // Request the telemetry data using a global admin
-                            RestAPI.Telemetry.getTelemetryData(globalAdminRestContext, function(err, res) {
-                                assert.ok(!err);
-                                return callback();
+                            // Request the telemetry data using a tenant admin
+                            RestAPI.Telemetry.getTelemetryData(camAdminRestContext, function(err, res) {
+                                assert.ok(err);
+                                assert.equal(err.code, 404);
+
+                                // Request the telemetry data using a global admin
+                                RestAPI.Telemetry.getTelemetryData(globalAdminRestContext, function(err, res) {
+                                    assert.ok(!err);
+                                    return callback();
+                                });
                             });
                         });
                     });

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -653,25 +653,24 @@ describe('Tenants', function() {
                                     assert.equal(err.code, 401);
 
                                     // Create a regular non-admin user
-                                    var userId = TestsUtil.generateTestUserId('john');
-                                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-                                        var johnCamRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
+                                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+                                        assert.ok(!err);
 
                                         // Try to update the tenant's display name as a non-admin user on a user tenant
-                                        RestAPI.Tenants.updateTenant(johnCamRestContext, null, {'displayName': 'Anglia Ruskin University'}, function(err) {
+                                        RestAPI.Tenants.updateTenant(john.restContext, null, {'displayName': 'Anglia Ruskin University'}, function(err) {
                                             assert.ok(err);
                                             assert.equal(err.code, 401);
 
                                             // Try to update the tenant's host as a non-admin user on a user tenant
-                                            RestAPI.Tenants.updateTenant(johnCamRestContext, null, {'host': 'newcamtest.oae.com'}, function(err) {
+                                            RestAPI.Tenants.updateTenant(john.restContext, null, {'host': 'newcamtest.oae.com'}, function(err) {
                                                 assert.ok(err);
                                                 assert.equal(err.code, 401);
 
                                                 // Try to update tenant's display name and host as a non-admin user on a user tenant
-                                                RestAPI.Tenants.updateTenant(johnCamRestContext, null, {'displayName': 'Anglia Ruskin University', 'host': 'newcamtest.oae.com'}, function(err) {
+                                                RestAPI.Tenants.updateTenant(john.restContext, null, {'displayName': 'Anglia Ruskin University', 'host': 'newcamtest.oae.com'}, function(err) {
                                                     assert.ok(err);
                                                     assert.equal(err.code, 401);
-                                                    callback();
+                                                    return callback();
                                                 });
                                             });
                                         });

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -92,7 +92,7 @@ var createTestServer = module.exports.createTestServer = function(callback, _att
  * @throws {Error}                  An assertion error is thrown if an unexpected error occurs
  */
 var clearAllData = module.exports.clearAllData = function(callback) {
-    var columnFamiliesToClear = ['Content', 'Discussions', 'Folders', 'Principals', 'AuthenticationLoginId', 'AuthenticationUserLoginId'];
+    var columnFamiliesToClear = ['Content', 'Discussions', 'Folders', 'Principals', 'PrincipalsByEmail', 'AuthenticationLoginId', 'AuthenticationUserLoginId'];
 
     /*!
      * Once all column families have been truncated, we re-populate the administrators
@@ -106,7 +106,10 @@ var clearAllData = module.exports.clearAllData = function(callback) {
             var globalContext = createGlobalAdminContext();
 
             // Create the global admin user if they don't exist yet with the username "administrator"
-            AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', 'admin@example.com', null, function(err) {
+            var opts = {
+                'email': generateTestEmailAddress()
+            };
+            AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', opts, function(err) {
                 assert.ok(!err);
 
                 // Re-create the tenant administrators
@@ -205,7 +208,7 @@ var _setupTenantAdmin = function(tenant, callback) {
     var email = generateTestEmailAddress();
 
     var ctx = createTenantAdminContext(tenant);
-    AuthenticationAPI.createUser(ctx, adminLoginId, displayName, email, null, function(err, createdUser) {
+    AuthenticationAPI.createUser(ctx, adminLoginId, displayName, {'email': email}, function(err, createdUser) {
         assert.ok(!err);
 
         return PrincipalsAPI.setTenantAdmin(ctx, createdUser.id, true, callback);

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -103,15 +103,10 @@ var clearAllData = module.exports.clearAllData = function(callback) {
             assert.ok(!err);
 
             // Mock a global admin request context so we can create a proper global administrator in the system
-            var globalTenant = TenantsAPI.getTenant('admin');
-            var globalUser = new User(globalTenant.alias, 'u:admin:admin', 'Global Administrator', {
-                'visibility': 'admin',
-                'isGlobalAdmin': true
-            });
-            var globalContext = new Context(globalTenant, globalUser);
+            var globalContext = createGlobalAdminContext();
 
             // Create the global admin user if they don't exist yet with the username "administrator"
-            AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', null, function(err) {
+            AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', 'admin@example.com', null, function(err) {
                 assert.ok(!err);
 
                 // Re-create the tenant administrators
@@ -206,14 +201,11 @@ var _setUpTenantAdmins = function(callback) {
  */
 var _setupTenantAdmin = function(tenant, callback) {
     var adminLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, 'administrator', { 'password': 'administrator' });
-    var mockUserId = 'u:' + tenant.alias + ':admin';
-    var adminUser = new User(tenant.alias, mockUserId, 'The admin User', {
-        'isGlobalAdmin': false,
-        'isTenantAdmin': true
-    });
+    var displayName = generateRandomText(2);
+    var email = generateTestEmailAddress();
 
-    var ctx = new Context(tenant, adminUser);
-    AuthenticationAPI.createUser(ctx, adminLoginId, adminUser.displayName, null, function(err, createdUser) {
+    var ctx = createTenantAdminContext(tenant);
+    AuthenticationAPI.createUser(ctx, adminLoginId, displayName, email, null, function(err, createdUser) {
         assert.ok(!err);
 
         return PrincipalsAPI.setTenantAdmin(ctx, createdUser.id, true, callback);
@@ -256,7 +248,7 @@ var generateTestUsers = module.exports.generateTestUsers = function(restCtx, tot
         var username = generateTestUserId('random-user');
         var displayName = generateTestGroupId('random-user');
         var email = generateTestEmailAddress(username);
-        RestAPI.User.createUser(restCtx, username, 'password', displayName, {'email': email}, function(err, user) {
+        RestAPI.User.createUser(restCtx, username, 'password', displayName, email, {}, function(err, user) {
             if (err) {
                 return callback(err);
             }
@@ -328,15 +320,16 @@ var createTenantWithAdmin = module.exports.createTenantWithAdmin = function(tena
             return callback(err);
         }
 
-        // Disable recaptcha so we can create a user
+        // Disable reCaptcha so we can create a user
         ConfigTestUtil.updateConfigAndWait(adminCtx, tenantAlias, {'oae-principals/recaptcha/enabled': false}, function(err) {
             if (err) {
                 return callback(err);
             }
 
-            // Create the user and make them admin
+            // Create the user and make them a tenant administrator
             var anonymousCtx = createTenantRestContext(tenantHost);
-            RestAPI.User.createUser(anonymousCtx, 'administrator', 'administrator', 'Tenant Administrator', null, function(err, tenantAdmin) {
+            var email = generateTestEmailAddress('administrator');
+            RestAPI.User.createUser(anonymousCtx, 'administrator', 'administrator', 'Tenant Administrator', email, null, function(err, tenantAdmin) {
                 if (err) {
                     return callback(err);
                 }
@@ -346,7 +339,7 @@ var createTenantWithAdmin = module.exports.createTenantWithAdmin = function(tena
                         return callback(err);
                     }
 
-                    // Re-enable captcha
+                    // Re-enable reCaptcha
                     var tenantAdminRestCtx = createTenantAdminRestContext(tenantHost);
                     ConfigTestUtil.updateConfigAndWait(tenantAdminRestCtx, null, {'oae-principals/recaptcha/enabled': true}, function(err) {
                         if (err) {
@@ -502,7 +495,8 @@ var createGlobalAdminRestContext = module.exports.createGlobalAdminRestContext =
  * @return {Context}           The api context that represents an administrator of the tenant
  */
 var createTenantAdminContext = module.exports.createTenantAdminContext = function(tenant) {
-    return new Context(tenant, new User(tenant.alias, 'u:' + tenant.alias + ':admin', 'Tenant Administrator', {'isTenantAdmin': true}));
+    var email = util.format('tenant-admin-%s', tenant.alias);
+    return new Context(tenant, new User(tenant.alias, 'u:' + tenant.alias + ':admin', 'Tenant Administrator', email, {'isTenantAdmin': true}));
 };
 
 /**
@@ -512,7 +506,12 @@ var createTenantAdminContext = module.exports.createTenantAdminContext = functio
  */
 var createGlobalAdminContext = module.exports.createGlobalAdminContext = function() {
     var globalTenant = global.oaeTests.tenants.global;
-    return new Context(globalTenant, new User(globalTenant.alias, 'u:' + globalTenant.alias + ':admin', 'Global Administrator', {'isGlobalAdmin': true}));
+    var globalAdminId = 'u:' + globalTenant.alias + ':admin';
+    var globalUser = new User(globalTenant.alias, globalAdminId, 'Global Administrator', 'admin@example.com', {
+        'visibility': 'private',
+        'isGlobalAdmin': true
+    });
+    return new Context(globalTenant, globalUser);
 };
 
 /**
@@ -801,7 +800,8 @@ var _createUserWithVisibility = function(restCtx, visibility, callback) {
     var password = 'password-' + randomId;
     var displayName = 'displayName-' + randomId;
     var publicAlias = 'publicAlias-' + randomId;
-    RestAPI.User.createUser(restCtx, username, password, displayName, {'visibility': visibility, 'publicAlias': publicAlias}, function(err, user) {
+    var email = generateTestEmailAddress();
+    RestAPI.User.createUser(restCtx, username, password, displayName, email, {'visibility': visibility, 'publicAlias': publicAlias}, function(err, user) {
         assert.ok(!err);
         return callback({'user': user, 'restContext': createTenantRestContext(restCtx.hostHeader, username, password)});
     });

--- a/node_modules/oae-util/tests/test-validator.js
+++ b/node_modules/oae-util/tests/test-validator.js
@@ -241,9 +241,9 @@ describe('Utilities', function() {
             // Invalid tenant
             var tenant2 = new Tenant(null, 'Invalid tenant', 2002);
             // Valid users
-            var user1 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'public', 'Nicolaas', 'Matthijs', 'Nicolaas Matthijs');
-            var user2 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'private', 'Nicolaas', 'Matthijs', 'Nicolaas Matthijs');
-            var user3 = new User(tenant1.alias, 'u:camtest:nm417', null, null, null, null, null);
+            var user1 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
+            var user2 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
+            var user3 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
 
             ////////////////////////////
             // Single test successful //
@@ -324,7 +324,7 @@ describe('Utilities', function() {
             var gtTenant = global.oaeTests.tenants.gt;
 
             // Test user
-            var user1 = new User(camTenant.alias, 'u:camtest:nm417', 'nm417', 'public', 'Nicolaas', 'Matthijs', 'Nicolaas Matthijs');
+            var user1 = new User(camTenant.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
 
             // Ensure it gives a validation error when not authenticated
             var validator = new Validator();


### PR DESCRIPTION
A mapping between an email address and a principal has been added which allows
us to resolve a user by their email address. Email verification is NOT
implemented yet.

This commit also moves `email` out of the options field when creating users 
and makes it a required parameter. Lots of the tests that were using 
createUser directly have been replaced with `TestsUtil.generateTestUsers`.