### PR TITLE
(Issue 1175) New-line before every HTML attribute

### DIFF
--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -10,19 +10,19 @@
         // Aggregate the header content into an array of lines of HTML content
         var lines = [];
         lines.push('<tr id="header" class="row">');
-        lines.push('    <td align="center">');
-        lines.push('        <table cellpadding="0" cellspacing="0">');
-        lines.push('            <tr id="logo">');
-        lines.push('                <td><img src="' + institutionalLogoURL + '" /></td>');
-        lines.push('            </tr>');
-        lines.push('            <tr id="greeting">');
-        lines.push('                <td><h1>' + greeting + '</h1></td>');
-        lines.push('            </tr>');
-        lines.push('            <tr id="summary" class="muted">');
-        lines.push('                <td class="wrapped">' + shared.getEmailSummary(util, user.emailPreference, activities, baseUrl) + '</td>');
-        lines.push('            </tr>');
-        lines.push('        </table>');
-        lines.push('    </td>');
+        lines.push(     '<td align="center">');
+        lines.push(         '<table cellpadding="0" cellspacing="0">');
+        lines.push(             '<tr id="logo">');
+        lines.push(                 '<td><img src="' + institutionalLogoURL + '" /></td>');
+        lines.push(             '</tr>');
+        lines.push(             '<tr id="greeting">');
+        lines.push(                 '<td><h1>' + greeting + '</h1></td>');
+        lines.push(             '</tr>');
+        lines.push(             '<tr id="summary" class="muted">');
+        lines.push(                 '<td class="wrapped">' + shared.getEmailSummary(util, user.emailPreference, activities, baseUrl) + '</td>');
+        lines.push(             '</tr>');
+        lines.push(         '</table>');
+        lines.push(     '</td>');
         lines.push('</tr>');
 
         // Join the lines together by new line, adding the trailing new line to the end

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -21,7 +21,8 @@ var util = require('util');
 
 var AuthzUtil = require('oae-authz/lib/util');
 var ConfigTestUtil = require('oae-config/lib/test/util');
-var EmailTestsUtil = require('oae-email/lib/test/util');
+var EmailTestUtil = require('oae-email/lib/test/util');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var Sanitization = require('oae-util/lib/sanitization');
@@ -55,7 +56,7 @@ describe('Activity Email', function() {
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
 
         // Flush the pending mails
-        EmailTestsUtil.clearEmailCollections(function() {
+        EmailTestUtil.clearEmailCollections(function() {
             refreshConfiguration(null, false, false, {}, function(config) {
                 return callback();
             });
@@ -146,7 +147,7 @@ describe('Activity Email', function() {
                 assert.ok(!err);
 
                 // Clear emails to start
-                EmailTestsUtil.collectAndFetchAllEmails(function() {
+                EmailTestUtil.collectAndFetchAllEmails(function() {
                     var instanceName = TestsUtil.generateRandomText(1);
                     var instanceURL = util.format('http://www.instance.oaeproject.org/%s', TestsUtil.generateRandomText(1));
                     var hostingOrganization = TestsUtil.generateRandomText(1);
@@ -181,7 +182,7 @@ describe('Activity Email', function() {
                         assertions = assertions || {};
 
                         // Ensure the OAE information is always available
-                        assert.notEqual(message.html.indexOf('Apereo <a href=\"http://www.oaeproject.org\" '), -1);
+                        assert.notEqual(message.html.indexOf('Apereo <a\n href=\"http://www.oaeproject.org\"\n '), -1);
                         assert.notEqual(message.html.indexOf('Open Academic Environment</a>'), -1);
 
                         // Ensure the instance information is accurate
@@ -194,10 +195,10 @@ describe('Activity Email', function() {
                         }
 
                         if (assertions.expectInstanceURL) {
-                            assert.notEqual(message.html.indexOf(util.format('<a href=\"%s\" ', instanceURL)), -1);
+                            assert.notEqual(message.html.indexOf(util.format('<a\n href=\"%s\"\n ', instanceURL)), -1);
                             assert.notEqual(message.html.indexOf(util.format('%s</a>', instanceName)), -1);
                         } else {
-                            assert.strictEqual(message.html.indexOf(util.format('<a href=\"%s\" ', instanceURL)), -1);
+                            assert.strictEqual(message.html.indexOf(util.format('<a href=\"%s\"\n ', instanceURL)), -1);
                             assert.strictEqual(message.html.indexOf(util.format('%s</a>', instanceName)), -1);
                         }
 
@@ -211,10 +212,10 @@ describe('Activity Email', function() {
                         }
 
                         if (assertions.expectHostingOrganizationURL) {
-                            assert.notEqual(message.html.indexOf(util.format('<a href=\"%s\" ', hostingOrganizationURL)), -1);
+                            assert.notEqual(message.html.indexOf(util.format('<a\n href=\"%s\"\n ', hostingOrganizationURL)), -1);
                             assert.notEqual(message.html.indexOf(util.format('%s</a>', hostingOrganization)), -1);
                         } else {
-                            assert.strictEqual(message.html.indexOf(util.format('<a href=\"%s\" ', hostingOrganizationURL)), -1);
+                            assert.strictEqual(message.html.indexOf(util.format('<a\n href=\"%s\"\n ', hostingOrganizationURL)), -1);
                             assert.strictEqual(message.html.indexOf(util.format('%s</a>', hostingOrganization)), -1);
                         }
                     };
@@ -227,7 +228,7 @@ describe('Activity Email', function() {
                             assert.ok(!err);
 
                             // Ensure the email is as expected
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                 _assertEmailFooter(messages[0]);
 
                                 // Add a host instance information and generate another email
@@ -235,7 +236,7 @@ describe('Activity Email', function() {
                                     assert.ok(!err);
                                     RestAPI.Content.updateContent(mrvisser.restContext, link.id, {'displayName': 'Update 1'}, function(err, link) {
                                         assert.ok(!err);
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                             _assertEmailFooter(messages[0], {
                                                 'expectInstanceName': true,
                                                 'expectInstanceURL': true
@@ -248,7 +249,7 @@ describe('Activity Email', function() {
                                                     assert.ok(!err);
                                                     RestAPI.Content.updateContent(mrvisser.restContext, link.id, {'displayName': 'Update 2'}, function(err, link) {
                                                         assert.ok(!err);
-                                                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                             _assertEmailFooter(messages[0], {
                                                                 'expectHostingOrganizationName': true,
                                                                 'expectHostingOrganizationURL': true
@@ -259,7 +260,7 @@ describe('Activity Email', function() {
                                                                 assert.ok(!err);
                                                                 RestAPI.Content.updateContent(mrvisser.restContext, link.id, {'displayName': 'Update 3'}, function(err, link) {
                                                                     assert.ok(!err);
-                                                                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                                    EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                                         _assertEmailFooter(messages[0], {
                                                                             'expectInstanceName': true,
                                                                             'expectInstanceURL': true,
@@ -273,7 +274,7 @@ describe('Activity Email', function() {
                                                                             assert.ok(!err);
                                                                             RestAPI.Content.updateContent(mrvisser.restContext, link.id, {'displayName': 'Update 3'}, function(err, link) {
                                                                                 assert.ok(!err);
-                                                                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                                                     _assertEmailFooter(messages[0], {
                                                                                         'expectInstanceName': true,
                                                                                         'expectHostingOrganizationName': true
@@ -322,7 +323,7 @@ describe('Activity Email', function() {
                                 //  - 1 content-create: Branden created 2 links
                                 //  - 1 content-create: Simon created 2 links
                                 //  - 1 discussion-create: Simon created a discussion
-                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                     assert.equal(messages.length, 1);
                                     assert.equal(messages[0].to[0].address, nico.user.email);
                                     assert.ok(messages[0].html);
@@ -347,7 +348,7 @@ describe('Activity Email', function() {
                                     RestAPI.Discussions.createDiscussion(simong.restContext, 'Second discussion', 'descr', 'public', null, [nico.user.id, mrvisser.user.id], function(err, secondDiscussion) {
                                         assert.ok(!err);
 
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                             assert.equal(messages.length, 2);
                                             _.each(messages, function(message) {
                                                 assert.ok(_.contains([nico.user.email, mrvisser.user.email], message.to[0].address));
@@ -388,7 +389,7 @@ describe('Activity Email', function() {
                 assert.ok(!err);
 
                 // Collect the e-mails, Branden should've received an e-mail containing the content-create activity
-                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                     assert.equal(messages.length, 1);
                     assert.equal(messages[0].to[0].address, branden.user.email);
                     assert.ok(messages[0].html.indexOf(firstContentObj.displayName) > 0);
@@ -399,7 +400,7 @@ describe('Activity Email', function() {
                         assert.ok(!err);
 
                         // Collect the e-mails, Branden should've received an e-mail containing the content-create activity
-                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                             assert.equal(messages.length, 1);
                             assert.equal(messages[0].to[0].address, branden.user.email);
                             assert.equal(messages[0].html.indexOf(firstContentObj.displayName), -1);
@@ -411,7 +412,7 @@ describe('Activity Email', function() {
                                 assert.ok(!err);
 
                                 // Collect the e-mails, Branden should've received an e-mail containing the content-create activity
-                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                     assert.equal(messages.length, 1);
                                     assert.equal(messages[0].to[0].address, branden.user.email);
                                     assert.equal(messages[0].html.indexOf(firstContentObj.displayName), -1);
@@ -452,7 +453,7 @@ describe('Activity Email', function() {
                                     assert.ok(!err);
 
                                     // Collect the e-mails, only the immediate user should receive an e-mail
-                                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                    EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                         assert.equal(messages.length, 1);
                                         assert.equal(messages[0].to[0].address, immediateMailUser.user.email);
 
@@ -465,7 +466,7 @@ describe('Activity Email', function() {
                                                 assert.ok(!err);
 
                                                 // Collect the e-mails, only the immediate and daily users should've received an e-mail
-                                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                     assert.equal(messages.length, 2);
                                                     assert.ok(_.contains([immediateMailUser.user.email, dailyMailUser.user.email], messages[0].to[0].address));
                                                     assert.ok(_.contains([immediateMailUser.user.email, dailyMailUser.user.email], messages[1].to[0].address));
@@ -482,7 +483,7 @@ describe('Activity Email', function() {
                                                             assert.ok(!err);
 
                                                             // Collect the e-mails, only the immediate and weekly users should've received an e-mail
-                                                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                            EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                                 assert.equal(messages.length, 2);
                                                                 var mailAddresses = [immediateMailUser.user.email, weeklyMailUser.user.email];
                                                                 assert.ok(_.contains(mailAddresses, messages[0].to[0].address));
@@ -500,7 +501,7 @@ describe('Activity Email', function() {
                                                                         assert.ok(!err);
 
                                                                         // Collect the e-mails, all users (except the neverMailUser) should've received an e-mail
-                                                                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                                             assert.equal(messages.length, 3);
                                                                             var mailAddresses = [immediateMailUser.user.email, dailyMailUser.user.email, weeklyMailUser.user.email];
                                                                             assert.ok(_.contains(mailAddresses, messages[0].to[0].address));
@@ -587,7 +588,7 @@ describe('Activity Email', function() {
              * Once all tenants are setup trigger mail to all the users and assert that only one gets sent out
              */
             var allTenantsCreated = function() {
-                EmailTestsUtil.clearEmailCollections(function() {
+                EmailTestUtil.clearEmailCollections(function() {
                     // Create a user who will create the link and add the users thus triggering an email for each one
                     TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
                         assert.ok(!err);
@@ -597,7 +598,7 @@ describe('Activity Email', function() {
                             assert.ok(!err);
 
                             // Only one user should've received an email
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                 assert.equal(messages.length, 1);
                                 assert.equal(messages[0].to[0].address, receivingUser);
 
@@ -642,7 +643,7 @@ describe('Activity Email', function() {
                                 assert.ok(!err);
 
                                 // As the hour was set to 5hrs after Nico's current time, he should not receive an email yet
-                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                     assert.equal(messages.length, 0);
 
                                     // If we manually collect the daily emails that are scheduled 5 hours ahead of the the UTC-5 timezone, Nico's mail should be sent out
@@ -882,7 +883,7 @@ describe('Activity Email', function() {
                             assert.ok(!err);
 
                             // Collect the email as though it is 3 hours ahead. Ensure only the later content item email gets sent to mrvisser
-                            EmailTestsUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
+                            EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
                                 assert.ok(!err);
                                 assert.strictEqual(messages.length, 1);
                                 assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
@@ -899,7 +900,7 @@ describe('Activity Email', function() {
                                     assert.ok(!err);
 
                                     // Collect the email for the current time and ensure we get the 2 "now" items
-                                    EmailTestsUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
+                                    EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
                                         assert.ok(!err);
                                         assert.strictEqual(messages.length, 1);
                                         assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
@@ -950,7 +951,7 @@ describe('Activity Email', function() {
                                 assert.ok(!err);
 
                                 // Collect the email as though it is 2 days ahead. Ensure only the later content item email gets sent to mrvisser
-                                EmailTestsUtil.collectAndFetchEmailsForBucket(0, 'daily', null, config.mail.daily.hour, function(messages) {
+                                EmailTestUtil.collectAndFetchEmailsForBucket(0, 'daily', null, config.mail.daily.hour, function(messages) {
                                     assert.ok(!err);
                                     assert.strictEqual(messages.length, 1);
                                     assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
@@ -967,7 +968,7 @@ describe('Activity Email', function() {
                                         assert.ok(!err);
 
                                         // Collect the email for the current time and ensure we get the 2 "now" items
-                                        EmailTestsUtil.collectAndFetchEmailsForBucket(0, 'daily', null, config.mail.daily.hour, function(messages) {
+                                        EmailTestUtil.collectAndFetchEmailsForBucket(0, 'daily', null, config.mail.daily.hour, function(messages) {
                                             assert.ok(!err);
                                             assert.strictEqual(messages.length, 1);
                                             assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
@@ -1019,7 +1020,7 @@ describe('Activity Email', function() {
                                 assert.ok(!err);
 
                                 // Collect the email as though it is 2 weeks ahead. Ensure only the later content item email gets sent to mrvisser
-                                EmailTestsUtil.collectAndFetchEmailsForBucket(0, 'weekly', config.mail.weekly.day, config.mail.weekly.hour, function(messages) {
+                                EmailTestUtil.collectAndFetchEmailsForBucket(0, 'weekly', config.mail.weekly.day, config.mail.weekly.hour, function(messages) {
                                     assert.ok(!err);
                                     assert.strictEqual(messages.length, 1);
                                     assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
@@ -1036,7 +1037,7 @@ describe('Activity Email', function() {
                                         assert.ok(!err);
 
                                         // Collect the email for the current time and ensure we get the 2 "now" items
-                                        EmailTestsUtil.collectAndFetchEmailsForBucket(0, 'weekly', config.mail.weekly.day, config.mail.weekly.hour, function(messages) {
+                                        EmailTestUtil.collectAndFetchEmailsForBucket(0, 'weekly', config.mail.weekly.day, config.mail.weekly.hour, function(messages) {
                                             assert.ok(!err);
                                             assert.strictEqual(messages.length, 1);
                                             assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
@@ -1075,7 +1076,7 @@ describe('Activity Email', function() {
                         // Trigger a mail for Nico
                         RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [nico.user.id], [], function(err, link) {
                             assert.ok(!err);
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                 assert.equal(messages.length, 1);
 
                                 // Assert that we're using a localized message for the subject header
@@ -1093,7 +1094,7 @@ describe('Activity Email', function() {
                                         assert.ok(!err);
 
                                         // Collect the e-mail, there should only be one
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                             assert.equal(messages.length, 1);
 
                                             // Assert that we're using a localized message for the subject header
@@ -1106,7 +1107,7 @@ describe('Activity Email', function() {
                                             // Trigger a mail for Branden and Bert
                                             RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [branden.user.id, bert.user.id], [], function(err, thirdLink) {
                                                 assert.ok(!err);
-                                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                     assert.equal(messages.length, 2);
 
                                                     // Assert that the two subject headers are different as they have different email preferences
@@ -1168,9 +1169,9 @@ describe('Activity Email', function() {
                     ].join('\n');
 
                     var htmlBody = [
-                        '<p', /* style inserted here */ '>Link: <a href="http://oaeproject.org"', /* style inserted here */ '>OAE</a></p>',
-                        '<p', /* style inserted here */ '>OAE Link: <a href="http://' + global.oaeTests.tenants.cam.host + '/content/cam/foo"', /* style inserted here */ '>/content/cam/foo</a></p>',
-                        '<p', /* style inserted here */ '>Image: <img src="http://www.oaeproject.org/themes/oae/logo.png" alt="Alternate Text" style="',
+                        '<p', /* style inserted here */ '>Link: <a\n href="http://oaeproject.org"', /* style inserted here */ '>OAE</a></p>',
+                        '<p', /* style inserted here */ '>OAE Link: <a\n href="http://' + global.oaeTests.tenants.cam.host + '/content/cam/foo"', /* style inserted here */ '>/content/cam/foo</a></p>',
+                        '<p', /* style inserted here */ '>Image: <img\n src="http://www.oaeproject.org/themes/oae/logo.png"\n alt="Alternate Text"\n style="',
                         '<ul', /* style inserted here */ '>','<li>Bullet Item</li>','</ul>',
                         '<p', /* style inserted here */ '><em>Emphasized Text</em></p>',
                         '<p', /* style inserted here */ '><strong>Strong Text</strong></p>',
@@ -1184,7 +1185,7 @@ describe('Activity Email', function() {
                         assert.ok(!err);
 
                         // Get the resulting email notification
-                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
 
                             // Find the email message for the first user
                             var mail = _.find(messages, function(message) { return (message.to[0].address === user1.user.email); });
@@ -1226,7 +1227,7 @@ describe('Activity Email', function() {
                         // Trigger a mail for Nico and Bert
                         RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [nico.user.id, bert.user.id], [], function(err, link) {
                             assert.ok(!err);
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                 assert.equal(messages.length, 2);
 
                                 // Assert that the messages contain properly formatted dates
@@ -1287,7 +1288,7 @@ describe('Activity Email', function() {
                                                         // Deliver the e-mails, only Branden and Bert should get an e-mail as stuart has
                                                         // selected to never get emails and Nico his activity email stream should've been
                                                         // cleared when he marked his notifications as read
-                                                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                                             assert.equal(messages.length, 2);
                                                             _.each(messages, function(message) {
                                                                 assert.ok(_.contains([branden.user.email, bert.user.email], message.to[0].address));
@@ -1335,7 +1336,7 @@ describe('Activity Email', function() {
                         ActivityAPI.once(ActivityConstants.events.UPDATED_USER, function() {
 
                             // When we collect the emails, Nico should not get an email
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                 assert.equal(messages.length, 0);
 
                                 // Sanity check that Nico gets the email when the dailies are sent out
@@ -1368,7 +1369,7 @@ describe('Activity Email', function() {
                     assert.ok(!err);
 
                     // When we collect the emails, Nico should get an email
-                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                    EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                         assert.equal(messages.length, 1);
 
                         // Now change Nico's preference to never
@@ -1380,7 +1381,7 @@ describe('Activity Email', function() {
                                 assert.ok(!err);
 
                                 // When we collect the emails, Nico should get an email
-                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                     assert.equal(messages.length, 0);
                                     return callback();
                                 });
@@ -1433,7 +1434,7 @@ describe('Activity Email', function() {
                                         assert.ok(!err);
 
                                         // Collect the emails, there should only be one containing one activity which is an aggregate of 4 comments
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                             // 3 messages, 1 for Simon (manager) and 2 for Nico and Branden (recent commenters)
                                             assert.equal(messages.length, 3);
 
@@ -1483,7 +1484,7 @@ describe('Activity Email', function() {
                         assert.ok(!err);
 
                          // Collect the email and check for some basic pitfalls in the template
-                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                             assert.equal(messages.length, 1);
                             var html = messages[0].html;
                             var text = messages[0].text;
@@ -1493,12 +1494,12 @@ describe('Activity Email', function() {
                             assert.ok(text);
 
                             // Assert there are no untranslated keys in there
-                            assert.strictEqual(html.indexOf('__MSG__'), -1, 'An i18n key was not replaced in the html template');
-                            assert.strictEqual(text.indexOf('__MSG__'), -1, 'An i18n key was not replaced in the text template');
+                            assert.strictEqual(html.indexOf('__MSG__'), -1, 'An i18n key was not replaced in the html email template');
+                            assert.strictEqual(text.indexOf('__MSG__'), -1, 'An i18n key was not replaced in the text email template');
 
                             // Assert all dynamic variables are replaced
-                            assert.strictEqual(html.indexOf('${'), -1, 'A dynamic variable was not replaced in the html template');
-                            assert.strictEqual(text.indexOf('${'), -1, 'A dynamic variable was not replaced in the text template');
+                            assert.strictEqual(html.indexOf('${'), -1, 'A dynamic variable was not replaced in the html email template');
+                            assert.strictEqual(text.indexOf('${'), -1, 'A dynamic variable was not replaced in the text email template');
 
                             // Assert that there are no URLs in the template that don't include the tenant base url
                             assert.strictEqual(html.indexOf('href="/'), -1, 'Links in emails should include the tenant base url');
@@ -1559,7 +1560,7 @@ describe('Activity Email', function() {
                     assert.ok(!err);
 
                     // Collect the emails for the target users
-                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                    EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                         // Ensure we have 1 message. `thirdUser` does not get one because they do
                         // not have an email addres. However that should not stop `secondUser` from
                         // getting an email
@@ -1587,7 +1588,7 @@ describe('Activity Email', function() {
                     assert.ok(!err);
 
                     // Collect the emails
-                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                    EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                         // Ensure we get one email, it is the following email, and that there are no
                         // links to mrvisser's profile
                         assert.strictEqual(messages.length, 1);
@@ -1640,14 +1641,52 @@ describe('Activity Email', function() {
                             assert.ok(!err);
 
                              // Because of the grace period however, Nico should not get the email in this collection cycle
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                 assert.strictEqual(messages.length, 0);
 
                                 // If we let the grace period pass, Nico should get his email
-                                setTimeout(EmailTestsUtil.collectAndFetchAllEmails, 1000, function(messages) {
+                                setTimeout(EmailTestUtil.collectAndFetchAllEmails, 1000, function(messages) {
                                     assert.strictEqual(messages.length, 1);
                                     assert.ok(messages[0].html.indexOf('Link #1') > 0);
                                     assert.ok(messages[0].html.indexOf('Link #2') > 0);
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    /**
+     * Regression test for one of our more verbose activities (2 or more items shared with a group).
+     * Here we ensure that there is no line that surpasses a safe SMTP threshold
+     */
+    it('verify email for 2 items being created for a group do not result in lines that are too long', function(callback) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, simong, nico) {
+            assert.ok(!err);
+            TestsUtil.generateTestGroups(simong.restContext, 1, function(group) {
+                group = group.group;
+
+                // Add the members to the group
+                var members = {};
+                members[nico.user.id] = 'manager';
+                PrincipalsTestUtil.assertSetGroupMembersSucceeds(simong.restContext, group.id, members, function() {
+
+                    // Collect any email notifications so we can focus on just the one we generate next
+                    EmailTestUtil.collectAndFetchAllEmails(function() {
+
+                        // Create 2 links for the group
+                        RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.myawesomelinkthatilike.ca', [group.id], [], [], function(err) {
+                            assert.ok(!err);
+                            RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.anotherlinkthatilike.ca/this/is/reasonably/long?so=what&will=happen', [group.id], [], [], function(err) {
+                                assert.ok(!err);
+
+                                // Collect email, ensuring that no line surpasses an acceptable threshold
+                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
+                                    assert.strictEqual(messages.length, 1);
+                                    assert.notEqual(messages[0].html.indexOf('in the group'), -1);
                                     return callback();
                                 });
                             });

--- a/node_modules/oae-email/lib/api.js
+++ b/node_modules/oae-email/lib/api.js
@@ -399,7 +399,19 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
             return callback(err);
         }
 
-        emailInfo.html = inlinedHtml;
+        // Process the HTML such that we add line breaks before each html attribute to try and keep
+        // line length below 998 characters
+        emailInfo.html = _.chain(inlinedHtml.split('\n'))
+            .map(function(line) {
+                return line.replace(/<[^\/][^>]+>/g, function(match) {
+                    return match.replace(/\s+[a-zA-Z0-9_-]+="[^"]+"/g, function(match) {
+                        return util.format('\n%s', match);
+                    });
+                });
+            })
+            .value()
+            .join('\n');
+
         return _sendEmail(emailInfo, opts, callback);
     });
 };

--- a/node_modules/oae-email/lib/test/util.js
+++ b/node_modules/oae-email/lib/test/util.js
@@ -106,13 +106,17 @@ var collectAndFetchAllEmails = module.exports.collectAndFetchAllEmails = functio
                     ActivityEmail.collectAllBuckets(function() {
                         EmailAPI.removeListener('debugSent', _handleDebugSent);
 
-                        // Ensure no email has an html content line longer than 997 chars (999 chars
-                        // minus CR+LF) to ensure we don't have any issues with postfix line-wrap
+                        // SMTP specifications have a requirement that no line in an email body
+                        // should surpass 999 characters, including the CR+LF character. This check
+                        // ensures no email has an html content line longer than 500 chars, which
+                        // accounts for post-processing things such as SendGrid changing the links
+                        // to extremely long values (e.g., ~400 characters long) for click-tracking
+                        //
                         // @see https://github.com/oaeproject/Hilary/issues/1168
                         _.each(messages, function(message) {
                             assert.ok(_.isString(message.html));
                             _.each(message.html.split('\n'), function(line) {
-                                assert.ok(line.length <= 997, util.format('Expected no email line to be more than 997 characters, but found: %s', line));
+                                assert.ok(line.length <= 500, util.format('Expected no email line to be more than 500 characters, but found: (%s) %s', line.length, line));
                             });
                         });
 

--- a/node_modules/oae-email/lib/test/util.js
+++ b/node_modules/oae-email/lib/test/util.js
@@ -117,6 +117,7 @@ var collectAndFetchAllEmails = module.exports.collectAndFetchAllEmails = functio
                             assert.ok(_.isString(message.html));
                             _.each(message.html.split('\n'), function(line) {
                                 assert.ok(line.length <= 500, util.format('Expected no email line to be more than 500 characters, but found: (%s) %s', line.length, line));
+                                assert.ok(line.split('<a').length < 3, util.format('Expected no email line to have more than 1 link, but found: %s', line));
                             });
                         });
 


### PR DESCRIPTION
I'm currently testing this, but thought I'd run the approach by you.

It adds a new line before all HTML attributes. It's quite aggressive, but should allow us to mostly forget about line length, unless our inlined styles get crazy.

As things stand right now with this fix, the longest email line that gets generated in our unit tests is ~350 chars long.