### PR TITLE
Remove backward compatibility route for members library search: `members`

### DIFF
--- a/node_modules/oae-search/lib/rest.js
+++ b/node_modules/oae-search/lib/rest.js
@@ -79,20 +79,5 @@ var _handleSearchRequest = function(req, res) {
     });
 };
 
-/*!
- * DEPRECATED: After released, removal of this endpoint should be coordinated with the STEM
- * Incubator group.
- *
- * Provides the same functionality as the `members-library` search.
- */
-OAE.tenantRouter.on('get', '/api/search/members/:groupId', function(req, res) {
-    var redirectUrl = util.format('/api/search/members-library/%s', req.params.groupId);
-    var queryString = req.originalUrl.split('?')[1];
-    if (queryString) {
-        redirectUrl += util.format('?%s', queryString);
-    }
-    res.redirect(301, redirectUrl);
-});
-
 OAE.tenantRouter.on('get', REGEX_SEARCH_ENDPOINT, _handleSearchRequest, '/api/search');
 OAE.globalAdminRouter.on('get', REGEX_SEARCH_ENDPOINT, _handleSearchRequest, '/api/search');


### PR DESCRIPTION
STEM incubator UI is now transitioned over as per @sathomas 