### PR TITLE
Documentation warning

### DIFF
--- a/node_modules/oae-principals/lib/delete.js
+++ b/node_modules/oae-principals/lib/delete.js
@@ -168,7 +168,7 @@ var _invokeGroupHandlers = function(log, handlers, group) {
  * @param  {Logger}         log         The logger to use to report progress
  * @param  {Object}         handlers    The handler functions keyed by their handler name, indicating which handlers to invoke
  * @param  {User|Group}     principal   The user or group that was the target of the operation
- * @param  {Object...}      args...     A variable number of arguments for the handler depending on its type
+ * @param  {...Object}      args        A variable number of arguments for the handler depending on its type
  * @api private
  */
 var _invokeHandlers = function(log, handlers, principal /*, args... */) {

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -350,7 +350,7 @@ var updateTenant = module.exports.updateTenant = function(ctx, alias, tenantUpda
  * @param  {Context}      ctx             Standard context object containing the current user and the current tenant
  * @param  {String[]}     aliases         An array of aliases representing the tenants that should be stopped
  * @param  {Boolean}      disabled        True if the tenant needs to be disabled
- * @param  {[Function]}   callback        Callback function executed when request is completed
+ * @param  {Function}     [callback]      Callback function executed when request is completed
  * @param  {Object}       callback.err    An error that occurred, if any
  */
 var disableTenants = module.exports.disableTenants = function(ctx, aliases, disabled, callback) {

--- a/node_modules/oae-util/lib/util.js
+++ b/node_modules/oae-util/lib/util.js
@@ -99,7 +99,7 @@ var isUnspecified = module.exports.isUnspecified = function(val) {
  *
  * @param  {Boolean}    isNecessary     Whether or not the provided method should be invoked with the given args. If falsey, the method will not be invoked, if not falsey (truesy?) the method will be invoked.
  * @param  {Function}   method          The method to invoke if `isNecessary` is true
- * @param  {Object...}  args...         The arguments for the provided method. The final argument should always be the `callback` method that needs to be invoked if `isNecessary` is false. It can be the same callback method invoked if the method is executed.
+ * @param  {...Object}  args            The arguments for the provided method. The final argument should always be the `callback` method that needs to be invoked if `isNecessary` is false. It can be the same callback method invoked if the method is executed.
  */
 var invokeIfNecessary = module.exports.invokeIfNecessary = function(isNecessary, method /*, method args..., callback */) {
     var args = Array.prototype.slice.call(arguments);


### PR DESCRIPTION
Fresh install of OAE on OS X, first run, has the following in the log:

```
[2015-05-27T16:16:05.319Z]  WARN: oae-doc/15618 on lawn-143-215-206-78.lawn.gatech.edu: Failed parsing comment data with dox for file /Users/stephen/Documents/Development/oae/Hilary/node_modules/oae-util/lib/../../../node_modules/oae-tenants/lib/api.js. Ignoring.
    err: {
      "name": "TypeLexerSyntaxError",
      "message": "Expected \"!\", \"(\", \"*\", \"...\", \"=\", \"?\", \"function\", \"module\", \"{\" or [a-zA-Z_$] but \"[\" found.:\n[Function]\n^"
    }
```

Presumably that's from

```
    /**
     * Disable or enable a tenant
     *
     * @param  {Context}      ctx             Standard context object containing the current user and the current tenant
     * @param  {String[]}     aliases         An array of aliases representing the tenants that should be stopped
     * @param  {Boolean}      disabled        True if the tenant needs to be disabled
     * @param  {[Function]}   callback        Callback function executed when request is completed
     * @param  {Object}       callback.err    An error that occurred, if any
     */
```