### PR TITLE
REST documentation out of date

### DIFF
--- a/node_modules/oae-search/lib/rest.js
+++ b/node_modules/oae-search/lib/rest.js
@@ -53,7 +53,7 @@ OAE.globalAdminRouter.on('post', '/api/search/reindexAll', function(req, res) {
  * @Server      admin,tenant
  * @Method      GET
  * @Path        /search/{searchType}
- * @PathParam   {string}                searchType          The type of search being performed                          [content-library,followers,following,general,members,memberships-library]
+ * @PathParam   {string}                searchType          The type of search being performed                          [content-library,followers,following,general,members-library,memberships-library]
  * @QueryParam  {number}                [limit]             The maximum number of search results to return
  * @QueryParam  {string}                [q]                 The search query
  * @QueryParam  {string}                [sort]              The sort direction. Defaults to asc                         [asc,desc]


### PR DESCRIPTION
It looks like the Swagger-based REST documentation is out of date:

![screen shot 2015-05-12 at 10 40 34 am](https://cloud.githubusercontent.com/assets/1731910/7590000/2a373eb0-f894-11e4-9758-206c2bc8d3b3.png)

I'm not sure what `memberships-library` does, but I think `members` should be changed to `members-library`? 

https://github.com/oaeproject/Hilary/blob/master/node_modules/oae-search/lib/rest.js#L56