### PR TITLE
`youtu.be` URL is not embedded correctly

### DIFF
--- a/node_modules/oae-preview-processor/config/config.js
+++ b/node_modules/oae-preview-processor/config/config.js
@@ -32,5 +32,12 @@ module.exports = {
             'apikey': new Fields.Text('API Key', 'The Flickr API key', '', {'tenantOverride': false, 'suppress': true, 'globalAdminOnly': true}),
             'apisecret': new Fields.Text('API Secret', 'The Flickr API secret', '', {'tenantOverride': false, 'suppress': true, 'globalAdminOnly': true})
         }
+    },
+    'youtube': {
+        'name': 'YouTube configuration',
+        'description': 'Configuration for the YouTube retriever',
+        'elements': {
+            'key': new Fields.Text('Key', 'The YouTube server key', '', {'tenantOverride': false, 'suppress': true, 'globalAdminOnly': true})
+        }
     }
 };

--- a/node_modules/oae-preview-processor/lib/processors/link/youtube.js
+++ b/node_modules/oae-preview-processor/lib/processors/link/youtube.js
@@ -15,11 +15,12 @@
 
 var _ = require('underscore');
 var url = require('url');
-var youtube = require('youtube-feeds');
+var Youtube = require('youtube-api');
 
 var log = require('oae-logger').logger('oae-preview-processor');
 
 var LinkProcessorUtil = require('oae-preview-processor/lib/processors/link/util');
+var PreviewConfig = require('oae-config').config('oae-preview-processor');
 var PreviewUtil = require('oae-preview-processor/lib/util');
 
 var YOUTUBE_FULL_REGEX = /^http(s)?:\/\/(www\.)?youtube\.com\/watch/;
@@ -49,21 +50,29 @@ var generatePreviews = module.exports.generatePreviews = function(ctx, contentOb
     // Get the movie identifier
     var id = _getId(contentObj.link);
 
+    Youtube.authenticate({
+        'type': 'key',
+        'key': PreviewConfig.getValue('admin', 'youtube', 'key')
+    });
+
     // Get the metadata for this video
-    youtube.video(id, function(err, data) {
+    Youtube.videos.list({'part': 'snippet', 'id': id}, function(err, data) {
         if (err) {
             log().error({'err': err}, 'Could not talk to the youtube api.');
             return callback({'code': 500, 'msg': err.message});
         }
 
-        if (data && data.thumbnail && data.thumbnail.hqDefault) {
+        if (data && data.items && data.items[0] && data.items[0].snippet) {
+            var snippet = data.items[0].snippet;
+
             var opts = {
-                'displayName': data.title,
-                'description': data.description
+                'displayName': snippet.title,
+                'description': snippet.description
             };
 
             // Download it
-            var imageUrl = data.thumbnail.hqDefault;
+            var thumbnail = snippet.thumbnails.maxres || snippet.thumbnails['default'];
+            var imageUrl = thumbnail.url;
             var path = ctx.baseDir + '/youtube.jpg';
             PreviewUtil.downloadRemoteFile(imageUrl, path, function(err, path) {
                 if (err) {

--- a/node_modules/oae-preview-processor/lib/rest.js
+++ b/node_modules/oae-preview-processor/lib/rest.js
@@ -14,6 +14,7 @@
  */
 
 var _ = require('underscore');
+var urlExpander = require('expand-url');
 
 var log = require('oae-logger').logger('preview-processor-rest');
 var OAE = require('oae-util/lib/oae');
@@ -100,3 +101,30 @@ var _handleReprocessPreview = function(req, res) {
  */
 OAE.globalAdminRouter.on('post', '/api/content/:contentId/revision/:revisionId/reprocessPreview', _handleReprocessPreview);
 OAE.tenantRouter.on('post', '/api/content/:contentId/revision/:revisionId/reprocessPreview', _handleReprocessPreview);
+
+/**
+ * @REST getLongurlExpand
+ *
+ * Expand a short URL into its long URL form
+ *
+ * @Server      tenant
+ * @Method      GET
+ * @Path        /longurl/expand
+ * @QueryParam  {string}        url             The short URL that should be expanded
+ * @Return      {LongUrl}
+ * @HttpResponse                200             The long URL
+ * @HttpResponse                500             The URL could not be expanded
+ */
+OAE.tenantRouter.on('get', '/api/longurl/expand', function(req, res) {
+    var url = decodeURIComponent(req.query.url);
+    urlExpander.expand(url, function(err, longUrl) {
+        if (err) {
+            return res.status(500).send(err.message);
+        }
+
+        var data = {
+            'long-url': longUrl
+        };
+        return res.status(200).send(data);
+    });
+});

--- a/node_modules/oae-preview-processor/lib/restmodel.js
+++ b/node_modules/oae-preview-processor/lib/restmodel.js
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+
+/**
+ * @RESTModel LongUrl
+ *
+ * @Required    [long-url]
+ * @Property    {string}            long-url             The expanded URL
+ */

--- a/node_modules/oae-preview-processor/tests/test-longurl.js
+++ b/node_modules/oae-preview-processor/tests/test-longurl.js
@@ -1,0 +1,78 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+var assert = require('assert');
+
+var RestAPI = require('oae-rest');
+var TestsUtil = require('oae-tests/lib/util');
+
+describe('Long url', function() {
+
+    var anonymousCamRestContext = null;
+
+    before(function(callback) {
+        anonymousCamRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+        return callback();
+    });
+
+    /**
+     * Mock the HEAD requests the expander API will make
+     *
+     * @api private
+     */
+    var _mockRequests = function() {
+        // Require nock inline as it messes with the HTTP stack
+        // We only want this to happen in a controlled environment
+        var nock = require('nock');
+
+        // Ensure we can still perform regular HTTP requests during our tests
+        nock.enableNetConnect();
+
+        // The first request redirects to HTTPS
+        nock('http://youtu.be')
+            .head('/FYWLiGOBy1k')
+            .reply(301, 'OK', {
+                'location': 'https://youtu.be/FYWLiGOBy1k'
+            });
+
+        // The second request redirects to the full page
+        nock('https://youtu.be')
+            .get('/FYWLiGOBy1k')
+            .reply(301, 'OK', {
+                'location': 'https://www.youtube.com/watch?v=FYWLiGOBy1k&feature=youtu.be'
+            });
+
+        // The third request does not redirect
+        nock('https://www.youtube.com')
+            .get('/watch?v=FYWLiGOBy1k&feature=youtu.be')
+            .reply(200, '<html>..</html>');
+    };
+
+    /**
+     * Test that verifies that short URLs are expanded
+     */
+    it('verify it expands short URLs', function(callback) {
+        // Mock the HEAD requests
+        _mockRequests();
+
+        RestAPI.Previews.expandUrl(anonymousCamRestContext, 'http://youtu.be/FYWLiGOBy1k', function(err, data) {
+            assert.ok(!err);
+            assert.ok(data);
+            assert.strictEqual(data['long-url'], 'https://www.youtube.com/watch?v=FYWLiGOBy1k&feature=youtu.be');
+            return callback();
+        });
+    });
+});

--- a/node_modules/oae-preview-processor/tests/test-previews.js
+++ b/node_modules/oae-preview-processor/tests/test-previews.js
@@ -910,14 +910,81 @@ describe('Preview processor', function() {
         });
 
         /**
-         * FIXME: Re-enable when https://github.com/oaeproject/Hilary/pull/1139 is merged
-         * Test that verifies the youtube processor and assures that metadata is retrieved/set.
+         * Mock the YouTube REST API
          *
+         * @api private
+         */
+        var _mockYoutube = function() {
+            // Require nock inline as it messes with the HTTP stack
+            // We only want this to happen in a controlled environment
+            var nock = require('nock');
+
+            // Ensure we can still perform regular HTTP requests during our tests
+            nock.enableNetConnect();
+
+            // Expect GET requests to:
+            // https://www.googleapis.com/youtube/v3/videos?part=snippet&id=...&key=...
+            nock('https://www.googleapis.com')
+                .get('/youtube/v3/videos?part=snippet&id=lgTQ5I_H4Xk&key=')
+                .twice()
+                .reply(200, {
+                    'kind': 'youtube#videoListResponse',
+                    'etag': '\"tbWC5XrSXxe1WOAx6MK9z4hHSU8/CQhw2t_NZKBaw72WEH7b1hSa6RA\"',
+                    'pageInfo': {
+                        'totalResults': 1,
+                        'resultsPerPage': 1
+                    },
+                    'items': [
+                        {
+                            'kind': 'youtube#video',
+                            'etag': '"tbWC5XrSXxe1WOAx6MK9z4hHSU8/TScJmbzIomSQvSDFqAgTXGr7Y2U"',
+                            'id': 'lgTQ5I_H4Xk',
+                            'snippet': {
+                                'publishedAt': '2013-05-09T20:54:56.000Z',
+                                'channelId': 'UCzDbnWaP_5kd6HpvDUjoT4Q',
+                                'title': 'How to prounounce \"Apereo\"',
+                                'description': 'Here is Ian Dolphin, the Executive Director of the Apereo Foundation, with the official pronunciation of the word \"Apereo\".',
+                                'thumbnails': {
+                                    'default': {
+                                        'url': 'https://i.ytimg.com/vi/lgTQ5I_H4Xk/default.jpg',
+                                        'width': 120,
+                                        'height': 90
+                                    },
+                                    'medium': {
+                                        'url': 'https://i.ytimg.com/vi/lgTQ5I_H4Xk/mqdefault.jpg',
+                                        'width': 320,
+                                        'height': 180
+                                    },
+                                    'high': {
+                                        'url': 'https://i.ytimg.com/vi/lgTQ5I_H4Xk/hqdefault.jpg',
+                                        'width': 480,
+                                        'height': 360
+                                    }
+                                },
+                                'channelTitle': 'Apereo Foundation',
+                                'categoryId': '28',
+                                'liveBroadcastContent': 'none',
+                                'localized': {
+                                    'title': 'How to prounounce \"Apereo\"',
+                                    'description': 'Here is Ian Dolphin, the Executive Director of the Apereo Foundation, with the official pronunciation of the word \"Apereo\".'
+                                }
+                            }
+                        }
+                    ]
+                });
+        };
+
+        /**
+         * Test that verifies the youtube processor and assures that metadata is retrieved/set.
+         */
         it('verify youtube link processing works', function(callback) {
             // Ignore this test if the PP is disabled
             if (!defaultConfig.previews.enabled) {
                 return callback();
             }
+
+            // Mock the request to the YouTube API
+            _mockYoutube();
 
             // Assert a regular youtube link
             _createContentAndWait('link', 'http://www.youtube.com/watch?v=lgTQ5I_H4Xk', null, function(restCtx, content) {
@@ -958,7 +1025,6 @@ describe('Preview processor', function() {
                 });
             });
         });
-*/
 
         /**
          * Mock the SlideShare REST API if the tests are not run as part of an integration test

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "elasticsearchclient": "latest",
     "ent": "latest",
     "etherpad-lite-client": "latest",
+    "expand-url": "latest",
     "express": "4.2.0",
     "globalize": "0.1.1",
     "gm": "latest",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "watch": "latest",
     "webshot": "latest",
     "xml2js": "latest",
-    "youtube-feeds": "latest"
+    "youtube-api": "latest"
   },
   "devDependencies": {
     "coveralls": "latest",


### PR DESCRIPTION
When adding a `youtu.be` URL (e.g. https://youtu.be/FYWLiGOBy1k), the link does not embed correctly in the content profile page:

![screen shot 2015-03-12 at 10 46 43 am](https://cloud.githubusercontent.com/assets/109850/6624253/5ef6397c-c8a5-11e4-9718-63630c605a3a.png)

However, when using the full youtube URL (https://www.youtube.com/watch?v=FYWLiGOBy1k&feature=youtu.be), embedding is working as expected.

As the `youtu.be` and `youtube.com` URLs are essentially the same, they should both embed as expected.