### PR TITLE
Add REST endpoint to get login ids for a user

### DIFF
--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -770,16 +770,24 @@ var getUserLoginIds = module.exports.getUserLoginIds = function(ctx, userId, cal
     PrincipalsAPI.getUser(ctx, userId, function(err, user) {
         if (err) {
             return callback(err);
-        }
-
-        // Only global administrators and administrators of the tenant the user belongs to can request the login ids
-        var isGlobalAdmin = (ctx.user() && ctx.user().isGlobalAdmin());
-        var isAdmin = (ctx.user().isAdmin(user.tenant.alias));
-        if (!isGlobalAdmin && !isAdmin) {
+        } else if (!ctx.user().isAdmin(user.tenant.alias)) {
+            // Only global administrators and administrators of the tenant the user belongs to can request the login ids
             return callback({'code': 401, 'msg': 'You are not authorized to request the login ids for this user'});
         }
 
-        return _getUserLoginIds(userId, callback);
+        return _getUserLoginIds(userId, function(err, _loginIds) {
+            if (err) {
+                return callback(err);
+            }
+
+            // Only return the strategies and their corresponding external id
+            var loginIds = {};
+            _.each(_loginIds, function(values, strategy) {
+                loginIds[strategy] = values.externalId;
+            });
+
+            return callback(null, loginIds);
+        });
     });
 };
 

--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -594,8 +594,6 @@ var changePassword = module.exports.changePassword = function(ctx, userId, oldPa
                 return callback({'code': 400, 'msg': 'User does not have a local account mapping'});
             }
 
-
-
             // Determine the current user access
             var isAdmin = ctx.user().isAdmin(localLoginId.tenantAlias);
             var isTargetUser = ctx.user().id === userId;
@@ -748,6 +746,41 @@ var _associateLoginId = function(loginId, userId, callback) {
         }, 'Error constructing query to associate login id to user');
         return callback({'code': 500, 'msg': 'Error associating login id to user ' + userId});
     }
+};
+
+/**
+ * Get the login ids that are mapped to a user.
+ *
+ * @param  {Context}     ctx                 Standard context object containing the current user and the current tenant
+ * @param  {String}      userId              The id of the user
+ * @param  {Function}    callback            Standard callback function
+ * @param  {Object}      callback.err        An error that occurred, if any
+ * @param  {Object}      callback.loginIds   A hash whose keys are the authentication providers, and values are the LoginId objects that are mapped to the user
+ */
+var getUserLoginIds = module.exports.getUserLoginIds = function(ctx, userId, callback) {
+    // Parameter validation
+    var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'You have to be logged in to request the login ids for a user'}).isLoggedInUser(ctx);
+    validator.check(userId, {'code': 400, 'msg': 'A user id must be provided'}).isUserId();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    // Request the user details
+    PrincipalsAPI.getUser(ctx, userId, function(err, user) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Only global administrators and administrators of the tenant the user belongs to can request the login ids
+        var isGlobalAdmin = (ctx.user() && ctx.user().isGlobalAdmin());
+        var isAdmin = (ctx.user().isAdmin(user.tenant.alias));
+        if (!isGlobalAdmin && !isAdmin) {
+            return callback({'code': 401, 'msg': 'You are not authorized to request the login ids for this user'});
+        }
+
+        return _getUserLoginIds(userId, callback);
+    });
 };
 
 /**

--- a/node_modules/oae-authentication/lib/rest.js
+++ b/node_modules/oae-authentication/lib/rest.js
@@ -44,3 +44,39 @@ require('./strategies/twitter/rest');
  */
 OAE.globalAdminRouter.on('post', '/api/auth/logout', AuthenticationAPI.logout);
 OAE.tenantRouter.on('post', '/api/auth/logout', AuthenticationAPI.logout);
+
+/**
+ * Convenience function to handle requesting the user's login ids
+ *
+ * @param  {Request}    req     The express request
+ * @param  {Response}   res     The express response
+ * @api private
+ */
+var _getUserLoginIds = function(req, res) {
+    AuthenticationAPI.getUserLoginIds(req.ctx, req.params.userId, function(err, loginIds) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        return res.send(200, loginIds);
+    });
+};
+
+/**
+ * @REST getAuthLoginIds
+ *
+ * Get the login ids that are mapped to a user.
+ *
+ * @Server      admin,tenant
+ * @Method      GET
+ * @Path        /auth/loginIds/{userId}
+ * @PathParam   {string}        userId        The id of the user to return the login ids for
+ * @Return      {object}                      The user's login ids
+ * @HttpResponse                200           User login ids available
+ * @HttpResponse                400           A user id must be provided
+ * @HttpResponse                401           Only logged in users can request the login ids for a user
+ * @HttpResponse                401           You are not authorized to request the login ids for this user
+ * @HttpResponse                404           The specified user could not be found
+ */
+OAE.globalAdminRouter.on('get', '/api/auth/loginIds/:userId', _getUserLoginIds);
+OAE.tenantRouter.on('get', '/api/auth/loginIds/:userId', _getUserLoginIds);

--- a/node_modules/oae-authentication/tests/test-auth.js
+++ b/node_modules/oae-authentication/tests/test-auth.js
@@ -50,7 +50,7 @@ describe('Authentication', function() {
         /**
          * Test that verifies that a user's login ids can be requested
          */
-        it('verify requesting login ids for a user', function(callback) {
+        it('verify that only authorized admins can request a user\'s login ids', function(callback) {
             // Generate a user id
             var userId = TestsUtil.generateTestUserId();
 
@@ -93,13 +93,36 @@ describe('Authentication', function() {
                                             assert.ok(!err);
                                             assert.ok(loginIds);
 
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
                             });
                         });
                     });
+                });
+            });
+        });
+
+        /**
+         * Verify that a user's login ids can be successfully returned
+         */
+        it('verify that a user\'s login ids can be successfully returned', function(callback) {
+            // Generate a user id
+            var userId = TestsUtil.generateTestUserId();
+
+            // Create a test user
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+                assert.ok(!err);
+
+                // Verify that a global admin can request the login ids for the test user
+                RestAPI.Authentication.getUserLoginIds(globalAdminRestContext, createdUser.id, function(err, loginIds) {
+                    assert.ok(!err);
+                    assert.ok(loginIds);
+                    assert.ok(loginIds.local);
+                    assert.strictEqual(loginIds.local, userId.toLowerCase());
+
+                    return callback();
                 });
             });
         });

--- a/node_modules/oae-authentication/tests/test-auth.js
+++ b/node_modules/oae-authentication/tests/test-auth.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var assert = require('assert');
+
+var RestAPI = require('oae-rest');
+var TestsUtil = require('oae-tests');
+
+describe('Authentication', function() {
+
+    // Rest context that can be used for anonymous requests on the cambridge tenant
+    var anonymousCamRestContext = null;
+    // Rest context that can be used for anonymous requests on the global admin tenant
+    var anonymousGlobalRestContext = null;
+    // Rest context that can be used every time we need to make a request as a tenant admin
+    var camAdminRestContext = null;
+    // Rest context that can be used every time we need to make a request as a tenant admin
+    var gtAdminRestContext = null;
+    // Rest context that can be used every time we need to make a request as a global admin
+    var globalAdminRestContext = null;
+
+    /**
+     * Function that will fill up the tenant admin and anymous rest context
+     */
+    before(function(callback) {
+        // Prepare the contexts with which we'll perform requests
+        anonymousCamRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+        anonymousGlobalRestContext = TestsUtil.createGlobalRestContext();
+        camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+        gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
+        globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
+
+        return callback();
+    });
+
+    describe('Authentication', function(callback) {
+
+        /**
+         * Test that verifies that a user's login ids can be requested
+         */
+        it('verify requesting login ids for a user', function(callback) {
+            // Generate a user id
+            var userId = TestsUtil.generateTestUserId();
+
+            // Verify that an error is thrown when a malformed user id was specified
+            RestAPI.Authentication.getUserLoginIds(globalAdminRestContext, userId, function(err, loginIds) {
+                assert.ok(err);
+                assert.equal(err.code, 400);
+
+                // Verify that an error is thrown when an unexisting user id was specified
+                RestAPI.Authentication.getUserLoginIds(globalAdminRestContext, 'u:camtest:abcdefghij', function(err, loginIds) {
+                    assert.ok(err);
+                    assert.equal(err.code, 404);
+
+                    // Create a test user
+                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+                        assert.ok(!err);
+
+                        // Verify that an error is thrown when an anonymous user on the global admin router requests the login ids for the test user
+                        RestAPI.Authentication.getUserLoginIds(anonymousGlobalRestContext, createdUser.id, function(err, loginIds) {
+                            assert.ok(err);
+                            assert.equal(err.code, 401);
+
+                            // Verify that an error is thrown when an anonymous user on the tenant router requests the login ids for the test user
+                            RestAPI.Authentication.getUserLoginIds(anonymousCamRestContext, createdUser.id, function(err, loginIds) {
+                                assert.ok(err);
+                                assert.equal(err.code, 401);
+
+                                // Verify that an error is thrown when an unauthorized tenant admin requests the login ids for the test user
+                                RestAPI.Authentication.getUserLoginIds(gtAdminRestContext, createdUser.id, function(err, loginIds) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 401);
+
+                                    // Verify that a tenant admin can request the login ids for the test user
+                                    RestAPI.Authentication.getUserLoginIds(camAdminRestContext, createdUser.id, function(err, loginIds) {
+                                        assert.ok(!err);
+                                        assert.ok(loginIds);
+
+                                        // Verify that a global admin can request the login ids for the test user
+                                        RestAPI.Authentication.getUserLoginIds(globalAdminRestContext, createdUser.id, function(err, loginIds) {
+                                            assert.ok(!err);
+                                            assert.ok(loginIds);
+
+                                            callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
In order to support showing login ids for a user in the admin UI, an endpoint must be created to, given a user id, get the list of login ids associated to that user. This would require the following work:

1. There is an [internal `_getUserLoginIds` function](https://github.com/oaeproject/Hilary/blob/master/node_modules/oae-authentication/lib/api.js#L753-L783) that lists them from Cassandra. A new public function should be created that takes in the user id whose login ids to list and delegates to that internal function
    * Validation: Only admins of the specified user id or the user themself can get their list of login ids
2. A new GET request can be mounted in `oae-authentication/lib/rest.js` that delegates to this new public function. Maybe something like `GET /api/auth/loginIds/:userId` would work well, and in the future if we implement associating new login ids to user accounts, we could `POST /api/auth/loginIds/:userId/:strategyName`
3. Caution should be taken as the "local" auth strategy will have the password hash in its response. It should be omitted
