### PR TITLE
Prepend protocol to new links

### DIFF
--- a/node_modules/oae-content/lib/api.js
+++ b/node_modules/oae-content/lib/api.js
@@ -234,6 +234,13 @@ var createLink = module.exports.createLink = function(ctx, displayName, descript
 
     var contentId = _generateContentId(ctx.tenant().alias);
     var revisionId = _generateRevisionId(contentId);
+
+    // Make sure the URL starts with a protocol
+    var hasProtocol = link.indexOf('://') !== -1;
+    if (!hasProtocol) {
+        link = 'http://' + link;
+    }
+
     _createContent(ctx, contentId, revisionId, 'link', displayName, description, visibility, additionalMembers, folders, {'link': link}, {}, function(err, content, revision) {
         if (err) {
             return callback(err);

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -1522,7 +1522,18 @@ describe('Content', function() {
                                                             RestAPI.Content.createLink(contexts['nicolaas'].restContext, 'Test Content 7', '', null, 'http://www.oaeproject.org/', [], [], [], function(err, contentObj) {
                                                                 assert.ok(!err);
                                                                 assert.ok(contentObj.id);
-                                                                callback();
+
+                                                                // Verify that a protocol is added if missing
+                                                                RestAPI.Content.createLink(contexts['nicolaas'].restContext, 'Test Content 8', 'Test content description 8', 'public', 'www.oaeproject.org', [], [], [], function(err, contentObj, response) {
+                                                                    assert.ok(!err);
+                                                                    assert.ok(contentObj.id);
+                                                                    RestAPI.Content.getContent(contexts['nicolaas'].restContext, contentObj.id, function(err, contentObj) {
+
+                                                                        assert.ok(!err);
+                                                                        assert.equal(contentObj.link, 'http://www.oaeproject.org');
+                                                                        callback();
+                                                                    });
+                                                                });
                                                             });
                                                         });
                                                     });


### PR DESCRIPTION
New links that don't have a protocol should be prepended with `http://` to ensure they can always be correctly embedded.