### PR TITLE
Support etherpad 1.5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,10 @@ before_install:
 
   # Install etherpad
   - cd /usr/src
-  - sudo wget https://s3.amazonaws.com/oae-releases/etherpad/1.4/etherpad-1.4.0-63-14f9c91_node-0.10.17.tar.gz
+  - sudo wget https://s3.amazonaws.com/oae-releases/etherpad/1.5/etherpad-1.5.6_node-0.10.17.tar.gz
   - sudo mkdir /opt/etherpad
   - cd /opt/etherpad
-  - sudo tar -zxvf /usr/src/etherpad-1.4.0-63-14f9c91_node-0.10.17.tar.gz > /dev/null
+  - sudo tar -zxvf /usr/src/etherpad-1.5.6_node-0.10.17.tar.gz > /dev/null
   - sudo touch APIKEY.txt
   - sudo chmod -R 777 .
 
@@ -78,7 +78,7 @@ before_install:
 
   # Configure etherpad
   - "sed -i 's/dbType\" : \"dirty/dbType\" : \"cassandra/g' settings.json"
-  - "sed -i 's/\"filename\" : \"var\\/dirty.db\"/\"hosts\": [ \"localhost:9160\" ], \"keyspace\": \"etherpad\", \"cfName\": \"Etherpad\", \"user\": \"\", \"pass\": \"\", \"timeout\": 3000, \"replication\": \"1\", \"strategyClass\": \"SimpleStrategy\", \"cqlVersion\": \"2.0.0\"/g' settings.json"
+  - "sed -i 's/\"filename\" : \"var\\/dirty.db\"/\"clientOptions\": {\"keyspace\": \"etherpad\", \"contactPoints\": [\"localhost\"]},\"columnFamily\": \"Etherpad\"/g' settings.json"
   - "sed -i 's/defaultPadText\" : \".*\"/defaultPadText\" : \"\"/g' settings.json"
   - echo "13SirapH8t3kxUh5T5aqWXhXahMzoZRA" > APIKEY.txt
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Nginx is the most tested load balancer and web server used for OAE. A web server
 
 #### Etherpad lite
 
-[Etherpad](http://etherpad.org/) is an open-source editor for online collaborative editing in real-time and is used to power the OAE collaborative documents. Follow the [Etherpad README](https://github.com/ether/etherpad-lite/blob/develop/README.md) to get it installed. Make sure you get the 1.4.0 release.
+[Etherpad](http://etherpad.org/) is an open-source editor for online collaborative editing in real-time and is used to power the OAE collaborative documents. Follow the [Etherpad README](https://github.com/ether/etherpad-lite/blob/develop/README.md) to get it installed. Make sure you get the 1.5.6 release.
 
 Once you've installed Etherpad, you will also need the [Etherpad OAE](https://github.com/oaeproject/ep_oae) plugin. This is the glue for authenticating users between Hilary and etherpad-lite. The simplest method of installing the plugin is cloning it in the top node_modules folder that can be found in your etherpad-lite directory.
 

--- a/node_modules/oae-content/tests/test-collabdoc.js
+++ b/node_modules/oae-content/tests/test-collabdoc.js
@@ -62,7 +62,7 @@ describe('Collaborative documents', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         // Get the original test config
         testConfig = Etherpad.getConfig();
-        callback();
+        return callback();
     });
 
     /**
@@ -398,7 +398,7 @@ describe('Collaborative documents', function() {
 
                                 getEtherpadText(contentObj, function(err, data) {
                                     assert.ok(!err);
-                                    assert.equal(data.text, texts[1] + '\n');
+                                    assert.equal(data.text, texts[1] + '\n\n');
                                     return callback();
                                 });
                             });


### PR DESCRIPTION
Now that Etherpad has released a version that contains everything we need, we should be able to bind to a specific version (rather than a commit)