### PR TITLE
Intermittent failure in activity API

### DIFF
--- a/node_modules/oae-activity/tests/test-activity.js
+++ b/node_modules/oae-activity/tests/test-activity.js
@@ -1845,6 +1845,7 @@ describe('Activity', function() {
                         assert.ok(!err);
 
                         // Drop an aggregate in. This is when the aggregate should be initially persisted, so should expire 1s from this time
+                        var timePersisted = Date.now();
                         ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
                             assert.ok(!err);
 
@@ -1858,8 +1859,9 @@ describe('Activity', function() {
 
                                 // Verify that the DAO reports the aggregated entity is indeed there at this time
                                 ActivityDAO.getAggregatedEntities([aggregateKey], function(err, aggregatedEntities) {
+                                    var timeSincePersisted = Date.now() - timePersisted;
                                     assert.ok(!err);
-                                    assert.ok(aggregatedEntities[aggregateKey]);
+                                    assert.ok(aggregatedEntities[aggregateKey], util.format('Expected to find aggregate entity with key: %s. Duration since persistence: %s', aggregateKey, timeSincePersisted));
                                     assert.ok(aggregatedEntities[aggregateKey]['actors']['user:' + jack.id]);
                                     assert.ok(aggregatedEntities[aggregateKey]['objects']['content:' + link.id]);
 


### PR DESCRIPTION
See https://travis-ci.org/oaeproject/Hilary/builds/61470610

```
1) Activity Activity Stream Aggregation verify aggregated data is automatically deleted after the idle expiry time:
     Uncaught AssertionError: "undefined" == true
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-activity/tests/test-activity.js:1862:40
      at /home/travis/build/oaeproject/Hilary/node_modules/oae-activity/lib/internal/dao.js:9:12760
      at b (domain.js:183:18)
      at try_callback (/home/travis/build/oaeproject/Hilary/node_modules/redis/index.js:592:9)
      at RedisClient.return_reply (/home/travis/build/oaeproject/Hilary/node_modules/redis/index.js:685:13)
      at HiredisReplyParser.<anonymous> (/home/travis/build/oaeproject/Hilary/node_modules/redis/index.js:321:14)
      at HiredisReplyParser.emit (events.js:95:17)
      at HiredisReplyParser.execute (/home/travis/build/oaeproject/Hilary/node_modules/redis/lib/parser/hiredis.js:43:18)
      at RedisClient.on_data (/home/travis/build/oaeproject/Hilary/node_modules/redis/index.js:547:27)
      at Socket.<anonymous> (/home/travis/build/oaeproject/Hilary/node_modules/redis/index.js:102:14)
```