### PR TITLE
Deprecated usage of strftime

### DIFF
--- a/node_modules/oae-uservoice/lib/api.js
+++ b/node_modules/oae-uservoice/lib/api.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-var strftimeTz = require('strftime').strftimeTZ;
+var strftime = require('strftime');
 var UservoiceSSO = require('uservoice-sso');
 
 var log = require('oae-logger').logger('oae-uservoice-api');
@@ -99,7 +99,7 @@ var _generateAuthenticationToken = function(user, subdomain, ssoKey, expiresIn, 
     // Determine when this encrypted authentication token will expire. This does
     // not determine when the user profile expires, that lasts indefinitely
     var expiresOn = new Date(Date.now() + expiresIn);
-    data.expires = strftimeTz('%F %T', expiresOn, 0);
+    data.expires = strftime.timezone(0)('%F %T', expiresOn);
 
     var token = new UservoiceSSO(subdomain, ssoKey).createToken(data);
     log().trace({'subdomain': subdomain, 'data': data, 'token': token}, 'Created encrypted token for UserVoice authentication');


### PR DESCRIPTION
strftime has deprecated one of their methods. When running the unit tests I get:

> [WARNING] `require('strftime').strftimeTZ(format, date, tz)` is deprecated and will be removed in version 1.0. Instead, use `var s = require('strftime').timezone(tz); s(format, [date])` or `require('strftime').timezone(tz)(format, [date])`.