### PR TITLE
(InvitingGuests/EmailVerification)

### DIFF
--- a/etc/migration/10.3-to-11.0/mapped-emails.js
+++ b/etc/migration/10.3-to-11.0/mapped-emails.js
@@ -1,0 +1,175 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * This migration script will try to create a mapping between a user's email address and the user
+ * object in the Principals table. Before it does that however, the following checks will be made:
+ *   -  Ensure that the user has an email address
+ *   -  Ensure that the user's email address is valid
+ */
+
+var _ = require('underscore');
+var bunyan = require('bunyan');
+var csv = require('csv');
+var fs = require('fs');
+var optimist = require('optimist');
+var path = require('path');
+
+var Cassandra = require('oae-util/lib/cassandra');
+var log = require('oae-logger').logger('email-mapping-migrator');
+var OAE = require('oae-util/lib/oae');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
+var Validator = require('oae-util/lib/validator').Validator;
+
+
+var argv = optimist.usage('$0 [--config <path/to/config.js>] [--warnings <path/to/warnings.csv>]')
+    .alias('c', 'config')
+    .describe('c', 'Specify an alternate config file')
+    .default('c', 'config.js')
+
+    .alias('w', 'warnings')
+    .describe('w', 'Specify the path to the file where unmappable users should be dumped to')
+    .default('w', 'email-migration.csv')
+
+    .alias('h', 'help')
+    .describe('h', 'Show usage information')
+    .argv;
+
+if (argv.help) {
+    optimist.showHelp();
+    return;
+}
+
+// Get the config
+var configPath = path.resolve(process.cwd(), argv.config);
+var config = require(configPath).config;
+
+// Ensure that this application server does NOT start processing any preview images
+config.previews.enabled = false;
+
+// Ensure that we're logging to standard out/err
+config.log = {
+    'streams': [
+        {
+            'level': 'info',
+            'stream': process.stdout
+        }
+    ]
+};
+
+// Keep track of when we started the migration process so we can output how
+// long the migration took
+var start = Date.now();
+
+// Keep track of the total number of users and the number of users that were mapped
+var totalUsers = 0;
+var mappedUsers = 0;
+
+// Set up the CSV file
+var fileStream = fs.createWriteStream(argv.warnings, {'flags': 'a'});
+fileStream.on('error', function(err) {
+    log().error({'err': err}, 'Error occurred when writing to the warnings file');
+    process.exit(1);
+});
+var csvStream = csv.stringify({
+    'columns': ['principalId', 'displayName', 'email', 'message']
+});
+csvStream.pipe(fileStream);
+
+// Spin up the application container. This will allow us to re-use existing APIs
+OAE.init(config, function(err) {
+    if (err) {
+        log().error({'err': err}, 'Unable to spin up the application server');
+        return _exit(err.code);
+    }
+
+    PrincipalsDAO.iterateAll(['principalId', 'displayName', 'email'], 30, _mapPrincipals, function(err) {
+        if (err) {
+            log().error({'err': err}, 'Failed to migrate all users');
+            return _exit(1);
+        }
+
+        log().info('Migration completed, it took %d milliseconds', (Date.now() - start));
+        log().info('Total users: %d, mapped users: %d', totalUsers, mappedUsers);
+        if (mappedUsers !== totalUsers) {
+            log().warn('Not all users could be mapped, check the warning CSV file for which ones couldn\'t and why');
+        }
+        _exit(0);
+    });
+});
+
+/**
+ * Go through a set of rows and map the users who have a valid email address
+ *
+ * @param  {Object[]}   principals      An array of principal objects to map
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ * @api private
+ */
+var _mapPrincipals = function(principals, callback) {
+    var queries = [];
+
+    _.each(principals, function(principal) {
+        var principalId = principal.principalId;
+        var displayName = principal.displayName;
+        var email = principal.email;
+
+        // We only care about users in this migration process
+        if (!PrincipalsDAO.isUser(principalId)) {
+            return;
+        }
+        totalUsers++;
+
+        // Check if the user has an email address
+        if (!email) {
+            return csvStream.write({
+                'principalId': principalId,
+                'displayName': displayName,
+                'message': 'No email'
+            });
+        }
+
+        // Check whether the persisted email address is valid
+        var validator = new Validator();
+        validator.check(email, {'code': 400, 'msg': 'An invalid email address has been persisted'}).isEmail();
+        if (validator.hasErrors()) {
+            return csvStream.write({
+                'principalId': principalId,
+                'displayName': displayName,
+                'email': email,
+                'message':
+                'Invalid email'
+            });
+        }
+
+        // Create a mapping for the valid email address
+        queries.push({'query': 'INSERT INTO "PrincipalsByEmail" ("email", "principalId") VALUES (?, ?)', 'parameters': [email, principalId]});
+        mappedUsers++;
+    });
+
+    // Create the mappings and move on to the next set of principals
+    Cassandra.runBatchQuery(queries, callback);
+};
+
+/**
+ * Exit the migration script, but wait until the CSV stream has been properly closed down
+ *
+ * @param  {Number}     code    The exit code that should be used to stop the process with
+ */
+var _exit = function(code) {
+    csvStream.end(function() {
+        process.exit(code);
+    });
+};

--- a/node_modules/oae-activity/emailTemplates/mail.html.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.html.jst
@@ -1,89 +1,5 @@
-<%
-    /**
-     * Render the email header
-     */
-    var renderHeader = function() {
-        var institutionalLogoURL = shared.ensureAbsoluteLink(util.ui.getHashedPath(skinVariables['institutional-logo-url'].replace(/\'/g, '')), baseUrl);
-        var greeting = util.i18n.translate('__MSG__ACTIVITY_EMAIL_GREETING__', {'displayName': util.html.encodeForHTML(user.displayName)});
-        greeting = shared.ensureAbsoluteLinks(greeting, baseUrl);
-
-        // Aggregate the header content into an array of lines of HTML content
-        var lines = [];
-        lines.push('<tr id="header" class="row">');
-        lines.push(     '<td align="center">');
-        lines.push(         '<table cellpadding="0" cellspacing="0">');
-        lines.push(             '<tr id="logo">');
-        lines.push(                 '<td><img src="' + institutionalLogoURL + '" /></td>');
-        lines.push(             '</tr>');
-        lines.push(             '<tr id="greeting">');
-        lines.push(                 '<td><h1>' + greeting + '</h1></td>');
-        lines.push(             '</tr>');
-        lines.push(             '<tr id="summary" class="muted">');
-        lines.push(                 '<td class="wrapped">' + shared.getEmailSummary(util, user.emailPreference, activities, baseUrl) + '</td>');
-        lines.push(             '</tr>');
-        lines.push(         '</table>');
-        lines.push(     '</td>');
-        lines.push('</tr>');
-
-        // Join the lines together by new line, adding the trailing new line to the end
-        print(lines.join('\n') + '\n');
-    };
-%>
-
-<%
-    /**
-     * Render the email footer
-     */
-    var renderFooter = function() {
-        var oaeNameI18n = util.i18n.translate('__MSG__OPEN_ACADEMIC_ENVIRONMENT__');
-        var url = baseUrl + '/me?emailpreferences';
-
-        var oaeLink = '<a href="http://www.oaeproject.org">' + util.html.encodeForHTML(oaeNameI18n) + '</a>';
-
-        var instanceLink = util.html.encodeForHTML(instance.name);
-        if (instance.URL) {
-            instanceLink =
-                '<a href="' + util.html.encodeForHTMLAttribute(instance.URL) + '">' +
-                    instanceLink +
-                '</a>';
-        }
-
-        var hostingOrganizationLink = util.html.encodeForHTML(hostingOrganization.name);
-        if (hostingOrganization.URL) {
-            hostingOrganizationLink =
-                '<a href="' + util.html.encodeForHTMLAttribute(hostingOrganization.URL) + '">' +
-                    hostingOrganizationLink +
-                '</a>';
-        }
-
-        var footerContentData = {
-            'oaeLink': oaeLink,
-            'instanceLink': instanceLink,
-            'hostingOrganizationLink': hostingOrganizationLink
-        };
-
-        var footerContent = '__MSG__POWERED_BY_APEREO_OAE__';
-        if (instanceLink && hostingOrganizationLink) {
-            footerContent = '__MSG__POWERED_BY_APEREO_OAE_INSTANCE_HOSTING_ORGANIZATION__';
-        } else if (instanceLink) {
-            footerContent = '__MSG__POWERED_BY_APEREO_OAE_INSTANCE__';
-        } else if (hostingOrganizationLink) {
-            footerContent = '__MSG__POWERED_BY_APEREO_OAE_HOSTING_ORGANIZATION__';
-        }
-
-        // Aggregate the footer content into an array of lines of HTML content
-        var lines = [];
-        lines.push('<tr id="footer" class="row">');
-        lines.push(  '<td align="center">');
-        lines.push(      util.i18n.translate('__MSG__ACTIVITY_EMAIL_CHANGE_PREFRENCES__', {'url': url}) + '<br />');
-        lines.push(      util.i18n.translate(footerContent, footerContentData));
-        lines.push(  '</td>');
-        lines.push('</tr>');
-
-        // Join the lines together by new line, adding the trailing new line to the end
-        print(lines.join('\n') + '\n');
-    };
-%>
+<% include node_modules/oae-email/emailTemplates/header.html.jst %>
+<% include node_modules/oae-email/emailTemplates/footer.html.jst %>
 
 <%
     /**
@@ -92,18 +8,18 @@
      * @param  {ActivityViewThumbnail|ActivityEntity}    userProfile        The user profile information
      */
     var renderUserThumbnail = function(userProfile) {
-        var thumbnailUrl = shared.ensureAbsoluteLink(util.ui.getHashedPath('/ui/img/icons/user_small.png'), baseUrl);
+        var thumbnailUrl = util.url.ensureAbsoluteLink(util.ui.getHashedPath('/ui/img/icons/user_small.png'), baseUrl);
         if (userProfile && userProfile.thumbnailUrl) {
-            thumbnailUrl = shared.ensureAbsoluteLink(userProfile.thumbnailUrl, baseUrl);
+            thumbnailUrl = util.url.ensureAbsoluteLink(userProfile.thumbnailUrl, baseUrl);
         } else if (userProfile && userProfile['oae:thumbnail']) {
-            thumbnailUrl = shared.ensureAbsoluteLink(userProfile['oae:thumbnail'].url, baseUrl);
+            thumbnailUrl = util.url.ensureAbsoluteLink(userProfile['oae:thumbnail'].url, baseUrl);
         }
 
         var profilePath = null;
         if (userProfile && userProfile.profilePath) {
-            profilePath = shared.ensureAbsoluteLink(userProfile.profilePath, baseUrl);
+            profilePath = util.url.ensureAbsoluteLink(userProfile.profilePath, baseUrl);
         } else if (userProfile && userProfile['oae:profilePath']) {
-            profilePath = shared.ensureAbsoluteLink(userProfile['oae:profilePath'], baseUrl);
+            profilePath = util.url.ensureAbsoluteLink(userProfile['oae:profilePath'], baseUrl);
         }
 
         var str = '<img src="' + thumbnailUrl + '" alt="' + util.html.encodeForHTMLAttribute(userProfile.displayName) + '" />';
@@ -132,18 +48,18 @@
 
         // Determine the correct image url
         if (wide && entity.wideImageUrl) {
-            thumbnailUrl = shared.ensureAbsoluteLink(entity.wideImageUrl, baseUrl);
+            thumbnailUrl = util.url.ensureAbsoluteLink(entity.wideImageUrl, baseUrl);
         } else {
             wide = false;
 
             if (entity.thumbnailUrl) {
-                thumbnailUrl = shared.ensureAbsoluteLink(entity.thumbnailUrl, baseUrl);
+                thumbnailUrl = util.url.ensureAbsoluteLink(entity.thumbnailUrl, baseUrl);
             } else {
                 var resourceType = entity.resourceType;
                 if (resourceType === 'content') {
                     resourceType = entity.resourceSubType;
                 }
-                thumbnailUrl = shared.ensureAbsoluteLink(util.ui.getHashedPath('/ui/img/icons/' + resourceType + '.png'), baseUrl);
+                thumbnailUrl = util.url.ensureAbsoluteLink(util.ui.getHashedPath('/ui/img/icons/' + resourceType + '.png'), baseUrl);
             }
         }
 
@@ -183,7 +99,7 @@
         if (entity.resourceType === 'user' && entity.visibility === 'private') {
             lines.push('<span>');
         } else {
-            lines.push('<a href="' + shared.ensureAbsoluteLink(entity.profilePath, baseUrl) + '" title="' + util.html.encodeForHTMLAttribute(entity.displayName) + '" target="_blank">');
+            lines.push('<a href="' + util.url.ensureAbsoluteLink(entity.profilePath, baseUrl) + '" title="' + util.html.encodeForHTMLAttribute(entity.displayName) + '" target="_blank">');
         }
 
         lines.push('        <table cellpadding="0" cellspacing="0" class="preview-tile-container-inner">');
@@ -199,7 +115,7 @@
         if (entity.resourceType === 'user' && entity.visibility === 'private') {
             lines.push('                                <span class="preview-tile-title wrapped">' + title + '</span>');
         } else {
-            lines.push('                                <a href="' + shared.ensureAbsoluteLink(entity.profilePath, baseUrl) + '" title="' + util.html.encodeForHTMLAttribute(entity.displayName) + '" target="_blank" class="preview-tile-title wrapped">' + title + '</a>');
+            lines.push('                                <a href="' + util.url.ensureAbsoluteLink(entity.profilePath, baseUrl) + '" title="' + util.html.encodeForHTMLAttribute(entity.displayName) + '" target="_blank" class="preview-tile-title wrapped">' + title + '</a>');
         }
 
         lines.push('                                </h3></td>');
@@ -207,7 +123,7 @@
         lines.push('                            <tr>');
         lines.push('                                <td class="preview-tile-metadata-description"><small>' + resourceType + '</small></td>');
         if (entity.resourceType !== 'user') {
-            lines.push('                            <td class="preview-tile-metadata-visibility"><img src="' + shared.ensureAbsoluteLink(icon, baseUrl) + '" alt="' + i18nVisibility + '"/></td>');
+            lines.push('                            <td class="preview-tile-metadata-visibility"><img src="' + util.url.ensureAbsoluteLink(icon, baseUrl) + '" alt="' + i18nVisibility + '"/></td>');
         }
         lines.push('                            </tr>');
         lines.push('                        </table>');
@@ -234,102 +150,11 @@
         <meta name="viewport" content="width=device-width" />
         <style>
 
-            /*************
-             * CORE CSS **
-             *************/
-
-            body {
-                background-color: <%= skinVariables['body-background-color'] %>;
-                color: <%= skinVariables['text-color'] %>;
-                font-size: 13px;
-                height: 100%;
-                padding: 20px;
-                -webkit-font-smoothing: antialiased;
-                -webkit-text-size-adjust: 150%;
-            }
-
-            body, h1, h2, h3, h4, h5, h6, a, span, td, div {
-                font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-            }
-
-            body > table {
-                margin: 0 auto;
-            }
-
-            a {
-                color: <%= skinVariables['link-color'] %>;
-                text-decoration: none;
-            }
-
-            a:hover {
-                color: <%= skinVariables['link-hover-color'] %>;
-            }
-
-            h1, h2, h3, h4, h5, h6 {
-                color: <%= skinVariables['text-color']%>;
-                line-height: 1.1;
-            }
-
-            h1, h2 {
-                font-weight: 200;
-            }
-
-            h3 {
-                font-weight: 500;
-            }
-
-            img {
-                border: 0;
-            }
-
-            .muted {
-                color: <%= skinVariables['secondary-text-color'] %>;
-                font-size: 12px;
-            }
-
-            .wrapped {
-                word-wrap: break-word;
-            }
-
-            .row > td {
-                max-width: 700px;
-                min-width:400px;
-            }
-
-
-            /************
-             ** HEADER **
-             ************/
-
-            #header table {
-                width: 100%;
-            }
-
-            #header td {
-                text-align: center;
-                max-width: 650px;
-            }
-
-            #header #logo img {
-                margin: 0 0 30px;
-
-                /* GMail always converts `height` to `min-height` on at least images, so use
-                   `min-height` with `max-height` for some client consistency */
-                max-height: 50px;
-                min-height: 50px;
-            }
-
-            #header #greeting h1 {
-                font-size: 24px;
-                font-weight: bold;
-                margin: 0 0 5px;
-                word-wrap: break-word;
-            }
-
-            #header #summary td {
-                font-size: 15px;
-                padding-bottom: 10px;
-            }
+            /*
+             * Include the general styles. Note that we need to include them through
+             * Underscore as otherwise the skinVariable settings would be inaccessible
+             */
+            <% include node_modules/oae-email/emailTemplates/email.css.jst %>
 
 
             /***********
@@ -568,15 +393,6 @@
                 margin-top: 0;
             }
 
-            /************
-             ** FOOTER **
-             ************/
-
-            #footer {
-                font-size: 10px;
-                margin: 40px auto 0;
-            }
-
         </style>
     </head>
     <body>
@@ -587,7 +403,7 @@
                 <%
                 _.each(activities, function(activity) {
                     var summary = util.i18n.translate(activity.summary.i18nKey, activity.summary.i18nArguments) ;
-                    summary = shared.ensureAbsoluteLinks(summary, baseUrl);
+                    summary = util.url.ensureAbsoluteLinks(summary, baseUrl);
                 %>
                     <tr class="row activity-row" data-activity-id="<%= activity.originalActivity['oae:activityId'] %>">
                         <td>
@@ -633,7 +449,7 @@
                                                     </div>
                                                     <div class="activity-comment">
                                                         <%
-                                                            var authorLink = shared.ensureAbsoluteLink(item.comment.author['oae:profilePath'], baseUrl);
+                                                            var authorLink = util.url.ensureAbsoluteLink(item.comment.author['oae:profilePath'], baseUrl);
                                                             if (authorLink) {
                                                                 print('<a href="' + authorLink + '" title="' +  util.html.encodeForHTMLAttribute(item.comment.author.displayName) + '" class="wrapped">');
                                                             }
@@ -645,7 +461,7 @@
                                                             }
                                                         %>
                                                         <span class="activity-date muted"><%= util.i18n.formatDate(new Date(item.comment.published), 'f', timezone) %></span>
-                                                        <div class="activity-comment-message wrapped"><%= shared.ensureAbsoluteLinks(util.markdown.toHtml(item.comment.content), baseUrl) %></div>
+                                                        <div class="activity-comment-message wrapped"><%= util.url.ensureAbsoluteLinks(util.markdown.toHtml(item.comment.content), baseUrl) %></div>
                                                     </div>
                                                 </div>
                                             <% }); %>
@@ -657,7 +473,7 @@
                     </tr>
                 <% }); %>
 
-                <% renderFooter(); %>
+                <% renderFooter(true); %>
             </tbody>
         </table>
     </body>

--- a/node_modules/oae-activity/emailTemplates/mail.shared.js
+++ b/node_modules/oae-activity/emailTemplates/mail.shared.js
@@ -14,49 +14,6 @@
  */
 
 var _ = require('underscore');
-var $ = require('cheerio');
-
-/**
- * Ensure that a link is an absolute URL. If a relative link is
- * passed in, it will be prefixed with the base url.
- *
- * @param  {String}     link        The link to check
- * @param  {String}     baseUrl     The base url that can be used to prefix relative urls
- * @return {String}                 The absolute link prefixed with the base url
- */
-var ensureAbsoluteLink = module.exports.ensureAbsoluteLink = function(link, baseUrl) {
-    // If the link is empty or null, we return the empty string. This can happen when
-    // we try to link a private user (private users are scrubbed and have no profile path)
-    if (!link) {
-        return '';
-
-    // If the link already has `http` in it (e.g., twitter profile pics) we return as-is
-    } else if (link.indexOf('http') === 0) {
-        return link;
-
-    // Otherwise we prefix it with the base url
-    } else {
-        return baseUrl + link;
-    }
-};
-
-/**
- * Ensure that each link in an HTML fragment is an abolute url, If a relative link is
- * found, it will be prefixed with the base url.
- *
- * @param  {String}     str         The html string in which to check for absolute links
- * @param  {String}     baseUrl     The base url that can be used to prefix relative urls
- * @return {String}                 The html in which each link is absolute
- */
-var ensureAbsoluteLinks = module.exports.ensureAbsoluteLinks = function(str, baseUrl) {
-    var html = $('<div>' + str + '</div>');
-    html.find('a').each(function(i, elem) {
-        var link = $(this).attr('href');
-        link = ensureAbsoluteLink(link, baseUrl);
-        $(this).attr('href', link);
-    });
-    return html.html();
-};
 
 /**
  * Get an appropariate summary given a user's email preference and a set of activities
@@ -93,7 +50,7 @@ var getEmailSummary = module.exports.getEmailSummary = function(util, emailPrefe
 
             // If the profile path was set, it indicates that we have access to view the user, therefore
             // we should display a link. If not specified, we should show plain-text
-            var url = ensureAbsoluteLink(actor['oae:profilePath'], baseUrl);
+            var url = util.url.ensureAbsoluteLink(actor['oae:profilePath'], baseUrl);
             var actorLink = '<span>' + util.html.encodeForHTML(actor.displayName) + '</span>';
             if (url) {
                 actorLink = '<a href="' + url + '">' + util.html.encodeForHTML(actor.displayName) + '</a>';
@@ -101,7 +58,7 @@ var getEmailSummary = module.exports.getEmailSummary = function(util, emailPrefe
 
             var summary = util.i18n.translate(key, {'actorLink': actorLink});
 
-            return ensureAbsoluteLinks(summary, baseUrl);
+            return util.url.ensureAbsoluteLinks(summary, baseUrl);
         } else {
             return '__MSG__ACTIVITY_EMAIL_SUMMARY_IMMEDIATE_MULTIPLE_ACTORS__';
         }

--- a/node_modules/oae-activity/emailTemplates/mail.txt.jst
+++ b/node_modules/oae-activity/emailTemplates/mail.txt.jst
@@ -9,13 +9,13 @@
 
 <%= summary %>
 <% _.each(activities, function(activity) { %>
-    - <%= util.html.toText(shared.ensureAbsoluteLinks(util.i18n.translate(activity.summary.i18nKey, activity.summary.i18nArguments), baseUrl), true) %><% }); %>
+    - <%= util.html.toText(util.url.ensureAbsoluteLinks(util.i18n.translate(activity.summary.i18nKey, activity.summary.i18nArguments), baseUrl), true) %><% }); %>
 
 <%
 var url = baseUrl + '/me?emailpreferences';
 var footer = '';
 
-footer += util.html.toText(shared.ensureAbsoluteLinks(util.i18n.translate('__MSG__ACTIVITY_EMAIL_CHANGE_PREFRENCES__', {'url': url}), baseUrl), true) + '\n';
+footer += util.html.toText(util.url.ensureAbsoluteLinks(util.i18n.translate('__MSG__ACTIVITY_EMAIL_CHANGE_PREFRENCES__', {'url': url}), baseUrl), true) + '\n';
 
 var footerMsg = '__MSG__POWERED_BY_APEREO_OAE__';
 if (instance.name && hostingOrganization.name) {

--- a/node_modules/oae-activity/tests/test-activity.js
+++ b/node_modules/oae-activity/tests/test-activity.js
@@ -269,17 +269,15 @@ describe('Activity', function() {
                     assert.ok(!err);
 
                     // Create the user we will use as the activity stream
-                    var jackUsername = TestsUtil.generateTestUserId('jack');
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                         assert.ok(!err);
-                        var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                         // Try to generate an activity for Jack's feed
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                        RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                             assert.ok(!err);
 
                             // Verify no activity is generated, because we don't have any bound workers
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.ok(activityStream.items);
@@ -290,12 +288,12 @@ describe('Activity', function() {
                                     assert.ok(!err);
 
                                     // Generate a 2nd activity for Jack's feed
-                                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                                    RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                                         assert.ok(!err);
 
                                         // Verify both the first activity and the 2nd are collected into the stream, as the first one should have been queued until
                                         // we were finally enabled.
-                                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.ok(activityStream.items);
@@ -307,11 +305,11 @@ describe('Activity', function() {
                                                 assert.ok(!err);
 
                                                 // Create a 3rd activity to verify routing
-                                                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                                                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                                                     assert.ok(!err);
 
                                                     // Verify it was routed: now we should have 3 activities aggregated
-                                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                         assert.ok(!err);
                                                         assert.ok(activityStream);
                                                         assert.ok(activityStream.items);
@@ -339,24 +337,22 @@ describe('Activity', function() {
                 ActivityTestUtil.refreshConfiguration({'activityTtl': 2}, function(err) {
                     assert.ok(!err);
 
-                    var jackUsername = TestsUtil.generateTestUserId('jack');
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                         assert.ok(!err);
-                        var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                         // Try to generate an activity for Jack's feed
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                        RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                             assert.ok(!err);
 
                             // Verify the activity is generated immediately
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.ok(activityStream.items);
                                 assert.equal(activityStream.items.length, 1);
 
                                 // Now wait for the expiry and verify it has disappeared
-                                setTimeout(ActivityTestUtil.collectAndGetActivityStream, 2100, jackCtx, null, null, function(err, activityStream) {
+                                setTimeout(ActivityTestUtil.collectAndGetActivityStream, 2100, jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
                                     assert.ok(activityStream.items);
@@ -466,17 +462,14 @@ describe('Activity', function() {
              * Test that verifies that the default activity transformer will return just the oae:id, oae:tenant and objectType of an entity
              */
             it('verify default activity transformer returns objectType, oae:tenant and oae:id', function(callback) {
-                var username = TestsUtil.generateTestUserId('jack');
                 var testActivityType = TestsUtil.generateTestUserId();
                 var testResourceType = TestsUtil.generateTestUserId();
                 var testResourceId = 'foo:camtest:' + TestsUtil.generateTestUserId();
 
-                var jackUsername = TestsUtil.generateTestUserId('jack');
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    var actorResource = new ActivitySeedResource('user', jack.id);
+                    var actorResource = new ActivitySeedResource('user', jack.user.id);
                     var objectResource = new ActivitySeedResource(testResourceType, testResourceId, {'secret': 'My secret data!'});
                     var seed = new ActivitySeed(testActivityType, Date.now(), 'whistle', actorResource, objectResource);
 
@@ -505,7 +498,7 @@ describe('Activity', function() {
                         propagationCallback(null, [{'type': 'all'}]);
 
                         // Collect the persisted activity, and make sure its transformation contains the id and type, but not the secret
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.equal(activityStream.items.length, 1);
                             assert.ok(activityStream.items[0].object);
@@ -684,13 +677,11 @@ describe('Activity', function() {
              * Test that postActivity validates input properly
              */
             it('verify postActivity validation', function(callback) {
-                var jackUsername = TestsUtil.generateTestUserId('jack');
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // Generate an activity for Jack's feed
-                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         /*!
@@ -706,9 +697,9 @@ describe('Activity', function() {
                                 'verb': 'share',
                                 'published': Date.now()
                             };
-                            var actor = {'resourceType': 'user', 'resourceId': jack.id};
+                            var actor = {'resourceType': 'user', 'resourceId': jack.user.id};
                             var object = {'resourceType': 'content', 'resourceId': link.id};
-                            var target = {'resourceType': 'user', 'resourceId': jack.id};
+                            var target = {'resourceType': 'user', 'resourceId': jack.user.id};
 
                             seed = _.extend(seed, seedOverlay);
 
@@ -806,13 +797,11 @@ describe('Activity', function() {
              * Test that verifies activities stop being posted when it is disabled in the admin console.
              */
             it('verify disabling activity posting', function(callback) {
-                var jackUsername = TestsUtil.generateTestUserId('jack');
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // Generate an activity for Jack's feed
-                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         // Disable activity posting
@@ -820,13 +809,13 @@ describe('Activity', function() {
                             assert.ok(!err);
 
                             // Try and generate an activity, but this should actually not be posted
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, link2) {
+                            RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, link2) {
                                 assert.ok(!err);
 
                                 ConfigTestsUtil.updateConfigAndWait(globalAdminRestContext, null, {'oae-activity/activity/enabled': true}, function(err) {
                                     assert.ok(!err);
 
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         // Verify only one activity and it is not an aggregation
@@ -1422,20 +1411,16 @@ describe('Activity', function() {
          * Test that verifies the tenant information gets associated with each activity entity.
          */
         it('verify activities have tenant information', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
 
-                var jack = _.values(users)[0].user;
-                var jackCtx = _.values(users)[0].restContext;
-                var jane = _.values(users)[1].user;
-
                 // Jack creates a link and shares it with Jane.
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream.items.length > 0);
 
@@ -1469,19 +1454,16 @@ describe('Activity', function() {
          * Test that verifies the tenant information gets associated with each activity entity when they appear in collections.
          */
         it('verify activities with collections have tenant information', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-                var jack = _.values(users)[0].user;
-                var jackCtx = _.values(users)[0].restContext;
-                var jane = _.values(users)[1].user;
-                var jill = _.values(users)[2].user;
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, jill) {
+                assert.ok(!err);
 
                 // Jack creates a link and shares it with Jane and Jill.
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.com', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id, jill.id], function(err) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id, jill.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream.items.length > 0);
 
@@ -1517,47 +1499,38 @@ describe('Activity', function() {
          * Test that verifies paging of activity feeds
          */
         it('verify paging of activity feeds', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Generate 2 activities for jack's feed
+                RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    var janeCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                    // Generate 2 activities for jack's feed
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                         assert.ok(!err);
 
-                        RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                        // Get the items, ensure there are 2
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
+                            assert.equal(activityStream.items.length, 2);
 
-                            // Get the items, ensure there are 2
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            var firstId = activityStream.items[0]['oae:activityId'];
+                            var secondId = activityStream.items[1]['oae:activityId'];
+
+                            // Verify when you query with limit=1, you get the first and only the first activity
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, {'limit': 1}, function(err, activityStream) {
                                 assert.ok(!err);
-                                assert.equal(activityStream.items.length, 2);
+                                assert.equal(activityStream.items.length, 1);
+                                assert.equal(activityStream.items[0]['oae:activityId'], firstId);
+                                assert.equal(activityStream.nextToken, firstId);
 
-                                var firstId = activityStream.items[0]['oae:activityId'];
-                                var secondId = activityStream.items[1]['oae:activityId'];
-
-                                // Verify when you query with limit=1, you get the first and only the first activity
-                                ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, {'limit': 1}, function(err, activityStream) {
+                                // Verify when you query with the firstId as the start point, you get just the second activity
+                                ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, {'start': firstId}, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.equal(activityStream.items.length, 1);
-                                    assert.equal(activityStream.items[0]['oae:activityId'], firstId);
-                                    assert.equal(activityStream.nextToken, firstId);
-
-                                    // Verify when you query with the firstId as the start point, you get just the second activity
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, {'start': firstId}, function(err, activityStream) {
-                                        assert.ok(!err);
-                                        assert.equal(activityStream.items.length, 1);
-                                        assert.equal(activityStream.items[0]['oae:activityId'], secondId);
-                                        assert.ok(!activityStream.nextToken);
-                                        callback();
-                                    });
+                                    assert.equal(activityStream.items[0]['oae:activityId'], secondId);
+                                    assert.ok(!activityStream.nextToken);
+                                    return callback();
                                 });
                             });
                         });
@@ -1685,23 +1658,20 @@ describe('Activity', function() {
          * rather than continuing to aggregate in the previous activity.
          */
         it('verify aggregation idle expiry time', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Set the aggregate expiry time to 1 second. This should give us enough time to aggregate 2 activities, wait for expiry, then create a 3rd to verify it does not aggregate.
             ActivityTestUtil.refreshConfiguration({'aggregateIdleExpiry': 1}, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
+                    RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
                         assert.ok(!err);
 
-                        RestAPI.Content.createLink(jackCtx, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
+                        RestAPI.Content.createLink(jack.restContext, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
                             assert.ok(!err);
 
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
                                 // Verify both creates are aggregated into 1 activity
@@ -1724,11 +1694,11 @@ describe('Activity', function() {
                                 assert.ok(hasB);
 
                                 // Let the aggregation timeout expire and create a new link
-                                setTimeout(RestAPI.Content.createLink, 1100, jackCtx, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
+                                setTimeout(RestAPI.Content.createLink, 1100, jack.restContext, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
                                     assert.ok(!err);
 
                                     // Re-collect and verify that the aggregate expired, thus making the link a new activity, not an aggregate
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         // Now validate the activity stream contents
@@ -1768,33 +1738,30 @@ describe('Activity', function() {
          * does not fall idle.
          */
         it('verify aggregation max expiry time', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Set the aggregate max time to 1s and the idle time higher to 5s, this is to rule out the possibility of idle expiry messing up this test
             ActivityTestUtil.refreshConfiguration({'aggregateIdleExpiry': 5, 'aggregateMaxExpiry': 1}, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // This is when the createLink aggregate is born
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
+                    RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, linkA) {
                         assert.ok(!err);
 
                         // Drop an aggregate in. The when collected the aggregate is 600ms old
-                        setTimeout(RestAPI.Content.createLink, 600, jackCtx, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
+                        setTimeout(RestAPI.Content.createLink, 600, jack.restContext, 'B', 'B', 'public', 'http://www.google.ca', [], [], [], function(err, linkB) {
                             assert.ok(!err);
 
                             // Collect, then wait for expiry
-                            ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
                                 // When this content item is created, it should have crossed max expiry, causing this content create activity to be delivered individually
-                                setTimeout(RestAPI.Content.createLink, 1500, jackCtx, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
+                                setTimeout(RestAPI.Content.createLink, 1500, jack.restContext, 'C', 'C', 'public', 'http://www.google.ca', [], [], [], function(err, linkC) {
                                     assert.ok(!err);
 
-                                    ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         // Now validate the activity stream contents
@@ -1835,28 +1802,25 @@ describe('Activity', function() {
          * Test that verifies that when the aggregateIdleExpiry expires, the aggregate data disappears from storage.
          */
         it('verify aggregated data is automatically deleted after the idle expiry time', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Set the aggregate max time to 1s, if we add aggregate data then wait this period of time, queries to the DAO should show that this data has
             // been automatically cleaned out
             ActivityTestUtil.refreshConfiguration({'aggregateIdleExpiry': 1, 'aggregateMaxExpiry': 5}, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                     // Create a link then collect, which creates the aggregates
-                    RestAPI.Content.createLink(jackCtx, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(jack.restContext, 'A', 'A', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         // Drop an aggregate in. This is when the aggregate should be initially persisted, so should expire 1s from this time
                         var timePersisted = Date.now();
-                        ActivityTestUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
 
                             // Verify that the DAO reports the aggregate status is indeed there
-                            var aggregateKey = util.format('content-create#%s#activity#user:%s##__null__', jack.id, jack.id);
+                            var aggregateKey = util.format('content-create#%s#activity#user:%s##__null__', jack.user.id, jack.user.id);
 
                             ActivityDAO.getAggregateStatus([aggregateKey], function(err, aggregateStatus) {
                                 assert.ok(!err);
@@ -1868,7 +1832,7 @@ describe('Activity', function() {
                                     var timeSincePersisted = Date.now() - timePersisted;
                                     assert.ok(!err);
                                     assert.ok(aggregatedEntities[aggregateKey], util.format('Expected to find aggregate entity with key: %s. Duration since persistence: %s', aggregateKey, timeSincePersisted));
-                                    assert.ok(aggregatedEntities[aggregateKey]['actors']['user:' + jack.id]);
+                                    assert.ok(aggregatedEntities[aggregateKey]['actors']['user:' + jack.user.id]);
                                     assert.ok(aggregatedEntities[aggregateKey]['objects']['content:' + link.id]);
 
                                     // Wait the max expiry (1s) to let them disappear and verify there is no status

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -560,9 +560,8 @@ describe('Activity Email', function() {
                 TestsUtil.createTenantWithAdmin(alias, host, function(err, tenant, restContext, user) {
                     assert.ok(!err);
 
-                    // Give each user an email address and set his email preference to daily
+                    // Set each user's email preference to daily
                     var profile = {
-                        'email': util.format('%s@example.com', TestsUtil.generateRandomText(1)),
                         'emailPreference': 'daily'
                     };
                     RestAPI.User.updateUser(restContext, user.id, profile, function(err) {
@@ -575,7 +574,7 @@ describe('Activity Email', function() {
                             assert.ok(!err);
                             userIds.push(user.id);
                             if (timezone === 'Etc/GMT+0') {
-                                receivingUser = profile.email;
+                                receivingUser = user.email;
                             }
 
                             return createTenant();
@@ -1532,42 +1531,6 @@ describe('Activity Email', function() {
             refreshConfiguration(null, false, false, {'mail': {'pollingFrequency': 1}}, function() {
                 assert.strictEqual(ActivitySystemConfig.getConfig().mail.pollingFrequency, 60);
                 return callback();
-            });
-        });
-    });
-
-    /**
-     * Test that verifies if a user within a batch does not have an email address, it does not stop
-     * emails from being sent to other users in the same batch
-     */
-    it('verify user without email does not stop email from being sent to other users', function(callback) {
-        TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-            assert.ok(!err);
-
-            // Sort the user ids as the users are collected for emailing in this arbitrary ordering
-            var userIds = _.keys(users).sort();
-            var firstUser = users[userIds[0]];
-            var secondUser = users[userIds[1]];
-            var thirdUser = users[userIds[2]];
-
-            // Clear the email for the third user so we have a user that has no email address
-            RestAPI.User.updateUser(thirdUser.restContext, thirdUser.user.id, {'email': 'notavalidemail'}, function(err, updatedThirdUser) {
-                assert.ok(!err);
-                assert.strictEqual(updatedThirdUser.email, 'notavalidemail');
-
-                // The first user in the list triggers an email notification for the second and third user in the list
-                RestAPI.Content.createLink(firstUser.restContext, 'test content', 'Google', 'public', 'http://www.google.ca', [], [thirdUser.user.id, secondUser.user.id], [], function(err, link) {
-                    assert.ok(!err);
-
-                    // Collect the emails for the target users
-                    EmailTestUtil.collectAndFetchAllEmails(function(messages) {
-                        // Ensure we have 1 message. `thirdUser` does not get one because they do
-                        // not have an email addres. However that should not stop `secondUser` from
-                        // getting an email
-                        assert.strictEqual(messages.length, 1);
-                        return callback();
-                    });
-                });
             });
         });
     });

--- a/node_modules/oae-activity/tests/test-notifications.js
+++ b/node_modules/oae-activity/tests/test-notifications.js
@@ -364,9 +364,9 @@ describe('Notifications', function() {
                 assert.ok(!err);
 
                 // Give mrvisser and nico an email address
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, {'email': 'mrvisser@example.com', 'emailPreference': 'immediate'}, function(err) {
+                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, {'emailPreference': 'immediate'}, function(err) {
                     assert.ok(!err);
-                    RestAPI.User.updateUser(nico.restContext, nico.user.id, {'email': 'nico@example.com', 'emailPreference': 'immediate'}, function(err) {
+                    RestAPI.User.updateUser(nico.restContext, nico.user.id, {'emailPreference': 'immediate'}, function(err) {
                         assert.ok(!err);
 
                         // Create a piece of content and make nico and mrvisser managers. They should each get an e-mail
@@ -376,8 +376,8 @@ describe('Notifications', function() {
                             // Assert that both nico and mrvisser received an e-mail, but noone else
                             EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
                                 assert.equal(messages.length, 2);
-                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[0].to[0].address));
-                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[1].to[0].address));
+                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[0].to[0].address));
+                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[1].to[0].address));
                                 assert.notEqual(messages[0].to, messages[1].to);
 
                                 // Simulate an unexpected loop and try to route the same activity seed multiple times
@@ -394,8 +394,8 @@ describe('Notifications', function() {
                                             // Assert that only 1 mail got sent to both nico and mrvisser
                                             EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
                                                 assert.equal(messages.length, 2);
-                                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[0].to[0].address));
-                                                assert.ok(_.contains(['mrvisser@example.com', 'nico@example.com'], messages[1].to[0].address));
+                                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[0].to[0].address));
+                                                assert.ok(_.contains([mrvisser.user.email, nico.user.email], messages[1].to[0].address));
                                                 assert.notEqual(messages[0].to, messages[1].to[0].address);
                                                 return callback();
                                             });

--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -179,7 +179,7 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
 
     var validator = new Validator();
     validator.check(null, {'code': 401, 'msg': 'You must be authenticated to the global admin tenant to create a global administrator user'}).isLoggedInUser(ctx, globalTenantAlias);
-    validator.check(null, {'code': 401, 'msg': 'You must be a global administrator to create a global administraotr user'}).isGlobalAdministratorUser(ctx);
+    validator.check(null, {'code': 401, 'msg': 'You must be a global administrator to create a global administrator user'}).isGlobalAdministratorUser(ctx);
     validator.check(username, {'code': 400, 'msg': 'You must provide a username'}).notEmpty();
     validator.check(password, {'code': 400, 'msg': 'You must provide a password'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
@@ -190,6 +190,10 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
 
     // Global admin users always start out private
     opts.visibility = AuthzConstants.visibility.PRIVATE;
+
+    // Global admins can only be created by other global administrators,
+    // who probably know the email address is accurate
+    opts.emailVerified = true;
 
     var providerProperties = {'password': password};
     getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, username, providerProperties, displayName, opts, function(err, user, loginId, created) {
@@ -204,9 +208,9 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
         PrincipalsAPI.setGlobalAdmin(ctx, user.id, true, function(err) {
             if (err) {
                 return callback(err);
+            } else if (created) {
+                log().info({'user': user, 'username': username}, 'Global Admin account created');
             }
-
-            log().info({'user': user, 'username': username}, 'Global Admin account created');
 
             // Fetch the user again to get the updated version of the user
             PrincipalsAPI.getUser(ctx, user.id, function(err, user) {
@@ -233,7 +237,6 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
  * @param  {String}       [opts.emailPreference]    The email preference for the user
  * @param  {String}       [opts.visibility]         The visibility of the user. One of: @see AuthzConstants.visibility
  * @param  {String}       [opts.publicAlias]        The name to show when the user is inaccessible to a user
- * @param  {String}       [opts.emailPreference]    The email preference for the user. One of: @see PrincipalsConstants.emailPreference
  * @param  {Function}     callback                  Standard callback function
  * @param  {Object}       callback.err              An error that occurred, if any
  * @param  {User}         callback.user             The user that was fetched or created
@@ -241,6 +244,8 @@ var getOrCreateGlobalAdminUser = module.exports.getOrCreateGlobalAdminUser = fun
  * @param  {Boolean}      callback.created          `true` if the user was created, `false` otherwise
  */
 var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvider, externalId, providerProperties, displayName, opts, callback) {
+    opts = opts || {};
+
     var validator = new Validator();
     validator.check(displayName, {'code': 400, 'msg': 'You must provide a display name'}).notEmpty();
     validator.check(displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
@@ -273,6 +278,8 @@ var getOrCreateUser = module.exports.getOrCreateUser = function(ctx, authProvide
  * @api private
  */
 var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
+    opts = opts || {};
+
     _getUserIdFromLoginId(loginId, function(err, userId) {
         if (err && err.code !== 404) {
             return callback(err);
@@ -287,14 +294,13 @@ var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
 
             createUser(ctx, loginId, displayName, opts, function(err, user) {
                 if (err) {
-                    return (err);
+                    return callback(err);
                 }
-
                 return callback(null, user, _flattenLoginId(loginId), true);
             });
         } else {
             // The user existed, simply fetch their profile
-            PrincipalsAPI.getUser(ctx, userId, function(err, user) {
+            PrincipalsDAO.getPrincipal(userId, function(err, user) {
                 if (err) {
                     return callback(err);
                 } else if (user.deleted) {
@@ -314,7 +320,7 @@ var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
  * @param  {LoginId}    loginId                     The login id that will be associated with the tenant administrator so they may log in
  * @param  {String}     displayName                 The display name for the tenant administrator
  * @param  {Object}     [opts]                      Optional user profile parameters
- * @param  {String}     [opts.email]                The email address for the tenant administrator
+ * @param  {String}     [opts.email]                The email address for the user
  * @param  {String}     [opts.emailPreference]      The email preference for the tenant administrator. One of: @see PrincipalsConstants.emailPreference
  * @param  {String}     [opts.locale]               The locale for the tenant administrator
  * @param  {String}     [opts.publicAlias]          The name to show when the tenant administrator is inaccessible to a user
@@ -345,6 +351,10 @@ var createTenantAdminUser = module.exports.createTenantAdminUser = function(ctx,
 
     // Tenant administrators always start private
     opts.visibility = AuthzConstants.visibility.PRIVATE;
+
+    // Tenant administrators can only be created by other administrators,
+    // who probably know the email address is accurate
+    opts.emailVerified = true;
 
     // Create the user object with their login id
     _createUser(ctx, loginId, displayName, opts, function(err, user) {
@@ -452,7 +462,7 @@ var _createUser = function(ctx, loginId, displayName, opts, callback) {
             PrincipalsAPI.createUser(ctx, loginId.tenantAlias, displayName, opts, function(err, user) {
                 if (err) {
                     Locking.release(lockKey, lockToken, function() {
-                        callback(err);
+                        return callback(err);
                     });
                     return;
                 }

--- a/node_modules/oae-authentication/lib/strategies/cas/init.js
+++ b/node_modules/oae-authentication/lib/strategies/cas/init.js
@@ -83,6 +83,11 @@ module.exports = function() {
                 // Set the optional profile parameters
                 AuthenticationUtil.setProfileParameter(opts, 'email', mapEmail, casResponse.attributes);
                 AuthenticationUtil.setProfileParameter(opts, 'locale', mapLocale, casResponse.attributes);
+
+                // If the CAS server provided an email address we consider it verified
+                if (opts.email) {
+                    opts.emailVerified = true;
+                }
             }
 
             var context = new Context(tenant, null);

--- a/node_modules/oae-authentication/lib/strategies/facebook/init.js
+++ b/node_modules/oae-authentication/lib/strategies/facebook/init.js
@@ -61,7 +61,6 @@ module.exports = function() {
                 opts.mediumPictureUri = 'remote:' + picture.data.url;
             }
 
-            // Not all facebook users have an e-mail address.
             if (profile.emails.length > 0 && profile.emails[0].value) {
                 opts.email = profile.emails[0].value;
             }

--- a/node_modules/oae-authentication/lib/strategies/google/init.js
+++ b/node_modules/oae-authentication/lib/strategies/google/init.js
@@ -90,7 +90,8 @@ module.exports = function() {
             // The locale returned by google only specifies the language, but not the region which
             // isn't very useful
             var opts = {
-                'email': email
+                'email': email,
+                'emailVerified': true
             };
             var picture = profile['_json'].picture;
             if (picture) {

--- a/node_modules/oae-authentication/lib/strategies/shibboleth/api.js
+++ b/node_modules/oae-authentication/lib/strategies/shibboleth/api.js
@@ -16,7 +16,7 @@
 var util = require('util');
 
 var Context = require('oae-context').Context;
-var PrincipalsAPI = require('oae-principals/lib/api');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
 var Signature = require('oae-util/lib/signature');
 var TenantsAPI = require('oae-tenants/lib/api');
 var Validator = require('oae-util/lib/validator').Validator;
@@ -178,8 +178,7 @@ var getUser = module.exports.getUser = function(tenant, userId, signature, expir
         }
 
         // Get the user object
-        var context = new Context(tenant, null);
-        PrincipalsAPI.getUser(context, userId, function(err, user) {
+        PrincipalsDAO.getPrincipal(userId, function(err, user) {
             if (err) {
                 return callback(err);
             } else if (user.deleted) {

--- a/node_modules/oae-authentication/lib/strategies/shibboleth/init.js
+++ b/node_modules/oae-authentication/lib/strategies/shibboleth/init.js
@@ -81,17 +81,12 @@ module.exports = function(config) {
             // Set the optional profile parameters
             var opts = {};
 
-            // Get an email address from the provided headers. We fall back to `eppn` which may not always
-            // contain a valid email address. We only set the `email` value if a valid email has been provided
-            var email = _getBestAttributeValue(tenant.alias, 'mapEmail', headers, headers['eppn']);
-            if (email) {
-                var validator = new Validator();
-                validator.check(email, {'code': 400, 'msg': 'Invalid email'}).isEmail();
-                if (!validator.hasErrors()) {
-                    opts['email'] = email;
-                } else {
-                    log().warn({'email': email, 'externalId': externalId, 'tenant': tenant.alias}, 'A user signed in via Shib with an invalid email address');
-                }
+            // Get an email address from the provided headers
+            opts.email = _getBestAttributeValue(tenant.alias, 'mapEmail', headers);
+
+            // If the Shibboleth IdP provided an email address we consider it verified
+            if (opts.email) {
+                opts.emailVerified = true;
             }
 
             // Get a locale, if any

--- a/node_modules/oae-authentication/lib/strategies/shibboleth/rest.js
+++ b/node_modules/oae-authentication/lib/strategies/shibboleth/rest.js
@@ -154,7 +154,7 @@ OAE.tenantRouter.on('get', '/api/auth/shibboleth/sp/callback', function(req, res
 /**
  * @REST getAuthShibbolethTenantCallback
  *
- * Redirect an authenticated user back to their originating tenant
+ * Redirect an authenticated user to the /me page
  *
  * @Api         private
  * @Server      tenant
@@ -179,29 +179,8 @@ OAE.tenantRouter.on('get', '/api/auth/shibboleth/callback', function(req, res, n
             return res.send(err.code, err.msg);
         }
 
-        // The user's authentication credentials are correct
+        // Log the user in
         var strategyId = AuthenticationUtil.getStrategyId(req.tenant, AuthenticationConstants.providers.SHIBBOLETH);
-        var authInfo = {
-            'user': user,
-            'strategyId': strategyId
-        };
-        AuthenticationUtil.logAuthenticationSuccess(req, authInfo, strategyId);
-
-        // Create a session for this user
-        req.logIn(authInfo, function(err) {
-            if (err) {
-                return res.send(500, 'Failed to log you in');
-            }
-
-            // Get the URL to which the user should be redirected
-            var redirectUrl = AuthenticationUtil.validateRedirectUrl(req.cookies.redirectUrl);
-
-            // Remove the cookie
-            res.clearCookie('redirectUrl');
-
-            // The user now has a session within Express. We can now safely
-            // redirect the user into the system
-            return res.redirect(redirectUrl);
-        });
+        return AuthenticationUtil.handleLogin(strategyId, user, req, res, next);
     });
 });

--- a/node_modules/oae-authentication/lib/test/util.js
+++ b/node_modules/oae-authentication/lib/test/util.js
@@ -18,6 +18,7 @@ var assert = require('assert');
 
 var ConfigTestUtil = require('oae-config/lib/test/util');
 var RestAPI = require('oae-rest');
+var TestsUtil = require('oae-tests/lib/util');
 
 var AuthenticationAPI = require('oae-authentication');
 var AuthenticationConstants = require('oae-authentication/lib/constants').AuthenticationConstants;
@@ -48,4 +49,144 @@ var assertUpdateAuthConfigSucceeds = module.exports.assertUpdateAuthConfigSuccee
             return callback();
         });
     });
+};
+
+/**
+ * Assert that a user can log in using the local authentication strategy
+ *
+ * @param  {RestContext}    restContext     The REST context with which to attempt to log in
+ * @param  {String}         username        The username to log in with
+ * @param  {String}         password        The password to log in with
+ * @param  {Function}       callback        Invoked when the user has been logged in
+ * @throws {Error}                          Thrown if the operation fails in an unexpected way
+ */
+var assertLocalLoginSucceeds = module.exports.assertLocalLoginSucceeds = function(restContext, username, password, callback) {
+    RestAPI.Authentication.login(restContext, username, password, function(err) {
+        assert.ok(!err);
+
+        // Assert the user is logged in
+        RestAPI.User.getMe(restContext, function(err, me) {
+            assert.ok(!err);
+            assert.ok(!me.anon);
+
+            return callback();
+        });
+    });
+};
+
+/**
+ * Assert that a user can log in using the google authentication strategy
+ *
+ * @param  {String}         tenantHost              The host of the tenant on which to log in through google
+ * @param  {String}         [email]                 The email address of the user that will sign in. If null, no email will be returned in the mocked response
+ * @param  {Function}       callback                Invoked when it's been verified the user has logged in through google
+ * @param  {RestContext}    callback.restContext    The rest context that was used to sign in through google
+ * @param  {Response}       callback.response       The response that came back from the google callback endpoint
+ */
+var assertGoogleLoginSucceeds = module.exports.assertGoogleLoginSucceeds = function(tenantHost, email, callback) {
+    _mockGoogleResponse(email);
+
+    // A user returns from Google sign-in and hits our API
+    var restContext = TestsUtil.createTenantRestContext(tenantHost);
+    restContext.followRedirect = false;
+    RestAPI.Authentication.googleCallback(restContext, {'code': 'foo'}, function(err, body, response) {
+        assert.ok(!err);
+        assert.strictEqual(response.headers.location, '/me');
+
+        // Assert we were signed in successfully
+        RestAPI.User.getMe(restContext, function(err, me) {
+            assert.ok(!err);
+            assert.ok(!me.anon);
+            assert.strictEqual(me.email, email.toLowerCase());
+            assert.strictEqual(me.authenticationStrategy, 'google');
+
+            return callback(restContext, response);
+        });
+    });
+};
+
+/**
+ * Assert that a user can not log in using the google authentication strategy
+ *
+ * @param  {String}         tenantHost              The host of the tenant on which to log in through google
+ * @param  {String}         [email]                 The email address of the user that will sign in. If null, no email will be returned in the mocked response
+ * @param  {String}         reason                  The expected authentication failure's reason
+ * @param  {Function}       callback                Invoked when it's been verified the user was not able to sign in through google
+ * @param  {RestContext}    callback.restContext    The rest context that was used to attempt to sign in through google
+ * @param  {Response}       callback.response       The response that came back from the google callback endpoint
+ */
+var assertGoogleLoginFails = module.exports.assertGoogleLoginFails = function(tenantHost, email, reason, callback) {
+    _mockGoogleResponse(email);
+
+    // A user returns from the Google sign-in page and hits our API
+    var restContext = TestsUtil.createTenantRestContext(tenantHost);
+    restContext.followRedirect = false;
+    RestAPI.Authentication.googleCallback(restContext, {'code': 'foo'}, function(err, body, response) {
+        assert.ok(!err);
+        assert.strictEqual(response.headers.location, '/?authentication=failed&reason=' + reason);
+
+        // Assert we are still anonymous
+        RestAPI.User.getMe(restContext, function(err, me) {
+            assert.ok(!err);
+            assert.ok(me.anon);
+
+            return callback(restContext, response);
+        });
+    });
+};
+
+/**
+ * Mock the requests the google passport strategy will make
+ *
+ * @param  {String}         [email]                 The email address of the user that will sign in. If null, no email will be returned in the mocked response
+ * @api private
+ */
+var _mockGoogleResponse = function(email) {
+    // Require nock in-line as it messes with the HTTP stack
+    // We only want this to happen in a controlled environment
+    var nock = require('nock');
+
+    // Ensure we can still perform regular HTTP requests during our tests
+    nock.enableNetConnect();
+
+    // Mock the "get access token" request in the OAuth2 cycle
+    var accessToken = _.random(10000);
+    nock('https://accounts.google.com')
+        .post('/o/oauth2/token')
+        .reply(200, {
+            'access_token': accessToken,
+            'refresh_token': 'foo'
+        });
+
+    // Mock the "get user profile" request
+    var mockedResponse = {
+        'kind': 'plus#person',
+        'etag': 'RqKWnRU4WW46-6W3rWhLR9',
+        'gender': 'male',
+        'emails': [],
+        'urls': [
+            {'value': 'http://www.youtube.com/user/abc123','type': 'otherProfile','label': 'ABC 123'},
+        ],
+        'objectType': 'person',
+        'id': _.random(100000),
+        'displayName': 'Foo Bar',
+        'name': {
+            'familyName': 'Bar',
+            'givenName': 'Foo'
+        },
+        'url': 'https://plus.google.com/' + _.random(10000000),
+        'image': {
+            'url': 'https://lh5.googleusercontent.com/-wfVubfsOBV0/AAAAAAAAAAI/AAAAAAAAAGQ/rEb5FmsQuiA/photo.jpg?sz=50',
+            'isDefault': false
+        },
+        'isPlusUser': true,
+        'language': 'en',
+        'verified': false
+    };
+    if (email) {
+        mockedResponse.emails.push({'value': email, 'type': 'account'});
+    }
+    nock('https://www.googleapis.com')
+        .get('/plus/v1/people/me?access_token=' + accessToken)
+        .reply(200, mockedResponse);
 };

--- a/node_modules/oae-authentication/lib/util.js
+++ b/node_modules/oae-authentication/lib/util.js
@@ -240,12 +240,6 @@ var handleExternalCallback = module.exports.handleExternalCallback = function(st
     // Get the generic error handler
     var errorHandler = handlePassportError(req, res, next);
 
-    // Get the URL to which the user should be redirected
-    var redirectUrl = validateRedirectUrl(req.cookies.redirectUrl);
-
-    // This cookie serves no further purpose, remove it
-    res.clearCookie('redirectUrl');
-
     // Authenticate this request with Passport. Because we specify a callback function
     // we will need to manually log the user in the system
     passport.authenticate(strategyId, {}, function(err, user, challenges, status) {
@@ -260,25 +254,47 @@ var handleExternalCallback = module.exports.handleExternalCallback = function(st
             return res.redirect('/?authentication=failed&reason=tampering');
         }
 
-        // The user's authentication credentials are correct
-        // Log a message, as he logged in with an external tenant
-        var authInfo = {
-            'user': user,
-            'strategyId': strategyId
-        };
-        logAuthenticationSuccess(req, authInfo, strategyId);
-
-        // Create a session for this user
-        req.logIn(authInfo, function(err) {
-            if (err) {
-                return errorHandler(err);
-            }
-
-            // The user now has a session within Express
-            // We can now safely redirect the user into the system
-            return res.redirect(redirectUrl);
-        });
+        // The user's authentication credentials are correct, log the user into the system
+        handleLogin(strategyId, user, req, res, next);
     })(req, res, errorHandler);
+};
+
+/**
+ * Log a user onto the system
+ *
+ * @param  {String}         strategyId          The ID of the strategy that should be used to authenticate the user. This is the string as returned by `getStrategyId`
+ * @param  {User}           user                The user that should be logged into the system
+ * @param  {Request}        req                 The ExpressJS request object
+ * @param  {Response}       res                 The ExpressJS response object
+ * @param  {Function}       [next]              In case, this function is called in some middleware, the next function in the chain
+ */
+var handleLogin = module.exports.handleLogin = function(strategyId, user, req, res, next) {
+    // Get the URL to which the user should be redirected
+    var redirectUrl = validateRedirectUrl(req.cookies.redirectUrl);
+
+    // This cookie serves no further purpose, remove it
+    res.clearCookie('redirectUrl');
+
+    // Get the generic error handler
+    var errorHandler = handlePassportError(req, res, next);
+
+    // Log a message, as he logged in with an external tenant
+    var authInfo = {
+        'user': user,
+        'strategyId': strategyId
+    };
+    logAuthenticationSuccess(req, authInfo, strategyId);
+
+    // Create a session for this user
+    req.logIn(authInfo, function(err) {
+        if (err) {
+            return errorHandler(err);
+        }
+
+        // The user now has a session within Express
+        // We can now safely redirect the user into the system
+        return res.redirect(redirectUrl);
+    });
 };
 
 /**

--- a/node_modules/oae-authentication/tests/test-auth-local.js
+++ b/node_modules/oae-authentication/tests/test-auth-local.js
@@ -24,6 +24,7 @@ var TestsUtil = require('oae-tests');
 
 var AuthenticationAPI = require('oae-authentication');
 var AuthenticationConstants = require('oae-authentication/lib/constants').AuthenticationConstants;
+var AuthenticationTestUtil = require('oae-authentication/lib/test/util');
 var LoginId = require('oae-authentication/lib/model').LoginId;
 
 describe('Authentication', function() {
@@ -57,14 +58,7 @@ describe('Authentication', function() {
      * Ensure that all tests will start with local authentication enabled, even if tests that disable it fail
      */
     afterEach(function(callback) {
-        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-authentication/local/enabled': true}, function(err) {
-            assert.ok(!err);
-        });
-
-        // When the strategies have refreshed, then continue
-        AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-            callback();
-        });
+        return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(camAdminRestContext,  null, {'oae-authentication/local/enabled': true}, callback);
     });
 
 
@@ -75,48 +69,45 @@ describe('Authentication', function() {
          */
         it('verify local authentication', function(callback) {
             // Create a test user
-            var userId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                assert.ok(createdUser);
-                var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
 
                 // Log the user out first, to make sure that the cookie jar for the user is empty
-                RestAPI.Authentication.logout(userRestContext, function(err, body, response) {
+                RestAPI.Authentication.logout(user.restContext, function(err, body, response) {
                     assert.ok(!err);
                     assert.equal(response.statusCode, 302);
                     assert.equal(response.headers.location, '/');
 
                     // Login without a user id
-                    RestAPI.Authentication.login(userRestContext, null, 'password', function(err) {
+                    RestAPI.Authentication.login(user.restContext, null, 'password', function(err) {
                         assert.ok(err);
 
                         // Log in with the wrong password
-                        RestAPI.Authentication.login(userRestContext, userId, 'wrong-password', function(err) {
+                        RestAPI.Authentication.login(user.restContext, user.restContext.username, 'wrong-password', function(err) {
                             assert.ok(err);
 
                             // Log in with the correct password
-                            RestAPI.Authentication.login(userRestContext, userId, 'password', function(err) {
+                            RestAPI.Authentication.login(user.restContext, user.restContext.username, 'password', function(err) {
                                 assert.ok(!err);
 
                                 // Verify that we are actually logged in
-                                RestAPI.User.getMe(userRestContext, function(err, meObj) {
+                                RestAPI.User.getMe(user.restContext, function(err, meObj) {
                                     assert.ok(!err);
                                     assert.ok(meObj);
-                                    assert.equal(meObj.id, createdUser.id);
+                                    assert.equal(meObj.id, user.user.id);
 
                                     // Logout
-                                    RestAPI.Authentication.logout(userRestContext, function(err, body, response) {
+                                    RestAPI.Authentication.logout(user.restContext, function(err, body, response) {
                                         assert.ok(!err);
                                         assert.equal(response.statusCode, 302);
                                         assert.equal(response.headers.location, '/');
 
                                         // Verify that we are now logged out
-                                        RestAPI.User.getMe(userRestContext, function(err, meObj) {
+                                        RestAPI.User.getMe(user.restContext, function(err, meObj) {
                                             assert.ok(!err);
                                             assert.ok(meObj);
                                             assert.equal(meObj.anon, true);
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -151,17 +142,19 @@ describe('Authentication', function() {
                     var err = err1 || err2;
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 }
             };
 
             // Create a test user
             var userId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            var email2 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', email1, {}, function(err, createdUser) {
                 err1 = err;
                 checkComplete();
             });
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', email2, {}, function(err, createdUser) {
                 err2 = err;
                 checkComplete();
             });
@@ -180,7 +173,7 @@ describe('Authentication', function() {
                 RestAPI.Authentication.login(anonymousCamRestContext, 'u:cam:non-existing-user', 'password', function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -190,19 +183,18 @@ describe('Authentication', function() {
          */
         it('verify tenant login separation', function(callback) {
             // Create a test user
-            var userId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', null, function(err, createdUser) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                assert.ok(createdUser);
-                var anymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
 
                 // Verify that we cannot login on tenant B
-                RestAPI.Authentication.login(anonymousGtRestContext, userId, 'password', function(err) {
+                var anonymousGtRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host);
+                RestAPI.Authentication.login(anonymousGtRestContext, user.restContext.username, 'password', function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Verify that we can login on tenant A
-                    RestAPI.Authentication.login(anymousRestContext, userId, 'password', function(err) {
+                    var anonymousCamRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+                    RestAPI.Authentication.login(anonymousCamRestContext, user.restContext.username, 'password', function(err) {
                         assert.ok(!err);
                         return callback();
                     });
@@ -216,23 +208,21 @@ describe('Authentication', function() {
          */
         it('verify disable local authentication', function(callback) {
             // Create a user and associated anonymous context they we'll use to verify local login
-            var jackUsername = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackRestCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Sanity check login with the rest context
-                RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                RestAPI.User.getMe(jack.restContext, function(err, me) {
                     assert.ok(!err);
-                    assert.equal(me.id, jack.id);
+                    assert.equal(me.id, jack.user.id);
 
                     // Log it out and sanity check we're anonymous again
-                    RestAPI.Authentication.logout(jackRestCtx, function(err, body, response) {
+                    RestAPI.Authentication.logout(jack.restContext, function(err, body, response) {
                         assert.ok(!err);
                         assert.equal(response.statusCode, 302);
                         assert.equal(response.headers.location, '/');
 
-                        RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                        RestAPI.User.getMe(jack.restContext, function(err, me) {
                             assert.ok(!err);
                             assert.strictEqual(me.anon, true);
 
@@ -245,13 +235,13 @@ describe('Authentication', function() {
                             AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
 
                                 // Verify local authentication fails
-                                RestAPI.Authentication.login(jackRestCtx, jackUsername, 'password', function(err, body, response) {
+                                RestAPI.Authentication.login(jack.restContext, jack.restContext.username, 'password', function(err, body, response) {
                                     assert.ok(!err);
                                     assert.equal(response.statusCode, 302);
                                     assert.equal(response.headers.location, '/?authentication=disabled');
 
                                     // Ensure the user is still anonymous
-                                    RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                                    RestAPI.User.getMe(jack.restContext, function(err, me) {
                                         assert.ok(!err);
                                         assert.strictEqual(me.anon, true);
 
@@ -264,13 +254,13 @@ describe('Authentication', function() {
                                         AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
 
                                             // Verify authentication succeeds now
-                                            RestAPI.Authentication.login(jackRestCtx, jackUsername, 'password', function(err) {
+                                            RestAPI.Authentication.login(jack.restContext, jack.restContext.username, 'password', function(err) {
                                                 assert.ok(!err);
 
-                                                RestAPI.User.getMe(jackRestCtx, function(err, me) {
+                                                RestAPI.User.getMe(jack.restContext, function(err, me) {
                                                     assert.ok(!err);
-                                                    assert.equal(me.id, jack.id);
-                                                    callback();
+                                                    assert.equal(me.id, jack.user.id);
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -343,7 +333,7 @@ describe('Authentication', function() {
                         // Log the global admin back in so the cookie jar can be restored
                         RestAPI.Authentication.login(globalAdminRestContext, globalAdminRestContext.username, globalAdminRestContext.userPassword, function(err) {
                             assert.ok(!err);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -358,49 +348,39 @@ describe('Authentication', function() {
          */
         it('verify change password', function(callback) {
             // Create a test user
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Test User', null, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA, userB) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
                 // Try changing the password with a wrong old password
-                RestAPI.Authentication.changePassword(testUserRestContext, userObj.id, 'wrong-password', 'totally-new-password', function(err) {
+                RestAPI.Authentication.changePassword(userA.restContext, userA.user.id, 'wrong-password', 'totally-new-password', function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Try changing the password with the correct old password
-                    RestAPI.Authentication.changePassword(testUserRestContext, userObj.id, 'password', 'totally-new-password', function(err) {
+                    RestAPI.Authentication.changePassword(userA.restContext, userA.user.id, 'password', 'totally-new-password', function(err) {
                         assert.ok(!err);
-                        testUserRestContext.userPassword = 'totally-new-password';
+                        userA.restContext.userPassword = 'totally-new-password';
 
                         // Try changing someone else's password
-                        RestAPI.User.createUser(camAdminRestContext, usernameB, 'password', 'Test User', null, function(err, otherUserObj) {
-                            assert.ok(!err);
-                            assert.ok(otherUserObj);
-                            RestAPI.Authentication.changePassword(testUserRestContext, otherUserObj.id, 'password', 'totally-new-password', function(err) {
+                        RestAPI.Authentication.changePassword(userA.restContext, userB.user.id, 'password', 'totally-new-password', function(err) {
+                            assert.ok(err);
+                            assert.equal(err.code, 401);
+
+                            // Try logging in with the wrong password
+                            RestAPI.Authentication.login(anonymousCamRestContext, userA.restContext.username, 'password', function(err) {
                                 assert.ok(err);
                                 assert.equal(err.code, 401);
 
-                                var anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
-
                                 // Try logging in with the wrong password
-                                RestAPI.Authentication.login(anonymousRestContext, usernameA, 'password', function(err) {
+                                var anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+                                RestAPI.Authentication.login(anonymousRestContext, userA.restContext.username, 'password', function(err) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
 
                                     // Try logging in with the new password
-                                    RestAPI.Authentication.login(anonymousRestContext, usernameA, 'totally-new-password', function(err) {
+                                    RestAPI.Authentication.login(anonymousRestContext, userA.restContext.username, 'totally-new-password', function(err) {
                                         assert.ok(!err);
-
-                                        // Log out again
-                                        RestAPI.Authentication.logout(testUserRestContext, function(err, body, response) {
-                                            assert.ok(!err);
-                                            assert.equal(response.statusCode, 302);
-                                            assert.equal(response.headers.location, '/');
-                                            return callback();
-                                        });
+                                        return callback();
                                     });
                                 });
                             });
@@ -415,17 +395,15 @@ describe('Authentication', function() {
          */
         it('verify admin change password', function(callback) {
             // Create a test user
-            var testUserId = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, testUserId, 'password', 'Test User', null, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                assert.ok(userObj);
 
                 // Try to change the password as the anonymous user
-                RestAPI.Authentication.changePassword(anonymousCamRestContext, userObj.id, 'password', 'totally-new-password', function(err) {
+                RestAPI.Authentication.changePassword(anonymousCamRestContext, user.user.id, 'password', 'totally-new-password', function(err) {
                     assert.ok(err);
 
                     // Try to change the password as the tenant admin
-                    RestAPI.Authentication.changePassword(camAdminRestContext, userObj.id, 'password', 'totally-new-password', function(err) {
+                    RestAPI.Authentication.changePassword(camAdminRestContext, user.user.id, 'password', 'totally-new-password', function(err) {
                         assert.ok(!err);
 
                         // make a broken password change request as admin
@@ -435,9 +413,10 @@ describe('Authentication', function() {
 
                             // Try changing passwords for a user with no local strategy
                             var twitterTestUserId = TestsUtil.generateTestUserId();
+                            var email = TestsUtil.generateTestEmailAddress();
                             var ctx = new Context(global.oaeTests.tenants.cam);
                             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, twitterTestUserId);
-                            AuthenticationAPI.createUser(ctx, loginId, 'Twitter User', undefined, function(err, userObj) {
+                            AuthenticationAPI.createUser(ctx, loginId, 'Twitter User', {'email': email}, function(err, userObj) {
                                 assert.ok(!err);
                                 assert.ok(userObj);
 
@@ -445,7 +424,7 @@ describe('Authentication', function() {
                                     assert.ok(err);
                                     assert.equal(err.code, 400);
 
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });
@@ -498,7 +477,7 @@ describe('Authentication', function() {
                                             assert.ok(err);
                                             assert.equal(err.code, 400);
 
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -524,7 +503,8 @@ describe('Authentication', function() {
                 assert.equal(err.code, 404);
 
                 // Create a user with this login id
-                RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, createdUser) {
+                var email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                     assert.ok(!err);
                     assert.ok(createdUser);
 
@@ -552,7 +532,8 @@ describe('Authentication', function() {
                                         assert.equal(err.code, 404);
 
                                         // Create a user with this login id
-                                        RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'Test User', {'visibility': 'public'}, function(err, createdUser) {
+                                        var email = TestsUtil.generateTestEmailAddress();
+                                        RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'Test User', email, {'visibility': 'public'}, function(err, createdUser) {
                                             assert.ok(!err);
                                             assert.ok(createdUser);
 
@@ -603,7 +584,7 @@ describe('Authentication', function() {
                 // Verify that the existence cannot be checked when an empty string username is provided
                 RestAPI.Authentication.exists(anonymousCamRestContext, '', function(err) {
                     assert.ok(err);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -616,21 +597,22 @@ describe('Authentication', function() {
          * API as this would normally be called by Facebook, Twitter, etc. authentication
          */
         it('verify getOrCreateUser', function(callback) {
-            var userId = TestsUtil.generateTestUserId();
+            var externalId = TestsUtil.generateTestUserId();
             var ctx = new Context(global.oaeTests.tenants.cam);
+            var email = TestsUtil.generateTestEmailAddress();
 
-            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, userId, null, 'Nicolaas Matthijs', null, function(err, userObj, loginId, created) {
+            AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Nicolaas Matthijs', {'email': email}, function(err, userObj, loginId, created) {
                 assert.ok(!err);
                 assert.ok(userObj);
                 assert.strictEqual(created, true);
 
                 // Get the user again through the same function
-                AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, userId, null, 'Branden Visser', null, function(err, userObj, loginId, created) {
+                AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Branden Visser', {'email': email}, function(err, userObj, loginId, created) {
                     assert.ok(!err);
                     assert.ok(userObj);
                     assert.equal(userObj.displayName, 'Nicolaas Matthijs');
                     assert.strictEqual(created, false);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -643,24 +625,26 @@ describe('Authentication', function() {
          */
         it('verify create without login id', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            AuthenticationAPI.createUser(ctx, undefined, 'Branden Visser', undefined, function(err, userObj) {
+            var email = TestsUtil.generateTestEmailAddress();
+            AuthenticationAPI.createUser(ctx, undefined, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
         /**
-         * Test that verifies that a user cannot be created without a tenant
+         * Test that verifies that a user cannot be created without a tenant alias
          */
-        it('verify create without tenant id', function(callback) {
+        it('verify create without tenant alias', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -670,11 +654,12 @@ describe('Authentication', function() {
         it('verify create without provider', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, undefined, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -683,11 +668,12 @@ describe('Authentication', function() {
          */
         it('verify create without external id', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, undefined, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -698,24 +684,41 @@ describe('Authentication', function() {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Test with `undefined` display name
-            AuthenticationAPI.createUser(ctx, loginId, undefined, null, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, undefined, {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
 
                 // Test with `null` display name
-                AuthenticationAPI.createUser(ctx, loginId, null, null, function(err, userObj) {
+                AuthenticationAPI.createUser(ctx, loginId, null, {'email': email}, function(err, userObj) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
                     // Test with empty string display name
-                    AuthenticationAPI.createUser(ctx, loginId, '', null, function(err, userObj) {
+                    AuthenticationAPI.createUser(ctx, loginId, '', {'email': email}, function(err, userObj) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
-                        callback();
+                        return callback();
                     });
                 });
+            });
+        });
+
+        /**
+         * Test that verifies that a user cannot be created with an invalid email address
+         */
+        it('verify create with invalid email address', function(callback) {
+            var ctx = new Context(global.oaeTests.tenants.cam);
+            var username = TestsUtil.generateTestUserId();
+            var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
+
+            // Test with an invalid email address
+            AuthenticationAPI.createUser(ctx, loginId, 'Test', {'email': 'not an email address'}, function(err, userObj) {
+                assert.ok(err);
+                assert.equal(err.code, 400);
+                return callback();
             });
         });
 
@@ -725,11 +728,12 @@ describe('Authentication', function() {
         it('verify create local without password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username);
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -739,11 +743,12 @@ describe('Authentication', function() {
         it('verify create local with short password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
 
@@ -752,10 +757,11 @@ describe('Authentication', function() {
          */
         it('verify create user with local loginId', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
+            var email = TestsUtil.generateTestEmailAddress();
             var username = TestsUtil.generateTestUserId();
             var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(!err);
                 assert.ok(userObj);
 
@@ -780,12 +786,13 @@ describe('Authentication', function() {
         it('verify create user with non-local loginId', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, {
                 'username': username,
                 'userPassword': 'password'
             });
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, username);
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(!err);
                 assert.ok(userObj);
 
@@ -793,7 +800,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, username, function(err, userId) {
                     assert.ok(!err);
                     assert.equal(userId, userObj.id);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -804,6 +811,7 @@ describe('Authentication', function() {
         it('verify creating a user fails if the local login id is already taken', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
             var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, {
                 'username': username,
                 'userPassword': 'password'
@@ -811,11 +819,11 @@ describe('Authentication', function() {
 
             // Create the user with the login id
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
-            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', undefined, function(err, userObj) {
+            AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(!err);
 
                 // Ensure we get an error when trying to create a user with the same login id
-                AuthenticationAPI.createUser(ctx, loginId, 'Evil Branden Visser', undefined, function(err) {
+                AuthenticationAPI.createUser(ctx, loginId, 'Evil Branden Visser', {'email': email}, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
@@ -840,18 +848,18 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Cam Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL',
                 'acceptedTC': 'true'
             };
 
             // Ensure the profile parameters are accurate when creating a tenant administrator as a global administrator
-            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, opts, function(err, user) {
+            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, email, opts, function(err, user) {
                 assert.ok(!err);
                 assert.equal(user.displayName, displayName);
-                assert.equal(user.email, opts.email);
+                assert.equal(user.email, email.toLowerCase());
                 assert.equal(user.locale, opts.locale);
                 assert.equal(user.publicAlias, opts.publicAlias);
                 assert.equal(user.visibility, 'private');
@@ -860,7 +868,7 @@ describe('Authentication', function() {
                 RestAPI.User.getUser(globalAdminRestContext, user.id, function(err, user) {
                     assert.ok(!err);
                     assert.equal(user.displayName, displayName);
-                    assert.equal(user.email, opts.email);
+                    assert.equal(user.email, email.toLowerCase());
                     assert.equal(user.locale, opts.locale);
                     assert.equal(user.publicAlias, opts.publicAlias);
                     assert.equal(user.visibility, 'private');
@@ -869,10 +877,11 @@ describe('Authentication', function() {
 
                     // Ensure the profile parameters are accurate when creating a new tenant administrator as a tenant administrator
                     username = TestsUtil.generateTestUserId();
-                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, opts, function(err, user) {
+                    email = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, email, opts, function(err, user) {
                         assert.ok(!err);
                         assert.equal(user.displayName, displayName);
-                        assert.equal(user.email, opts.email);
+                        assert.equal(user.email, email.toLowerCase());
                         assert.equal(user.locale, opts.locale);
                         assert.equal(user.publicAlias, opts.publicAlias);
                         assert.equal(user.visibility, 'private');
@@ -881,7 +890,7 @@ describe('Authentication', function() {
                         RestAPI.User.getUser(camAdminRestContext, user.id, function(err, user) {
                             assert.ok(!err);
                             assert.equal(user.displayName, displayName);
-                            assert.equal(user.email, opts.email);
+                            assert.equal(user.email, email.toLowerCase());
                             assert.equal(user.locale, opts.locale);
                             assert.equal(user.publicAlias, opts.publicAlias);
                             assert.equal(user.visibility, 'private');
@@ -900,27 +909,28 @@ describe('Authentication', function() {
          */
         it('verify authorization of creating a tenant admin user on a tenant', function(callback) {
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, mrvisser) {
                 assert.ok(!err);
 
                 // Ensure anonymous global tenant user cannot create a tenant admin
-                RestAPI.User.createTenantAdminUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                RestAPI.User.createTenantAdminUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Ensure anonymous user tenant user cannot create a tenant admin on a tenant
-                    RestAPI.User.createTenantAdminUserOnTenant(anonymousCamRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                    RestAPI.User.createTenantAdminUserOnTenant(anonymousCamRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 404);
 
                         // Ensure regular user tenant user cannot create a tenant admin on a tenant
-                        RestAPI.User.createTenantAdminUserOnTenant(mrvisser.restContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                        RestAPI.User.createTenantAdminUserOnTenant(mrvisser.restContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 404);
 
                             // Sanity check global admin can create a tenant administrator on another tenant
-                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', null, function(err, user) {
+                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'displayName', email, {}, function(err, user) {
                                 assert.ok(!err);
 
                                 return callback();
@@ -936,22 +946,23 @@ describe('Authentication', function() {
          */
         it('verify authorization of creating a tenant admin user on the current tenant', function(callback) {
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, mrvisser) {
                 assert.ok(!err);
 
                 // Ensure anonymous users cannot create tenant admins
-                RestAPI.User.createTenantAdminUser(anonymousCamRestContext, username, 'password', 'displayName', null, function(err, user) {
+                RestAPI.User.createTenantAdminUser(anonymousCamRestContext, username, 'password', 'displayName', email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
 
                     // Ensure regular users cannot create tenant admins
-                    RestAPI.User.createTenantAdminUser(mrvisser.restContext, username, 'password', 'displayName', null, function(err, user) {
+                    RestAPI.User.createTenantAdminUser(mrvisser.restContext, username, 'password', 'displayName', email, {}, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 401);
 
                         // Sanity check a tenant administrator can create a new tenant administrator on the tenant
-                        RestAPI.User.createTenantAdminUser(camAdminRestContext, username, 'password', 'displayName', null, function(err, user) {
+                        RestAPI.User.createTenantAdminUser(camAdminRestContext, username, 'password', 'displayName', email, {}, function(err, user) {
                             assert.ok(!err);
 
                             return callback();
@@ -968,15 +979,15 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Cam Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL',
                 'acceptedTC': 'true'
             };
 
             // Ensure a tenant alias is required
-            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, null, username, password, displayName, opts, function(err, user) {
+            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, null, username, password, displayName, email, opts, function(err, user) {
                 assert.ok(err);
 
                 // Note that this technically hits the "update user" endpoint with user id "createTenantAdmin". The mistake can be so subtle in
@@ -984,27 +995,27 @@ describe('Authentication', function() {
                 assert.equal(err.code, 400);
 
                 // Ensure a username is required
-                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, null, password, displayName, opts, function(err, user) {
+                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, null, password, displayName, email, opts, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
                     // Ensure a password is required
-                    RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, null, displayName, opts, function(err, user) {
+                    RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, null, displayName, email, opts, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
 
                         // Ensure a displayName is required
-                        RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, null, opts, function(err, user) {
+                        RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, null, email, opts, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
 
                             // Ensure target tenant cannot be the global admin tenant
-                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, 'admin', username, password, displayName, opts, function(err, user) {
+                            RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, 'admin', username, password, displayName, email, opts, function(err, user) {
                                 assert.ok(err);
                                 assert.equal(err.code, 400);
 
                                 // Sanity check we can create one with these parameters
-                                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, opts, function(err, user) {
+                                RestAPI.User.createTenantAdminUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, password, displayName, email, opts, function(err, user) {
                                     assert.ok(!err);
 
                                     return callback();
@@ -1023,38 +1034,48 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Cam Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL',
                 'acceptedTC': 'true'
             };
 
             // Ensure a username is required
-            RestAPI.User.createTenantAdminUser(camAdminRestContext, null, password, displayName, opts, function(err, user) {
+            RestAPI.User.createTenantAdminUser(camAdminRestContext, null, password, displayName, email, opts, function(err, user) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
 
                 // Ensure a password is required
-                RestAPI.User.createTenantAdminUser(camAdminRestContext, username, null, displayName, opts, function(err, user) {
+                RestAPI.User.createTenantAdminUser(camAdminRestContext, username, null, displayName, email, opts, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
 
                     // Ensure a displayName is required
-                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, null, opts, function(err, user) {
+                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, null, email, opts, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
 
-                        // Ensure target tenant cannot be the global admin tenant by requesting with the global administrator
-                        RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, opts, function(err, user) {
+                        // Ensure a valid email is required
+                        RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, null, opts, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
+                            RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, 'Not an email', opts, function(err, user) {
+                                assert.ok(err);
+                                assert.equal(err.code, 400);
 
-                            // Sanity check we can create one with these parameters
-                            RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, opts, function(err, user) {
-                                assert.ok(!err);
+                                // Ensure target tenant cannot be the global admin tenant by requesting with the global administrator
+                                RestAPI.User.createTenantAdminUser(globalAdminRestContext, username, password, displayName, email, opts, function(err, user) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 400);
 
-                                return callback();
+                                    // Sanity check we can create one with these parameters
+                                    RestAPI.User.createTenantAdminUser(camAdminRestContext, username, password, displayName, email, opts, function(err, user) {
+                                        assert.ok(!err);
+
+                                        return callback();
+                                    });
+                                });
                             });
                         });
                     });
@@ -1072,16 +1093,16 @@ describe('Authentication', function() {
             var username = TestsUtil.generateTestUserId();
             var password = 'password';
             var displayName = 'The Admin of Global Tenants';
+            var email = TestsUtil.generateTestEmailAddress();
             var opts = {
-                'email': TestsUtil.generateTestEmailAddress(),
                 'locale': 'en_US',
                 'publicAlias': 'Super User LOL'
             };
 
-            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, password, displayName, opts, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, password, displayName, email, opts, function(err, user) {
                 assert.ok(!err);
                 assert.equal(user.displayName, displayName);
-                assert.equal(user.email, opts.email);
+                assert.equal(user.email, email.toLowerCase());
                 assert.equal(user.locale, opts.locale);
                 assert.equal(user.publicAlias, opts.publicAlias);
                 assert.equal(user.visibility, 'private');
@@ -1089,7 +1110,7 @@ describe('Authentication', function() {
                 RestAPI.User.getUser(globalAdminRestContext, user.id, function(err, user) {
                     assert.ok(!err);
                     assert.equal(user.displayName, displayName);
-                    assert.equal(user.email, opts.email);
+                    assert.equal(user.email, email.toLowerCase());
                     assert.equal(user.locale, opts.locale);
                     assert.equal(user.publicAlias, opts.publicAlias);
                     assert.equal(user.visibility, 'private');
@@ -1105,10 +1126,11 @@ describe('Authentication', function() {
          */
         it('verify authorization of creating a global admin user', function(callback) {
             var userId = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Ensure anonymous on cam tenant cannot create a global admin user. We expect a 404 because the endpoint is
             // only mounted on the global tenant
-            RestAPI.User.createGlobalAdminUser(anonymousCamRestContext, userId, userId, userId, null, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(anonymousCamRestContext, userId, userId, userId, email, {}, function(err, user) {
                 assert.ok(err);
 
                 // Note that this technically hits the "update user" endpoint with user id "createGlobalAdmin". The mistake can be so subtle in
@@ -1117,14 +1139,14 @@ describe('Authentication', function() {
                 assert.ok(!user);
 
                 // Ensure anonymous on global admin tenant cannot create a global admin user
-                RestAPI.User.createGlobalAdminUser(anonymousGlobalRestContext, userId, userId, userId, null, function(err, user) {
+                RestAPI.User.createGlobalAdminUser(anonymousGlobalRestContext, userId, userId, userId, email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 401);
                     assert.ok(!user);
 
                     // Ensure tenant admin on cam tenant cannot create a global admin user. We expect a 404 because the endpoint is
                     // only mounted on the global tenant
-                    RestAPI.User.createGlobalAdminUser(camAdminRestContext, userId, userId, userId, null, function(err, user) {
+                    RestAPI.User.createGlobalAdminUser(camAdminRestContext, userId, userId, userId, email, {}, function(err, user) {
                         assert.ok(err);
 
                         // Note that this technically hits the "update user" endpoint with user id "createGlobalAdmin". The mistake can be so subtle in
@@ -1145,7 +1167,7 @@ describe('Authentication', function() {
                                 assert.ok(me.anon);
 
                                 // Sanity check that we can create the user and authenticate its context
-                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, null, function(err, user) {
+                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, email, {}, function(err, user) {
                                     assert.ok(!err);
                                     assert.ok(user);
                                     assert.equal(user.displayName, userId);
@@ -1173,55 +1195,67 @@ describe('Authentication', function() {
          */
         it('verify validation of creating a global admin user', function(callback) {
             var username = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Ensure you cannot create a global admin user without a username
-            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, null, username, username, null, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, null, username, username, email, {}, function(err, user) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
                 assert.ok(!user);
 
                 // Ensure you cannot create a global admin user without a password
-                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, null, username, null, function(err, user) {
+                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, null, username, email, {}, function(err, user) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
                     assert.ok(!user);
 
                     // Ensure you cannot create a global admin user with a password that is too short
-                    RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, 'a', username, null, function(err, user) {
+                    RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, 'a', username, email, {}, function(err, user) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
                         assert.ok(!user);
 
                         // Ensure you cannot create a global admin user without a displayName
-                        RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, null, function(err, user) {
+                        RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, email, {}, function(err, user) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
                             assert.ok(!user);
 
-                            // Ensure the global admin still cannot be authenticated
-                            var testGlobalUserRestContext = TestsUtil.createGlobalRestContext();
-
-                            // Ensure that the credentials do not authenticate a value global administrator
-                            RestAPI.Authentication.login(testGlobalUserRestContext, username, username, function(err) {
+                            // Ensure you cannot create a global admin user without a valid email address
+                            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, null, {}, function(err, user) {
                                 assert.ok(err);
-                                assert.equal(err.code, 401);
+                                assert.equal(err.code, 400);
+                                assert.ok(!user);
+                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, null, 'not an email', {}, function(err, user) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 400);
+                                    assert.ok(!user);
 
-                                // Verify the context was not authenticated
-                                RestAPI.User.getMe(testGlobalUserRestContext, function(err, me) {
-                                    assert.ok(!err);
-                                    assert.ok(me.anon);
+                                    // Ensure the global admin still cannot be authenticated
+                                    var testGlobalUserRestContext = TestsUtil.createGlobalRestContext();
 
-                                    // Sanity check the user can be created through the REST endpoints
-                                    RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, null, function(err, user) {
-                                        assert.ok(!err);
-                                        assert.ok(user);
+                                    // Ensure that the credentials do not authenticate a valid global administrator
+                                    RestAPI.Authentication.login(testGlobalUserRestContext, username, username, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
 
-                                        // Ensure when we try and create one with the same loginId, we get a 400 error
-                                        RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, null, function(err, secondUser) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 400);
+                                        // Verify the context was not authenticated
+                                        RestAPI.User.getMe(testGlobalUserRestContext, function(err, me) {
+                                            assert.ok(!err);
+                                            assert.ok(me.anon);
 
-                                            return callback();
+                                            // Sanity check the user can be created through the REST endpoints
+                                            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, email, {}, function(err, user) {
+                                                assert.ok(!err);
+                                                assert.ok(user);
+
+                                                // Ensure when we try and create one with the same loginId, we get a 400 error
+                                                RestAPI.User.createGlobalAdminUser(globalAdminRestContext, username, username, username, email, {}, function(err, secondUser) {
+                                                    assert.ok(err);
+                                                    assert.equal(err.code, 400);
+                                                    return callback();
+                                                });
+                                            });
                                         });
                                     });
                                 });
@@ -1237,9 +1271,10 @@ describe('Authentication', function() {
          */
         it('verify creating global admin user results in a user that has global admin user privileges', function(callback) {
             var userId = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Create a global admin user
-            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, null, function(err, user) {
+            RestAPI.User.createGlobalAdminUser(globalAdminRestContext, userId, userId, userId, email, {}, function(err, user) {
                 assert.ok(!err);
 
                 // Log them in
@@ -1269,17 +1304,15 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a login id
          */
         it('verify associate without loginId', function(callback) {
-            var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                var userId = TestsUtil.generateTestUserId();
-                ctx = new Context(global.oaeTests.tenants.cam, user);
 
                 // Associate a login id to the user, with no login id
-                AuthenticationAPI.associateLoginId(ctx, undefined, user.id, function(err) {
+                var ctx = new Context(global.oaeTests.tenants.cam, user.user);
+                AuthenticationAPI.associateLoginId(ctx, undefined, user.user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1288,18 +1321,16 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a tenant
          */
         it('verify associate without tenant', function(callback) {
-            var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                var userId = TestsUtil.generateTestUserId();
-                ctx = new Context(global.oaeTests.tenants.cam, user);
-                var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, userId, {'password': 'password'});
 
                 // Associate a login id to the user, with no tenant
-                AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
+                var ctx = new Context(global.oaeTests.tenants.cam, user.user);
+                var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, user.user.id, {'password': 'password'});
+                AuthenticationAPI.associateLoginId(ctx, loginId, user.user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1308,18 +1339,16 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a login provider
          */
         it('verify associate without provider', function(callback) {
-            var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                 assert.ok(!err);
-                var userId = TestsUtil.generateTestUserId();
-                ctx = new Context(global.oaeTests.tenants.cam, user);
-                var loginId = new LoginId(ctx.tenant().alias, undefined, userId, {'password': 'password'});
 
                 // Associate a login id to the user, with no login provider
+                var ctx = new Context(global.oaeTests.tenants.cam, user.user);
+                var loginId = new LoginId(ctx.tenant().alias, undefined, user.user.id, {'password': 'password'});
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1328,8 +1357,9 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without an external id
          */
         it('verify associate without external id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1339,7 +1369,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1348,8 +1378,9 @@ describe('Authentication', function() {
          * Test that verifies that a login id mapping cannot be done without a user id
          */
         it('verify associate without user id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1359,7 +1390,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, undefined, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1369,7 +1400,8 @@ describe('Authentication', function() {
          */
         it('verify associate local without password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1379,7 +1411,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1389,7 +1421,8 @@ describe('Authentication', function() {
          */
         it('verify associate local with short password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1399,7 +1432,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.associateLoginId(ctx, loginId, user.id, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    callback();
+                    return callback();
                 });
             });
         });
@@ -1409,7 +1442,8 @@ describe('Authentication', function() {
          */
         it('verify associate login id to self', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId();
                 ctx = new Context(global.oaeTests.tenants.cam, user);
@@ -1423,7 +1457,7 @@ describe('Authentication', function() {
                     AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, userId, function(err, userId) {
                         assert.ok(!err);
                         assert.equal(user.id, userId);
-                        callback();
+                        return callback();
                     });
                 });
             });
@@ -1434,7 +1468,8 @@ describe('Authentication', function() {
          */
         it('verify associate multiple login ids to self', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            var email = TestsUtil.generateTestEmailAddress();
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
                 var twitterId = TestsUtil.generateTestUserId() + ':withcolon';
@@ -1457,7 +1492,7 @@ describe('Authentication', function() {
                             AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, twitterId, function(err, userId) {
                                 assert.ok(!err);
                                 assert.equal(user.id, userId);
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -1469,8 +1504,9 @@ describe('Authentication', function() {
          * Test that verifies that an admin user can associate a login id to a user id
          */
         it('verify admin associate login id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
 
@@ -1482,7 +1518,7 @@ describe('Authentication', function() {
                     AuthenticationAPI.getUserIdFromLoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, userId, function(err, userId) {
                         assert.ok(!err);
                         assert.equal(user.id, userId);
-                        callback();
+                        return callback();
                     });
                 });
             });
@@ -1492,12 +1528,14 @@ describe('Authentication', function() {
          * Test that verifies that a user cannot associate a login id to someone else's user id
          */
         it('verify another user cannot associate login id', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, mrvisser) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, mrvisser) {
                 assert.ok(!err);
                 var mrvisserUsername = TestsUtil.generateTestUserId() + ':withcolon';
 
-                PrincipalsAPI.createUser(ctx, null, 'Bert Pareyn', undefined, function(err, bert) {
+                email = TestsUtil.generateTestEmailAddress();
+                PrincipalsAPI.createUser(ctx, null, 'Bert Pareyn', {'email': email}, function(err, bert) {
                     assert.ok(!err);
                     var bertCtx = new Context(global.oaeTests.tenants.cam, bert);
 
@@ -1511,7 +1549,7 @@ describe('Authentication', function() {
                             assert.ok(err);
                             assert.equal(err.code, 404);
                             assert.ok(!mrvisserId);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1522,8 +1560,9 @@ describe('Authentication', function() {
          * Test that verifies that a user can only be mapped to 1 login id per login provider
          */
         it('verify cannot associate multiple login ids of same type', function(callback) {
+            var email = TestsUtil.generateTestEmailAddress();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', undefined, function(err, user) {
+            PrincipalsAPI.createUser(ctx, null, 'Branden Visser', {'email': email}, function(err, user) {
                 assert.ok(!err);
                 var userId = TestsUtil.generateTestUserId() + ':withcolon';
                 var userId2 = TestsUtil.generateTestUserId() + ':withcolon';
@@ -1548,7 +1587,7 @@ describe('Authentication', function() {
                                 assert.ok(err);
                                 assert.equal(err.code, 404);
                                 assert.ok(!userId);
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -1563,12 +1602,14 @@ describe('Authentication', function() {
             var adminCtx = TestsUtil.createTenantAdminContext(global.oaeTests.tenants.cam);
             var mrvisserUsername = TestsUtil.generateTestUserId() + ':withcolon';
             var mrvisserLoginId = new LoginId(global.oaeTests.tenants.cam.alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername);
+            var mrvisserEmail = TestsUtil.generateTestEmailAddress();
             var bertUsername = TestsUtil.generateTestUserId() + ':withcolon';
             var bertLoginId = new LoginId(global.oaeTests.tenants.cam.alias, AuthenticationConstants.providers.LOCAL, bertUsername, {'password': 'password'});
-            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', undefined, function(err, mrvisser) {
+            var bertEmail = TestsUtil.generateTestEmailAddress();
+            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', {'email': mrvisserEmail}, function(err, mrvisser) {
                 assert.ok(!err);
 
-                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', undefined, function(err, bert) {
+                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', {'email': bertEmail}, function(err, bert) {
                     assert.ok(!err);
 
                     AuthenticationAPI.associateLoginId(adminCtx, new LoginId(adminCtx.tenant().alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername), bert.id, function(err) {
@@ -1577,7 +1618,7 @@ describe('Authentication', function() {
                         AuthenticationAPI.getUserIdFromLoginId(adminCtx.tenant().alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername, function(err, userId) {
                             assert.ok(!err);
                             assert.equal(userId, bert.id);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1593,7 +1634,7 @@ describe('Authentication', function() {
                 assert.ok(err);
                 assert.equal(err.code, 404);
                 assert.ok(!userId);
-                callback();
+                return callback();
             });
         });
 
@@ -1605,12 +1646,14 @@ describe('Authentication', function() {
             var adminCtx = TestsUtil.createTenantAdminContext(tenant);
             var mrvisserUsername = TestsUtil.generateTestUserId();
             var mrvisserLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername);
+            var mrvisserEmail = TestsUtil.generateTestEmailAddress();
             var bertUsername = TestsUtil.generateTestUserId();
             var bertLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, bertUsername, {'password': 'password'});
-            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', undefined, function(err, mrvisser) {
+            var bertEmail = TestsUtil.generateTestEmailAddress();
+            AuthenticationAPI.createUser(adminCtx, mrvisserLoginId, 'Branden Visser', {'email': mrvisserEmail}, function(err, mrvisser) {
                 assert.ok(!err);
 
-                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', undefined, function(err, bert) {
+                AuthenticationAPI.createUser(adminCtx, bertLoginId, 'Bert Pareyn', {'email': bertEmail}, function(err, bert) {
                     assert.ok(!err);
                     var bertCtx = new Context(tenant, bert);
 
@@ -1621,7 +1664,7 @@ describe('Authentication', function() {
                         AuthenticationAPI.getUserIdFromLoginId(tenant.alias, AuthenticationConstants.providers.TWITTER, mrvisserUsername, function(err, userId) {
                             assert.ok(!err);
                             assert.equal(userId, mrvisser.id);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1635,7 +1678,7 @@ describe('Authentication', function() {
             AuthenticationAPI.getUserIdFromLoginId(tenant.alias, AuthenticationConstants.providers.TWITTER, '', function(err, userId) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
-                callback();
+                return callback();
             });
         });
     });
@@ -1663,7 +1706,7 @@ describe('Authentication', function() {
                 assert.ok(tenant);
                 assert.ok(tenant.alias);
                 assert.equal(tenant.alias, global.oaeTests.tenants.cam.alias);
-                callback();
+                return callback();
             });
 
             // Refresh and propagate to the event binding above

--- a/node_modules/oae-authentication/tests/test-cookies.js
+++ b/node_modules/oae-authentication/tests/test-cookies.js
@@ -153,7 +153,8 @@ describe('Authentication', function() {
 
             // Create a test user
             var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, createdUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                 assert.ok(!err);
                 var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 

--- a/node_modules/oae-authentication/tests/test-external-strategies.js
+++ b/node_modules/oae-authentication/tests/test-external-strategies.js
@@ -67,23 +67,14 @@ describe('Authentication', function() {
         // Enable strategy
         var configUpdate = {};
         configUpdate['oae-authentication/' + strategyName + '/enabled'] = true;
-        ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-            assert.ok(!err);
-        });
-
-        // Wait until the authentication api has finished refreshing its strategies
-        AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+        AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
             // The strategy has been enabled, perform some assertions
             enabledCallback(function() {
+
                 // Reset strategy to cached status
                 configUpdate['oae-authentication/' + strategyName + '/enabled'] = strategyStatus;
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                    assert.ok(!err);
-                });
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-                    return resetCallback();
-                });
+                return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, resetCallback);
             });
         });
     };
@@ -114,12 +105,7 @@ describe('Authentication', function() {
                 // Now disable it
                 var configUpdate = {};
                 configUpdate['oae-authentication/' + strategyName + '/enabled'] = false;
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, 'localhost', configUpdate, function() {
-                    assert.ok(!err);
-                });
-
-                // Wait until the authentication api has finished refreshing its strategies
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+                AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                     // A disabled endpoint should return a 401.
                     request(options, function (err, response, body) {
@@ -382,6 +368,7 @@ describe('Authentication', function() {
         // A string that can be used with our mocked CAS server that will return a succesfull response
         var validTicket = null;
         var externalId = null;
+        var email = null;
 
         /**
          * Function that will start up a mocked CAS server. The url will be configured for the `localhost` tenant
@@ -394,6 +381,7 @@ describe('Authentication', function() {
 
                 validTicket = 'ticket-' + _.random(0, 10000);
                 externalId = 'sg555@' + _.random(0, 10000);
+                email = TestsUtil.generateTestEmailAddress();
                 app.get('/cas/serviceValidate', function(req, res) {
                     if (req.query.ticket === validTicket) {
                         var successXml = '<cas:serviceResponse>';
@@ -401,7 +389,7 @@ describe('Authentication', function() {
                         successXml += '<cas:user>' + externalId + '</cas:user>';
                         successXml += '<cas:attributes>';
                         successXml += '  <cas:displayName>Simon</cas:displayName>';
-                        successXml += '  <cas:email>simon@test.com</cas:email>';
+                        successXml += '  <cas:email>' + email + '</cas:email>';
                         successXml += '</cas:attributes>';
                         successXml += '</cas:authenticationSuccess>';
                         successXml += '</cas:serviceResponse>';
@@ -417,14 +405,7 @@ describe('Authentication', function() {
                 configUpdate['oae-authentication/cas/loginPath'] = '/login';
                 configUpdate['oae-authentication/cas/mapDisplayName'] = '{displayName}';
                 configUpdate['oae-authentication/cas/mapEmail'] = '{email}';
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                    assert.ok(!err);
-                });
-
-                // Wait until the authentication api has finished refreshing its strategies
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-                    return callback();
-                });
+                return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, callback);
             });
         });
 
@@ -473,8 +454,7 @@ describe('Authentication', function() {
 
                     // Configure the login path
                     var configUpdate = {'oae-authentication/cas/loginPath': '/login/something/foo'};
-                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                        assert.ok(!err);
+                    AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                         // The CAS redirect should now redirect to the new login url
                         RestAPI.Authentication.casRedirect(restContext, function(err, body, response) {
@@ -526,10 +506,7 @@ describe('Authentication', function() {
             // By configuring the CAS url to something non existant, we will trigger an error in the validation step
             var configUpdate = {};
             configUpdate['oae-authentication/cas/url'] = 'http://nothing.here.local';
-            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                assert.ok(!err);
-            });
-            AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+            AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                 _enableStrategy('cas', function(done) {
                     // Trigger a ticket validation error by attempting to log in
@@ -563,7 +540,7 @@ describe('Authentication', function() {
                         assert.ok(!err);
                         assert.ok(!me.anon);
                         assert.strictEqual(me.displayName, 'Simon');
-                        assert.strictEqual(me.email, 'simon@test.com');
+                        assert.strictEqual(me.email, email.toLowerCase());
                         assert.strictEqual(me.authenticationStrategy, 'cas');
 
                         return done();
@@ -581,13 +558,7 @@ describe('Authentication', function() {
                 // Misconfigure some attributes
                 var configUpdate = {};
                 configUpdate['oae-authentication/cas/mapDisplayName'] = '}displayname{';
-                configUpdate['oae-authentication/cas/mapEmail'] = '{oh lawdy}';
-                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                    assert.ok(!err);
-                });
-
-                // Wait until the authentication api has finished refreshing its strategies
-                AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+                AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                     // Log in with our CAS server, authentication should succeed
                     var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.localhost.host);
@@ -606,8 +577,6 @@ describe('Authentication', function() {
                             // Nothing can be replaced from the attribute template, so we use it as-is
                             assert.strictEqual(me.displayName, '}displayname{');
 
-                            // The email should not be configured
-                            assert.ok(!me.email);
                             return done();
                         });
                     });
@@ -622,10 +591,8 @@ describe('Authentication', function() {
         it('verify CAS logout', function(callback) {
             var configUpdate = {};
             configUpdate['oae-authentication/cas/logoutUrl'] = 'http://localhost:' + port + '/cas/logout';
-            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                assert.ok(!err);
-            });
-            AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+            AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
+
                 _enableStrategy('cas', function(done) {
                     // Log in with our CAS server
                     var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.localhost.host);
@@ -673,14 +640,7 @@ describe('Authentication', function() {
             // Setup the Shibboleth strategy (but do not enable it just yet)
             var configUpdate = {};
             configUpdate['oae-authentication/shibboleth/idpEntityID'] = 'https://idp.example.com/shibboleth';
-            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                assert.ok(!err);
-            });
-
-            // Wait until the authentication api has finished refreshing its strategies
-            AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
-                return callback();
-            });
+            return AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, callback);
         });
 
         /**
@@ -811,6 +771,7 @@ describe('Authentication', function() {
                 // Initiate the Shibboleth auth flow
                 _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
 
+                    var email = TestsUtil.generateTestEmailAddress();
                     var attributes = {
                         // Fake a session ID to log in
                         'shib-session-id': Math.random(),
@@ -826,7 +787,7 @@ describe('Authentication', function() {
 
                         // Pass along some attributes
                         'displayname': 'Simon',
-                        'email': 'simon@test.com',
+                        'email': email,
                         'locale': 'en_UK'
                     };
 
@@ -839,7 +800,53 @@ describe('Authentication', function() {
                             assert.ok(!me.anon);
                             assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                             assert.strictEqual(me.displayName, 'Simon');
-                            assert.strictEqual(me.email, 'simon@test.com');
+                            assert.strictEqual(me.email, email.toLowerCase());
+                            assert.strictEqual(me.locale, 'en_UK');
+                            return done();
+                        });
+                    });
+                });
+            }, callback);
+        });
+
+        /**
+         * Test that verifies that the remote_user attribute is used when no displayName attributes are specified
+         */
+        it('verify the remote_user attribute is used when no displayName attributes are specified', function(callback) {
+            _enableStrategy('shibboleth', function(done) {
+
+                // Initiate the Shibboleth auth flow
+                _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
+
+                    var email = TestsUtil.generateTestEmailAddress();
+                    var attributes = {
+                        // Fake a session ID to log in
+                        'shib-session-id': Math.random(),
+
+                        // Fake some data about the IdP
+                        'persistent-id': 'https://idp.example.com/shibboleth#https://sp.example.com/shibboleth#' + Math.random(),
+                        'identityProvider': 'https://idp.example.com/shibboleth',
+                        'affiliation': 'Digital Services',
+                        'unscopedAffiliation': 'OAE Team',
+
+                        // Generate an external id
+                        'remote_user': 'simon' + Math.random(),
+
+                        // Pass along some attributes, but don't specify a display name attribute
+                        'email': email,
+                        'locale': 'en_UK'
+                    };
+
+                    // Perform the callback part of the authentication flow
+                    _callbackShibbolethAuthFlow(tenantRestContext, spRestContext, attributes, '/content/bla', function() {
+
+                        // Assert we're logged in and the attributes were correctly persisted
+                        RestAPI.User.getMe(tenantRestContext, function(err, me) {
+                            assert.ok(!err);
+                            assert.ok(!me.anon);
+                            assert.strictEqual(me.authenticationStrategy, 'shibboleth');
+                            assert.strictEqual(me.displayName, attributes.remote_user);
+                            assert.strictEqual(me.email, email.toLowerCase());
                             assert.strictEqual(me.locale, 'en_UK');
                             return done();
                         });
@@ -969,12 +976,7 @@ describe('Authentication', function() {
                     // Configure the attribute priority list so it tries an `employee-numer`
                     var configUpdate = {};
                     configUpdate['oae-authentication/shibboleth/externalIdAttributes'] = 'irrelevant-attribute employee-number eppn persistent-id targeted-id';
-                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function(err) {
-                        assert.ok(!err);
-                    });
-
-                    // Wait until the authentication api has finished refreshing its strategies
-                    AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
+                    AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, configUpdate, function() {
 
                         // Initiate the Shibboleth auth flow
                         _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
@@ -1046,7 +1048,7 @@ describe('Authentication', function() {
                             assert.ok(!me.anon);
                             assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                             assert.strictEqual(me.displayName, 'Simon via displayname');
-                            assert.strictEqual(me.email, attributes.email);
+                            assert.strictEqual(me.email, attributes.email.toLowerCase());
                             assert.strictEqual(me.locale, 'en_UK');
 
 
@@ -1073,7 +1075,7 @@ describe('Authentication', function() {
                                         assert.ok(!me.anon);
                                         assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                                         assert.strictEqual(me.displayName, 'Nico via cn');
-                                        assert.strictEqual(me.email, attributes.email);
+                                        assert.strictEqual(me.email, attributes.email.toLowerCase());
                                         assert.strictEqual(me.locale, 'en_UK');
                                         return done();
                                     });
@@ -1113,7 +1115,7 @@ describe('Authentication', function() {
                             assert.ok(!me.anon);
                             assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                             assert.strictEqual(me.displayName, 'Simon');
-                            assert.strictEqual(me.email, attributes.email);
+                            assert.strictEqual(me.email, attributes.email.toLowerCase());
                             assert.strictEqual(me.locale, 'en_UK');
 
 
@@ -1140,46 +1142,12 @@ describe('Authentication', function() {
                                         assert.ok(!me.anon);
                                         assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                                         assert.strictEqual(me.displayName, 'Simon');
-                                        assert.strictEqual(me.email, attributes.eppn);
+                                        assert.strictEqual(me.email, attributes.eppn.toLowerCase());
                                         assert.strictEqual(me.locale, 'en_UK');
                                         return done();
                                     });
                                 });
                             });
-                        });
-                    });
-                });
-            }, callback);
-        });
-
-        /**
-         * Test that verifies that an invalid eppn attribute is not used as an email address
-         */
-        it('verify an invalid eppn attribute is not used as an email address', function(callback) {
-            _enableStrategy('shibboleth', function(done) {
-                _initiateShibbolethAuthFlow('/content/bla', function(tenantRestContext, spRestContext) {
-                    var attributes = {
-                        'shib-session-id': _.random(10000),
-                        'persistent-id': 'https://idp.example.com/shibboleth#https://sp.example.com/shibboleth#' + Math.random(),
-                        'identityProvider': 'https://idp.example.com/shibboleth',
-                        'affiliation': 'Digital Services',
-                        'unscopedAffiliation': 'OAE Team',
-                        'remote_user': 'simon' + _.random(10000),
-
-                        // Use an invalid `email` attribute. This should not be stored against the user
-                        'displayname': 'Simon',
-                        'email': 'Simon@backend@oae@apereo.org',
-                        'locale': 'en_UK'
-                    };
-                    _callbackShibbolethAuthFlow(tenantRestContext, spRestContext, attributes, '/content/bla', function() {
-                        RestAPI.User.getMe(tenantRestContext, function(err, me) {
-                            assert.ok(!err);
-                            assert.ok(!me.anon);
-                            assert.strictEqual(me.authenticationStrategy, 'shibboleth');
-                            assert.strictEqual(me.displayName, 'Simon');
-                            assert.ok(!me.email);
-                            assert.strictEqual(me.locale, 'en_UK');
-                            return done();
                         });
                     });
                 });
@@ -1214,7 +1182,7 @@ describe('Authentication', function() {
                             assert.ok(!me.anon);
                             assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                             assert.strictEqual(me.displayName, 'Simon');
-                            assert.strictEqual(me.email, attributes.email);
+                            assert.strictEqual(me.email, attributes.email.toLowerCase());
                             assert.strictEqual(me.locale, attributes.locality);
 
 
@@ -1242,7 +1210,7 @@ describe('Authentication', function() {
                                         assert.ok(!me.anon);
                                         assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                                         assert.strictEqual(me.displayName, 'Simon');
-                                        assert.strictEqual(me.email, attributes.eppn);
+                                        assert.strictEqual(me.email, attributes.eppn.toLowerCase());
                                         assert.strictEqual(me.locale, attributes.locale);
                                         return done();
                                     });
@@ -1279,7 +1247,7 @@ describe('Authentication', function() {
                             assert.ok(!me.anon);
                             assert.strictEqual(me.authenticationStrategy, 'shibboleth');
                             assert.strictEqual(me.displayName, 'Simon');
-                            assert.strictEqual(me.email, attributes.email);
+                            assert.strictEqual(me.email, attributes.email.toLowerCase());
                             assert.notStrictEqual(me.locale, attributes.locale);
 
                             // Verify the user's locale defaulted to the tenant's default locale
@@ -1311,95 +1279,6 @@ describe('Authentication', function() {
         };
 
         /**
-         * Mock the requests that the Passport library would make when verifying a user signing in through Google
-         *
-         * @param  {String}     email           The user's email address
-         */
-        var _mockGoogleSignInRequests = function(email) {
-            // Require nock inline as it messes with the HTTP stack
-            // We only want this to happen in a controlled environment
-            var nock = require('nock');
-
-            // Ensure we can still perform regular HTTP requests during our tests
-            nock.enableNetConnect();
-
-            // Mock the "get access token" request in the OAuth2 cycle
-            var accessToken = _.random(10000);
-            nock('https://accounts.google.com')
-                .post('/o/oauth2/token')
-                .reply(200, {
-                    'access_token': accessToken,
-                    'refresh_token': 'foo'
-                });
-
-            // Mock the "get user profile" request
-            nock('https://www.googleapis.com')
-                .get('/plus/v1/people/me?access_token=' + accessToken)
-                .reply(200, {
-                    'kind': 'plus#person',
-                    'etag': 'RqKWnRU4WW46-6W3rWhLR9',
-                    'gender': 'male',
-                    'emails': [{'value': email, 'type': 'account'}],
-                    'urls': [
-                        {'value': 'http://www.youtube.com/user/abc123','type': 'otherProfile','label': 'ABC 123'},
-                    ],
-                    'objectType': 'person',
-                    'id': _.random(100000),
-                    'displayName': 'Foo Bar',
-                    'name': {
-                        'familyName': 'Bar',
-                        'givenName': 'Foo'
-                    },
-                    'url': 'https://plus.google.com/' + _.random(10000000),
-                    'image': {
-                        'url': 'https://lh5.googleusercontent.com/-wfVubfsOBV0/AAAAAAAAAAI/AAAAAAAAAGQ/rEb5FmsQuiA/photo.jpg?sz=50',
-                        'isDefault': false
-                    },
-                    'isPlusUser': true,
-                    'language': 'en',
-                    'verified': false
-                });
-        };
-
-        /**
-         * Assert that signing in through google with a certain email address does the right thing
-         *
-         * @param  {String}     email               The email address of the user that will sign in
-         * @param  {Boolean}    expectSuccess       Whether or not google authentication is expected to succeed
-         * @param  {Function}   callback            Standard callback function
-         */
-        var _assertGoogleLogin = function(email, expectSuccess, callback) {
-            // Mock the requests the google passport strategy will make
-            _mockGoogleSignInRequests(email);
-
-            // A user returns from Google sign-in and hits our API
-            var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.localhost.host);
-            restContext.followRedirect = false;
-            RestAPI.Authentication.googleCallback(restContext, {'code': 'foo'}, function(err, body, response) {
-                assert.ok(!err);
-                if (expectSuccess) {
-                    assert.strictEqual(response.headers.location, '/me');
-                } else {
-                    assert.strictEqual(response.headers.location, '/?authentication=failed&reason=domain_not_allowed');
-                }
-
-                // Assert we're signed in (or not)
-                RestAPI.User.getMe(restContext, function(err, me) {
-                    assert.ok(!err);
-                    if (expectSuccess) {
-                        assert.ok(!me.anon);
-                        assert.strictEqual(me.email, email);
-                        assert.strictEqual(me.authenticationStrategy, 'google');
-                    } else {
-                        assert.ok(me.anon);
-                    }
-
-                    return callback();
-                });
-            });
-        };
-
-        /**
          * Test that verifies that authentication can be scoped to a set of domains
          */
         it('verify authentication can be scoped to a set of domains', function(callback) {
@@ -1407,27 +1286,27 @@ describe('Authentication', function() {
 
                 // Try with no domains
                 _setGoogleDomains('', function() {
-                    _assertGoogleLogin('simon@foo.com', true, function() {
-                        _assertGoogleLogin('simon@bar.com', true, function() {
-                            _assertGoogleLogin('simon@baz.com', true, function() {
+                    AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@foo.com', function() {
+                        AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@bar.com', function() {
+                            AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@baz.com', function() {
 
                                 // Try with a single domain
                                 _setGoogleDomains('foo.com', function() {
-                                    _assertGoogleLogin('simon@foo.com', true, function() {
-                                        _assertGoogleLogin('simon@bar.com', false, function() {
-                                            _assertGoogleLogin('simon@baz.com', false, function() {
+                                    AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@foo.com', function() {
+                                        AuthenticationTestUtil.assertGoogleLoginFails(global.oaeTests.tenants.localhost.host, 'simon@bar.com', 'domain_not_allowed', function() {
+                                            AuthenticationTestUtil.assertGoogleLoginFails(global.oaeTests.tenants.localhost.host, 'simon@baz.com', 'domain_not_allowed', function() {
 
                                                 // Try with multiple domains
                                                 _setGoogleDomains('foo.com,bar.com', function() {
-                                                    _assertGoogleLogin('simon@foo.com', true, function() {
-                                                        _assertGoogleLogin('simon@bar.com', true, function() {
-                                                            _assertGoogleLogin('simon@baz.com', false, function() {
+                                                    AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@foo.com', function() {
+                                                        AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@bar.com', function() {
+                                                            AuthenticationTestUtil.assertGoogleLoginFails(global.oaeTests.tenants.localhost.host, 'simon@baz.com', 'domain_not_allowed', function() {
 
                                                                 // Try with multiple domains, trailing spaces and mixed capitals
                                                                 _setGoogleDomains('foo.com, BAR.com', function() {
-                                                                    _assertGoogleLogin('simon@foo.com', true, function() {
-                                                                        _assertGoogleLogin('simon@bar.com', true, function() {
-                                                                            _assertGoogleLogin('simon@baz.com', false, function() {
+                                                                    AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@foo.com', function() {
+                                                                        AuthenticationTestUtil.assertGoogleLoginSucceeds(global.oaeTests.tenants.localhost.host, 'simon@bar.com', function() {
+                                                                            AuthenticationTestUtil.assertGoogleLoginFails(global.oaeTests.tenants.localhost.host, 'simon@baz.com', 'domain_not_allowed', function() {
 
                                                                                 return done();
                                                                             });

--- a/node_modules/oae-config/tests/test-config.js
+++ b/node_modules/oae-config/tests/test-config.js
@@ -52,10 +52,10 @@ describe('Configuration', function() {
         // Fill up the global admin rest context
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
         // Fill up the rest context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            callback();
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+            assert.ok(!err);
+            johnRestContext = john.restContext;
+            return callback();
         });
     });
 

--- a/node_modules/oae-content/tests/test-activity.js
+++ b/node_modules/oae-content/tests/test-activity.js
@@ -27,6 +27,7 @@ var EmailTestsUtil = require('oae-email/lib/test/util');
 var FollowingTestsUtil = require('oae-following/lib/test/util');
 var log = require('oae-logger').logger('test-activity');
 var PreviewConstants = require('oae-preview-processor/lib/constants');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var RestUtil = require('oae-rest/lib/util');
@@ -176,76 +177,63 @@ describe('Content Activity', function() {
          * Test that verifies a content resource routes activities to its members when created, updated and shared
          */
         it('verify routing to content members', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var managerGroupMemberUsername = TestsUtil.generateTestUserId('managerGroupMember');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, managerGroupMember) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create the group that will be a viewer of the content
+                RestAPI.Group.createGroup(camAdminRestContext, 'Viewer Group displayName', 'Viewer Group Description', 'public', 'no', [], [], function(err, viewerGroup) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, managerGroupMemberUsername, 'password', 'Jane', null, function(err, managerGroupMember) {
+                    // Create a group that will be a manager of the content
+                    RestAPI.Group.createGroup(camAdminRestContext, 'Manager Group displayName', 'Manager Group Description',  'public', 'no', [], [], function(err, managerGroup) {
                         assert.ok(!err);
 
-                        // Create the group that will be a viewer of the content
-                        RestAPI.Group.createGroup(camAdminRestContext, 'Viewer Group displayName', 'Viewer Group Description', 'public', 'no', [], [], function(err, viewerGroup) {
+                        // managerGroupMember should be a member of the manager group to verify indirect group member routing
+                        var membership = {};
+                        membership[managerGroupMember.user.id] = 'manager';
+                        RestAPI.Group.setGroupMembers(camAdminRestContext, managerGroup.id, membership, function(err) {
                             assert.ok(!err);
 
-                            // Create a group that will be a manager of the content
-                            RestAPI.Group.createGroup(camAdminRestContext, 'Manager Group displayName', 'Manager Group Description',  'public', 'no', [], [], function(err, managerGroup) {
+                            // Create a content item with manager group and viewer group as members.
+                            RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [managerGroup.id], [viewerGroup.id], [], function(err, link) {
                                 assert.ok(!err);
 
-                                // managerGroupMember should be a member of the manager group to verify indirect group member routing
-                                var membership = {};
-                                membership[managerGroupMember.id] = 'manager';
-                                RestAPI.Group.setGroupMembers(camAdminRestContext, managerGroup.id, membership, function(err) {
+                                // Share the content item with jane
+                                RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                                     assert.ok(!err);
 
-                                    // Create a content item with manager group and viewer group as members.
-                                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [managerGroup.id], [viewerGroup.id], [], function(err, link) {
+                                    // Update the content item
+                                    RestAPI.Content.updateContent(jack.restContext, link.id, {'description': 'Super awesome link'}, function(err) {
                                         assert.ok(!err);
 
-                                        // Share the content item with jane
-                                        RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                                        // Verify Jack got the create, share and update as he was the actor for all of them
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                             assert.ok(!err);
+                                            assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
+                                            assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.user.id));
+                                            assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
 
-                                            // Update the content item
-                                            RestAPI.Content.updateContent(jackCtx, link.id, {'description': 'Super awesome link'}, function(err) {
+                                            // Verify the manager group received the create, share and update as they are a content member
+                                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroup.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
+                                                assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
+                                                assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.user.id));
+                                                assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
 
-                                                // Verify Jack got the create, share and update as he was the actor for all of them
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                                // Verify the viewer group received only the create and update. only managers care about the sharing of the "object"
+                                                ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, viewerGroup.id, null, function(err, activityStream) {
                                                     assert.ok(!err);
                                                     assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                    assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.id));
+                                                    assert.ok(!_getActivity(activityStream, 'content-share', 'target', jane.user.id));
                                                     assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
 
-                                                    // Verify the manager group received the create, share and update as they are a content member
-                                                    ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroup.id, null, function(err, activityStream) {
+                                                    // Verify the manager group *member* got the same activities as the manager group, as they are a member
+                                                    ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroupMember.user.id, null, function(err, activityStream) {
                                                         assert.ok(!err);
                                                         assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                        assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.id));
+                                                        assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.user.id));
                                                         assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
-
-                                                        // Verify the viewer group received only the create and update. only managers care about the sharing of the "object"
-                                                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, viewerGroup.id, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                            assert.ok(!_getActivity(activityStream, 'content-share', 'target', jane.id));
-                                                            assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
-
-                                                            // Verify the manager group *member* got the same activities as the manager group, as they are a member
-                                                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, managerGroupMember.id, null, function(err, activityStream) {
-                                                                assert.ok(!err);
-                                                                assert.ok(_getActivity(activityStream, 'content-create', 'object', link.id));
-                                                                assert.ok(_getActivity(activityStream, 'content-share', 'target', jane.id));
-                                                                assert.ok(_getActivity(activityStream, 'content-update', 'object', link.id));
-                                                                callback();
-                                                            });
-                                                        });
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -264,8 +252,7 @@ describe('Content Activity', function() {
          * when non-manager), the content item is still propagated to the route appropriately.
          */
         it('verify content propagation to non-route activity feeds', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
 
                 // Create a private content item
@@ -275,10 +262,10 @@ describe('Content Activity', function() {
                     // Share the content item with Jack. Jack will get the activity in his feed because he is the target, but he will not be in
                     // the routes of the content item because he is not a manager. Despite this, we need to verify that Jack has the full content
                     // item propagated to him as he does have access to it.
-                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.id], function(err) {
+                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream);
 
@@ -288,7 +275,7 @@ describe('Content Activity', function() {
                             assert.equal(object['oae:resourceSubType'], 'link');
                             assert.equal(object['oae:profilePath'], '/content/' + link.tenant.alias + '/' + AuthzUtil.getResourceFromId(link.id).resourceId);
                             assert.equal(object['displayName'], 'Google');
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -299,10 +286,8 @@ describe('Content Activity', function() {
          * Test that verifies a comment activity is routed to recent commenters of a content item.
          */
         it('verify comment activity is routed to the recent commenters of a content item', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-                var simong = _.values(users)[0];
-                var mrvisser = _.values(users)[1];
-                var bert = _.values(users)[2];
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, simong, mrvisser, bert) {
+                assert.ok(!err);
 
                 // Create a content item to be commented on
                 RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
@@ -336,10 +321,8 @@ describe('Content Activity', function() {
          * access to the content item (e.g., it becomes private after they commented).
          */
         it('verify a comment activity is not routed to a recent commenter if they no longer have access to the content item', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
-                var simong = _.values(users)[0];
-                var mrvisser = _.values(users)[1];
-                var bert = _.values(users)[2];
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, simong, mrvisser, bert) {
+                assert.ok(!err);
 
                 // Create a content item to be commented on, bert is a member
                 RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [bert.user.id], [], function(err, link) {
@@ -744,17 +727,15 @@ describe('Content Activity', function() {
                 assert.ok(entity['id'].indexOf(contentId) !== -1);
             };
 
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Generate an activity with the content
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Verify model with no preview state
-                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                         assert.ok(!err);
                         var entity = activityStream.items[0].object;
                         _assertStandardLinkModel(entity, link.id);
@@ -775,7 +756,7 @@ describe('Content Activity', function() {
                                     assert.ok(!err);
 
                                     // Verify that the preview does not display
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                         assert.ok(!err);
 
                                         var entity = activityStream.items[0].object;
@@ -788,7 +769,7 @@ describe('Content Activity', function() {
                                             assert.ok(!err);
 
                                             // Verify that the preview still does not display
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
 
                                                 var entity = activityStream.items[0].object;
@@ -801,7 +782,7 @@ describe('Content Activity', function() {
                                                     assert.ok(!err);
 
                                                     // Verify that the previews are returned in the activity
-                                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                                         assert.ok(!err);
 
                                                         var entity = activityStream.items[0].object;
@@ -863,26 +844,24 @@ describe('Content Activity', function() {
          * Test that verifies the properties of a comment entity
          */
         it('verify the comment entity model contains the correct comment information', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Generate an activity with the content
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Create 3 comments, including one reply. We want to make sure the context is properly aggregated in these comments as their activities are delivered.
-                    RestAPI.Content.createComment(jackCtx, link.id, 'Comment A', null, function(err, commentA) {
+                    RestAPI.Content.createComment(jack.restContext, link.id, 'Comment A', null, function(err, commentA) {
                         assert.ok(!err);
 
-                        RestAPI.Content.createComment(jackCtx, link.id, 'Comment B', null, function(err, commentB) {
+                        RestAPI.Content.createComment(jack.restContext, link.id, 'Comment B', null, function(err, commentB) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createComment(jackCtx, link.id, 'Reply Comment A', commentA.created, function(err, replyCommentA) {
+                            RestAPI.Content.createComment(jack.restContext, link.id, 'Reply Comment A', commentA.created, function(err, replyCommentA) {
                                 assert.ok(!err);
 
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -947,7 +926,7 @@ describe('Content Activity', function() {
                                     assert.ok(hadCommentB);
                                     assert.ok(hadReplyCommentA);
 
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });
@@ -1030,19 +1009,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-create and content-update activity are generated when a content item is created and updated.
          */
         it('verify content-create and content-update activities are posted when content is created and updated', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Generate an activity with the content
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
-                    RestAPI.Content.updateContent(jackCtx, link.id, {'description': 'Super awesome link'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, link.id, {'description': 'Super awesome link'}, function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var createActivity = _getActivity(activityStream, 'content-create', 'object', link.id);
                             var updateActivity = _getActivity(activityStream, 'content-update', 'object', link.id);
@@ -1050,7 +1027,7 @@ describe('Content Activity', function() {
                             assert.equal(createActivity.verb, 'create');
                             assert.ok(updateActivity);
                             assert.equal(updateActivity.verb, 'update');
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1061,19 +1038,17 @@ describe('Content Activity', function() {
          * Test to verify the revision id gets updated in the activity when a new revision is posted
          */
         it('verify content-update activities have updated previews', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.Content.createFile(jackCtx, 'name', 'description', 'public', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
+                RestAPI.Content.createFile(jack.restContext, 'name', 'description', 'public', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Create a new revision
-                    RestAPI.Content.updateFileBody(jackCtx, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
+                    RestAPI.Content.updateFileBody(jack.restContext, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var createActivity = _getActivity(activityStream, 'content-create', 'object', content.id);
 
@@ -1081,7 +1056,7 @@ describe('Content Activity', function() {
                             assert.ok(createActivity);
                             assert.ok(updateActivity);
                             assert.notEqual(createActivity.object['oae:revisionId'], updateActivity.object['oae:revisionId']);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1092,18 +1067,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-share activity is generated when a content item is shared.
          */
         it('verify a content-share activity is generated when a content item is shared', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
 
                 RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Try and generate a share activity
-                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.id], function(err) {
+                    RestAPI.Content.shareContent(camAdminRestContext, link.id, [jack.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var shareActivity = _getActivity(activityStream, 'content-share', 'object', link.id);
                             assert.ok(shareActivity);
@@ -1147,22 +1121,20 @@ describe('Content Activity', function() {
          * Test that verifies that a content-revision activity is generated when a content item's body has been updated / uploaded.
          */
         it('verify a content-revision activity is generated when a content item\'s body has been updated', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a revisable content item
-                RestAPI.Content.createFile(jackCtx, 'Test Content 1', 'Test content description 1', 'private', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
+                RestAPI.Content.createFile(jack.restContext, 'Test Content 1', 'Test content description 1', 'private', getFunctionThatReturnsFileStream('oae-video.png'),  [], [], [], function(err, content) {
                     assert.ok(!err);
                     assert.ok(content);
 
                     // Create a new version
-                    RestAPI.Content.updateFileBody(jackCtx, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
+                    RestAPI.Content.updateFileBody(jack.restContext, content.id, getFunctionThatReturnsFileStream('apereo.jpg'), function(err) {
                         assert.ok(!err);
 
                         // Verify the revision activity was created for jack
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var revisionActivity = _getActivity(activityStream, 'content-revision', 'object', content.id);
                             assert.ok(revisionActivity);
@@ -1182,19 +1154,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-add-to-library activity is generated when a user adds a content item to their own library
          */
         it('verify a content-add-to-library activity is generated when a user adds a content item to their own library', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Jack adds the content item to his own library
-                    RestAPI.Content.shareContent(jackCtx, link.id, [jack.id], function(err) {
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jack.user.id], function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var addActivity = _getActivity(activityStream, 'content-add-to-library', 'object', link.id);
                             assert.ok(addActivity);
@@ -1210,19 +1180,17 @@ describe('Content Activity', function() {
          * Test that verifies that a content-update-visibility activity is generated when a content's visibility is updated
          */
         it('verify a content-update-visibility activity is generated when a content item\'s visibility is updated', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [jack.id], [], function(err, link) {
+                RestAPI.Content.createLink(camAdminRestContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [jack.user.id], [], function(err, link) {
                     assert.ok(!err);
 
                     // Jack adds the content item to his own library
                     RestAPI.Content.updateContent(camAdminRestContext, link.id, {'visibility': 'private'}, function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             var updateVisibilityActivity = _getActivity(activityStream, 'content-update-visibility', 'object', link.id);
                             assert.ok(updateVisibilityActivity);
@@ -1246,28 +1214,24 @@ describe('Content Activity', function() {
          * aggregated into a collection.
          */
         it('verify content-create activities are pivoted by actor', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Create a Yahoo link
-                    RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
                         // Verify the activities were aggregated into one, pivoted by actor
-                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(activityStream);
                             assert.equal(activityStream.items.length, 1);
 
-                            var aggregate = _getActivity(activityStream, 'content-create', 'actor', jack.id);
+                            var aggregate = _getActivity(activityStream, 'content-create', 'actor', jack.user.id);
                             assert.ok(aggregate.object);
                             assert.ok(aggregate.object['oae:collection']);
                             assert.equal(aggregate.object['oae:collection'].length, 2);
@@ -1292,39 +1256,35 @@ describe('Content Activity', function() {
          * deleted properly
          */
         it('verify when a content-create activity is redelivered, it deletes the previous one', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Force a collection of activities so that the individual activity is delivered
-                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                         assert.ok(!err);
                         assert.ok(activityStream);
                         assert.ok(activityStream.items.length, 1);
 
                         // Create a Yahoo link
-                        RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                             assert.ok(!err);
 
                             // Collect again and ensure we still only have one activity
-                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.ok(activityStream.items.length, 1);
 
                                 // Rinse and repeat once to ensure that the aggregates are removed properly as well
-                                RestAPI.Content.createLink(jackCtx, 'Apereo!', 'Apereo!', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                RestAPI.Content.createLink(jack.restContext, 'Apereo!', 'Apereo!', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                     assert.ok(!err);
 
                                     // Collect again and ensure we still only have one activity
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
                                         assert.ok(activityStream);
                                         assert.ok(activityStream.items.length, 1);
@@ -1497,23 +1457,19 @@ describe('Content Activity', function() {
          * Test that verifies when a content item is updated multiple times, the actors that updated it are aggregated into a collection.
          */
         it('verify content-update activities are pivoted by object', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Update the content once as jack
-                    RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'The Google'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'The Google'}, function(err) {
                         assert.ok(!err);
 
                         // Update it a second time as jack, we use this to make sure we don't get duplicates in the aggregation
-                        RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'Google'}, function(err) {
+                        RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'Google'}, function(err) {
                             assert.ok(!err);
 
                             // Update it with a different user, this should be a second entry in the collection
@@ -1521,7 +1477,7 @@ describe('Content Activity', function() {
                                 assert.ok(!err);
 
                                 // Verify we get the 2 actors in the stream
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -1546,31 +1502,27 @@ describe('Content Activity', function() {
          * timestamp.
          */
         it('verify duplicate content-update activities are re-released with a more recent date, with no aggregations', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Update the content once as jack
-                    RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'The Google'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'The Google'}, function(err) {
                         assert.ok(!err);
 
                         // Add something to the activity feed that happened later than the previous update
-                        RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                             assert.ok(!err);
 
                             // Update it a second time as jack, we use this to make sure we don't get duplicates in the aggregation, and ensure the update jumps ahead of the last create activity in the feed
-                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'Google'}, function(err) {
+                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'Google'}, function(err) {
                                 assert.ok(!err);
 
                                 // Verify that the activity is still a non-aggregated activity, it just jumped to the front of the feed
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -1580,35 +1532,35 @@ describe('Content Activity', function() {
                                     // Ensures that the actor is not a collection, but still an individual entity
                                     var activity = activityStream.items[0];
                                     assert.equal(activity['oae:activityType'], 'content-update');
-                                    assert.ok(activity.actor['oae:id'], jack.id);
-                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                    assert.ok(activity.actor['oae:id'], jack.user.id);
+                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' +  AuthzUtil.getResourceFromId(googleLink.id).resourceId);
 
                                     // Send a new activity into the feed so it is the most recent
-                                    RestAPI.Content.createLink(jackCtx, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                    RestAPI.Content.createLink(jack.restContext, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                         assert.ok(!err);
 
                                         // Force a collection so that the most recent activity is in the feed
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.equal(activityStream.items.length, 2);
 
                                             // Jump the update activity to the top again
-                                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'displayName': 'Google'}, function(err) {
+                                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'displayName': 'Google'}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Verify update activity is at the top and still an individual activity
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                     assert.ok(activityStream);
                                                     assert.equal(activityStream.items.length, 2);
 
                                                     // content-update activity should be the first in the list, it should still be a single activity
                                                     var activity = activityStream.items[0];
                                                     assert.equal(activity['oae:activityType'], 'content-update');
-                                                    assert.equal(activity.actor['oae:id'], jack.id);
-                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                                    assert.equal(activity.actor['oae:id'], jack.user.id);
+                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' +  AuthzUtil.getResourceFromId(googleLink.id).resourceId);
                                                     callback();
@@ -1639,31 +1591,27 @@ describe('Content Activity', function() {
          * activity feed. Instead, the activity should be updated and reposted as a recent item.
          */
         it('verify duplicate content-update-visibility activities are not duplicated in the feed', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
                     // Update the content once as jack
-                    RestAPI.Content.updateContent(jackCtx, googleLink.id, {'visibility': 'loggedin'}, function(err) {
+                    RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'visibility': 'loggedin'}, function(err) {
                         assert.ok(!err);
 
                         // Add something to the activity feed that happened later than the previous update
-                        RestAPI.Content.createLink(jackCtx, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        RestAPI.Content.createLink(jack.restContext, 'Yahoo!', 'Yahoo!', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                             assert.ok(!err);
 
                             // Update it a second time as jack, we use this to make sure we don't get duplicates in the aggregation, and ensure the update jumps ahead of the last create activity in the feed
-                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'visibility': 'private'}, function(err) {
+                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'visibility': 'private'}, function(err) {
                                 assert.ok(!err);
 
                                 // Verify that the activity is still a non-aggregated activity, it just jumped to the front of the feed
-                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                     assert.ok(!err);
                                     assert.ok(activityStream);
 
@@ -1673,35 +1621,35 @@ describe('Content Activity', function() {
                                     // Ensures that the actor is not a collection, but still an individual entity
                                     var activity = activityStream.items[0];
                                     assert.equal(activity['oae:activityType'], 'content-update-visibility');
-                                    assert.ok(activity.actor['oae:id'], jack.id);
-                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                    assert.ok(activity.actor['oae:id'], jack.user.id);
+                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' +  AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' +  AuthzUtil.getResourceFromId(googleLink.id).resourceId);
 
                                     // Send a new activity into the feed so it is the most recent
-                                    RestAPI.Content.createLink(jackCtx, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                    RestAPI.Content.createLink(jack.restContext, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                         assert.ok(!err);
 
                                         // Force a collection so that the most recent activity is in the feed
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.equal(activityStream.items.length, 2);
 
                                             // Jump the update activity to the top again
-                                            RestAPI.Content.updateContent(jackCtx, googleLink.id, {'visibility': 'public'}, function(err) {
+                                            RestAPI.Content.updateContent(jack.restContext, googleLink.id, {'visibility': 'public'}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Verify update activity is at the top and still an individual activity
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                     assert.ok(activityStream);
                                                     assert.equal(activityStream.items.length, 2);
 
                                                     // content-update activity should be the first in the list, it should still be a single activity
                                                     var activity = activityStream.items[0];
                                                     assert.equal(activity['oae:activityType'], 'content-update-visibility');
-                                                    assert.equal(activity.actor['oae:id'], jack.id);
-                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
+                                                    assert.equal(activity.actor['oae:id'], jack.user.id);
+                                                    assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
                                                     assert.ok(activity.object['oae:id'], googleLink.id);
                                                     assert.equal(activity.object['oae:profilePath'], '/content/' + googleLink.tenant.alias + '/' + AuthzUtil.getResourceFromId(googleLink.id).resourceId);
                                                     callback();
@@ -1732,19 +1680,15 @@ describe('Content Activity', function() {
          * for display.
          */
         it('verify that content-comment activity aggregates both actor and object entities while pivoting on target', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 // Create a google link
-                RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Post a content as jack
-                    RestAPI.Content.createComment(jackCtx, link.id, 'Test Comment A', null, function(err) {
+                    RestAPI.Content.createComment(jack.restContext, link.id, 'Test Comment A', null, function(err) {
                         assert.ok(!err);
 
                         // Post a comment as the cambridge admin, we have now aggregated a 2nd comment posting on the same content item
@@ -1752,7 +1696,7 @@ describe('Content Activity', function() {
                             assert.ok(!err);
 
                             // Verify that both actors (camadmin and jack) and both objects (both comments) are available in the activity
-                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(activityStream);
                                 assert.equal(activityStream.items.length, 2);
@@ -1770,11 +1714,11 @@ describe('Content Activity', function() {
                                 assert.equal(activity.target['oae:id'], link.id);
 
                                 // Post a 3rd comment as a user who has posted already
-                                RestAPI.Content.createComment(jackCtx, link.id, 'Test Comment C', null, function(err) {
+                                RestAPI.Content.createComment(jack.restContext, link.id, 'Test Comment C', null, function(err) {
                                     assert.ok(!err);
 
                                     // Verify that the 3rd comment is aggregated into the object collection of the activity, however the actor collection has only the 2 unique actors
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
                                         assert.ok(activityStream);
                                         assert.equal(activityStream.items.length, 2);
@@ -1817,87 +1761,76 @@ describe('Content Activity', function() {
          * activity feed.
          */
         it('verify duplicate content-share activities do not result in redundant activities', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                     assert.ok(!err);
-                    var janeCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                    // Create a google link
-                    RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                    // Share with jack, creates one activity item in cam admin's feed
+                    RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                         assert.ok(!err);
 
-                        // Share with jack, creates one activity item in cam admin's feed
-                        RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                        var removeJane = {};
+                        removeJane[jane.user.id] = false;
+
+                        // Remove jane so we can duplicate the content share after
+                        RestAPI.Content.updateMembers(jack.restContext, link.id, removeJane, function(err) {
                             assert.ok(!err);
 
-                            var removeJane = {};
-                            removeJane[jane.id] = false;
-
-                            // Remove jane so we can duplicate the content share after
-                            RestAPI.Content.updateMembers(jackCtx, link.id, removeJane, function(err) {
+                            // Create some noise in the feed to ensure that the second share content will jump to the top
+                            RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.google.ca', [], [], [], function(err, yahooLink) {
                                 assert.ok(!err);
 
-                                // Create some noise in the feed to ensure that the second share content will jump to the top
-                                RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.google.ca', [], [], [], function(err, yahooLink) {
+                                // Now re-add Jane
+                                RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                                     assert.ok(!err);
 
-                                    // Now re-add Jane
-                                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                                    // Verify that jack only has only one activity in his feed representing the content-share
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
+                                        assert.ok(activityStream);
+                                        assert.equal(activityStream.items.length, 2);
 
-                                        // Verify that jack only has only one activity in his feed representing the content-share
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        // The first activity should be the content share, and it should not be an aggregation
+                                        var activity = activityStream.items[0];
+                                        assert.equal(activity['oae:activityType'], 'content-share');
+                                        assert.equal(activity.actor['oae:id'], jack.user.id);
+                                        assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
+                                        assert.equal(activity.object['oae:id'], link.id);
+                                        assert.equal(activity.object['oae:profilePath'], '/content/' + link.tenant.alias + '/' + AuthzUtil.getResourceFromId(link.id).resourceId);
+                                        assert.equal(activity.target['oae:id'], jane.user.id);
+                                        assert.equal(activity.target['oae:profilePath'], '/user/' + jane.user.tenant.alias + '/' + AuthzUtil.getResourceFromId(jane.user.id).resourceId);
+
+                                        // Repeat once more to ensure we don't duplicate when the aggregate is already active
+                                        RestAPI.Content.updateMembers(jack.restContext, link.id, removeJane, function(err) {
                                             assert.ok(!err);
-                                            assert.ok(activityStream);
-                                            assert.equal(activityStream.items.length, 2);
 
-                                            // The first activity should be the content share, and it should not be an aggregation
-                                            var activity = activityStream.items[0];
-                                            assert.equal(activity['oae:activityType'], 'content-share');
-                                            assert.equal(activity.actor['oae:id'], jack.id);
-                                            assert.equal(activity.actor['oae:profilePath'], '/user/' + jack.tenant.alias + '/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
-                                            assert.equal(activity.object['oae:id'], link.id);
-                                            assert.equal(activity.object['oae:profilePath'], '/content/' + link.tenant.alias + '/' + AuthzUtil.getResourceFromId(link.id).resourceId);
-                                            assert.equal(activity.target['oae:id'], jane.id);
-                                            assert.equal(activity.target['oae:profilePath'], '/user/' + jane.tenant.alias + '/' + AuthzUtil.getResourceFromId(jane.id).resourceId);
-
-                                            // Repeat once more to ensure we don't duplicate when the aggregate is already active
-                                            RestAPI.Content.updateMembers(jackCtx, link.id, removeJane, function(err) {
+                                            // Create some noise in the feed to ensure that the third share content will jump to the top
+                                            RestAPI.Content.createLink(jack.restContext, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
                                                 assert.ok(!err);
 
-                                                // Create some noise in the feed to ensure that the third share content will jump to the top
-                                                RestAPI.Content.createLink(jackCtx, 'Apereo', 'Apereo', 'public', 'http://www.apereo.org', [], [], [], function(err, apereoLink) {
+                                                // Re-share with Jane for the 3rd time
+                                                RestAPI.Content.shareContent(jack.restContext, link.id, [jane.user.id], function(err) {
                                                     assert.ok(!err);
 
-                                                    // Re-share with Jane for the 3rd time
-                                                    RestAPI.Content.shareContent(jackCtx, link.id, [jane.id], function(err) {
+                                                    // Verify that jack still has only one activity in his feed representing the content-share
+                                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                         assert.ok(!err);
+                                                        assert.ok(activityStream);
+                                                        assert.equal(activityStream.items.length, 2);
 
-                                                        // Verify that jack still has only one activity in his feed representing the content-share
-                                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.ok(activityStream);
-                                                            assert.equal(activityStream.items.length, 2);
-
-                                                            // The first activity should be the content share, and it should still not be an aggregation
-                                                            var activity = activityStream.items[0];
-                                                            assert.equal(activity['oae:activityType'], 'content-share');
-                                                            assert.equal(activity.actor['oae:id'], jack.id);
-                                                            assert.equal(activity.actor['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jack.id).resourceId);
-                                                            assert.equal(activity.object['oae:id'], link.id);
-                                                            assert.equal(activity.object['oae:profilePath'], '/content/camtest/' + AuthzUtil.getResourceFromId(link.id).resourceId);
-                                                            assert.equal(activity.target['oae:id'], jane.id);
-                                                            assert.equal(activity.target['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jane.id).resourceId);
-                                                            callback();
-                                                        });
+                                                        // The first activity should be the content share, and it should still not be an aggregation
+                                                        var activity = activityStream.items[0];
+                                                        assert.equal(activity['oae:activityType'], 'content-share');
+                                                        assert.equal(activity.actor['oae:id'], jack.user.id);
+                                                        assert.equal(activity.actor['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jack.user.id).resourceId);
+                                                        assert.equal(activity.object['oae:id'], link.id);
+                                                        assert.equal(activity.object['oae:profilePath'], '/content/camtest/' + AuthzUtil.getResourceFromId(link.id).resourceId);
+                                                        assert.equal(activity.target['oae:id'], jane.user.id);
+                                                        assert.equal(activity.target['oae:profilePath'], '/user/camtest/' + AuthzUtil.getResourceFromId(jane.user.id).resourceId);
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -1916,40 +1849,82 @@ describe('Content Activity', function() {
          * from the activity bucket.
          */
         it('verify content-share activities aggregate and are branched properly when all collected at once', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                        // Share google link with jane and branden
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id, branden.user.id], function(err) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                            // Share Yahoo link with jane only
+                            RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                 assert.ok(!err);
 
-                                // Share google link with jane and branden
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id, branden.id], function(err) {
+                                // Verify that the share activities aggregated in both pivot points
+                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
+                                    assert.ok(!err);
+                                    assert.ok(activityStream);
+                                    assert.equal(activityStream.items.length, 3);
+
+                                    // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
+                                    var activity = activityStream.items[0];
+                                    assert.ok(activity.object['oae:collection']);
+                                    assert.equal(activity.object['oae:collection'].length, 2);
+
+                                    // 2. actor+object aggregate should have: jack+google+(jane,branden)
+                                    activity = activityStream.items[1];
+                                    assert.ok(activity.target['oae:collection']);
+                                    assert.equal(activity.target['oae:collection'].length, 2);
+
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies an activity with two aggregates will create 2 aggregate activities correctly when one single activity
+         * currently exists in the activity stream.
+         */
+        it('verify content-share activities aggregate and are branched properly when collected after first share', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
+                assert.ok(!err);
+
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                    assert.ok(!err);
+
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                        assert.ok(!err);
+
+                        // Share google link with jane
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id], function(err) {
+                            assert.ok(!err);
+
+                            // Perform a collection to activate some aggregates ahead of time
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
+                                assert.ok(!err);
+
+                                // Share google now with branden, should aggregate with the previous
+                                RestAPI.Content.shareContent(jack.restContext, googleLink.id, [branden.user.id], function(err) {
                                     assert.ok(!err);
 
                                     // Share Yahoo link with jane only
-                                    RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
+                                    RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                         assert.ok(!err);
 
                                         // Verify that the share activities aggregated in both pivot points
-                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                             assert.ok(!err);
                                             assert.ok(activityStream);
                                             assert.equal(activityStream.items.length, 3);
@@ -1964,81 +1939,7 @@ describe('Content Activity', function() {
                                             assert.ok(activity.target['oae:collection']);
                                             assert.equal(activity.target['oae:collection'].length, 2);
 
-                                            callback();
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-
-        /**
-         * Test that verifies an activity with two aggregates will create 2 aggregate activities correctly when one single activity
-         * currently exists in the activity stream.
-         */
-        it('verify content-share activities aggregate and are branched properly when collected after first share', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
-
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
-                    assert.ok(!err);
-
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
-                        assert.ok(!err);
-
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
-                            assert.ok(!err);
-
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
-                                assert.ok(!err);
-
-                                // Share google link with jane
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id], function(err) {
-                                    assert.ok(!err);
-
-                                    // Perform a collection to activate some aggregates ahead of time
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                        assert.ok(!err);
-
-                                        // Share google now with branden, should aggregate with the previous
-                                        RestAPI.Content.shareContent(jackCtx, googleLink.id, [branden.id], function(err) {
-                                            assert.ok(!err);
-
-                                            // Share Yahoo link with jane only
-                                            RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
-                                                assert.ok(!err);
-
-                                                // Verify that the share activities aggregated in both pivot points
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                    assert.ok(!err);
-                                                    assert.ok(activityStream);
-                                                    assert.equal(activityStream.items.length, 3);
-
-                                                    // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
-                                                    var activity = activityStream.items[0];
-                                                    assert.ok(activity.object['oae:collection']);
-                                                    assert.equal(activity.object['oae:collection'].length, 2);
-
-                                                    // 2. actor+object aggregate should have: jack+google+(jane,branden)
-                                                    activity = activityStream.items[1];
-                                                    assert.ok(activity.target['oae:collection']);
-                                                    assert.equal(activity.target['oae:collection'].length, 2);
-
-                                                    callback();
-                                                });
-                                            });
+                                            return callback();
                                         });
                                     });
                                 });
@@ -2054,61 +1955,45 @@ describe('Content Activity', function() {
          * in the feed before a third is collected.
          */
         it('verify content-share activities aggregate and are branched properly when collected before last share', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                        // Share google link with jane and branden
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id, branden.user.id], function(err) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                            // Perform a collection to activate some aggregates ahead of time
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Share google link with jane and branden
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id, branden.id], function(err) {
+                                // Share Yahoo link with jane only
+                                RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                     assert.ok(!err);
 
-                                    // Perform a collection to activate some aggregates ahead of time
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    // Verify that the share activities aggregated in both pivot points
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
+                                        assert.ok(activityStream);
+                                        assert.equal(activityStream.items.length, 3);
 
-                                        // Share Yahoo link with jane only
-                                        RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
-                                            assert.ok(!err);
+                                        // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
+                                        var activity = activityStream.items[0];
+                                        assert.ok(activity.object['oae:collection']);
+                                        assert.equal(activity.object['oae:collection'].length, 2);
 
-                                            // Verify that the share activities aggregated in both pivot points
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                assert.ok(!err);
-                                                assert.ok(activityStream);
-                                                assert.equal(activityStream.items.length, 3);
+                                        // 2. actor+object aggregate should have: jack+google+(jane,branden)
+                                        activity = activityStream.items[1];
+                                        assert.ok(activity.target['oae:collection']);
+                                        assert.equal(activity.target['oae:collection'].length, 2);
 
-                                                // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
-                                                var activity = activityStream.items[0];
-                                                assert.ok(activity.object['oae:collection']);
-                                                assert.equal(activity.object['oae:collection'].length, 2);
-
-                                                // 2. actor+object aggregate should have: jack+google+(jane,branden)
-                                                activity = activityStream.items[1];
-                                                assert.ok(activity.target['oae:collection']);
-                                                assert.equal(activity.target['oae:collection'].length, 2);
-
-                                                callback();
-                                            });
-                                        });
+                                        return callback();
                                     });
                                 });
                             });
@@ -2123,69 +2008,53 @@ describe('Content Activity', function() {
          * and delivered to the feed one by one.
          */
         it('verify content-share activities aggregate and are branched properly when collected after each share', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('mrvisser');
-
-            // Create Jack, the user whose will create content items
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                // Create Jane, the user who will be shared with
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                // Create a google link and yahoo link to be shared around
+                RestAPI.Content.createLink(jack.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
                     assert.ok(!err);
 
-                    // Create Branden, a second user to be shared with
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden Visser', null, function(err, branden) {
+                    RestAPI.Content.createLink(jack.restContext, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
                         assert.ok(!err);
 
-                        // Create a google link and yahoo link to be shared around
-                        RestAPI.Content.createLink(jackCtx, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, googleLink) {
+                        // Share google link with jane
+                        RestAPI.Content.shareContent(jack.restContext, googleLink.id, [jane.user.id], function(err) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createLink(jackCtx, 'Yahoo', 'Yahoo', 'public', 'http://www.yahoo.ca', [], [], [], function(err, yahooLink) {
+                            // Perform a collection to activate some aggregates ahead of time
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Share google link with jane
-                                RestAPI.Content.shareContent(jackCtx, googleLink.id, [jane.id], function(err) {
+                                // Share google now with branden, should aggregate with the previous
+                                RestAPI.Content.shareContent(jack.restContext, googleLink.id, [branden.user.id], function(err) {
                                     assert.ok(!err);
 
                                     // Perform a collection to activate some aggregates ahead of time
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                         assert.ok(!err);
 
-                                        // Share google now with branden, should aggregate with the previous
-                                        RestAPI.Content.shareContent(jackCtx, googleLink.id, [branden.id], function(err) {
+                                        // Share Yahoo link with jane only
+                                        RestAPI.Content.shareContent(jack.restContext, yahooLink.id, [jane.user.id], function(err) {
                                             assert.ok(!err);
 
-                                            // Perform a collection to activate some aggregates ahead of time
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
+                                            // Verify that the share activities aggregated in both pivot points
+                                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                                 assert.ok(!err);
+                                                assert.ok(activityStream);
+                                                assert.equal(activityStream.items.length, 3);
 
-                                                // Share Yahoo link with jane only
-                                                RestAPI.Content.shareContent(jackCtx, yahooLink.id, [jane.id], function(err) {
-                                                    assert.ok(!err);
+                                                // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
+                                                var activity = activityStream.items[0];
+                                                assert.ok(activity.object['oae:collection']);
+                                                assert.equal(activity.object['oae:collection'].length, 2);
 
-                                                    // Verify that the share activities aggregated in both pivot points
-                                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                                        assert.ok(!err);
-                                                        assert.ok(activityStream);
-                                                        assert.equal(activityStream.items.length, 3);
+                                                // 2. actor+object aggregate should have: jack+google+(jane,branden)
+                                                activity = activityStream.items[1];
+                                                assert.ok(activity.target['oae:collection']);
+                                                assert.equal(activity.target['oae:collection'].length, 2);
 
-                                                        // 1. actor+target should have jack+(google,yahoo)+jane, and it would be most recent
-                                                        var activity = activityStream.items[0];
-                                                        assert.ok(activity.object['oae:collection']);
-                                                        assert.equal(activity.object['oae:collection'].length, 2);
-
-                                                        // 2. actor+object aggregate should have: jack+google+(jane,branden)
-                                                        activity = activityStream.items[1];
-                                                        assert.ok(activity.target['oae:collection']);
-                                                        assert.equal(activity.target['oae:collection'].length, 2);
-
-                                                        callback();
-                                                    });
-                                                });
+                                                return callback();
                                             });
                                         });
                                     });
@@ -2205,79 +2074,64 @@ describe('Content Activity', function() {
          * scrubbed.
          */
         it('verify content-comment email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, mrvisser, simong, nicolaas) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-                var nicolaas = _.values(users)[2];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    RestAPI.Content.createLink(mrvisser.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
-                        RestAPI.Content.createLink(mrvisser.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                        RestAPI.Content.createComment(simong.restContext, link.id, '<b>Nice link.</b>\n\nWould click again', null, function(err, simongComment) {
                             assert.ok(!err);
 
-                            RestAPI.Content.createComment(simong.restContext, link.id, '<b>Nice link.</b>\n\nWould click again', null, function(err, simongComment) {
-                                assert.ok(!err);
+                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                // There should be exactly one message, the one sent to mrvisser (manager of content item receives content-comment notification)
+                                assert.equal(messages.length, 1);
 
-                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
-                                    // There should be exactly one message, the one sent to mrvisser (manager of content item receives content-comment notification)
-                                    assert.equal(messages.length, 1);
+                                var stringEmail = JSON.stringify(messages[0], null, 2);
+                                var message = messages[0];
 
-                                    var stringEmail = JSON.stringify(messages[0], null, 2);
-                                    var message = messages[0];
+                                // Sanity check that the message is to mrvisser
+                                assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                    // Sanity check that the message is to mrvisser
-                                    assert.equal(message.to[0].address, mrvisser.user.email);
+                                // Ensure that the subject of the email contains the poster's name
+                                assert.notEqual(message.subject.indexOf('swappedFromPublicAlias'), -1);
 
-                                    // Ensure that the subject of the email contains the poster's name
-                                    assert.notEqual(message.subject.indexOf('swappedFromPublicAlias'), -1);
+                                // Ensure some data expected to be in the email is there
+                                assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
+                                assert.notEqual(stringEmail.indexOf(link.displayName), -1);
 
-                                    // Ensure some data expected to be in the email is there
-                                    assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
-                                    assert.notEqual(stringEmail.indexOf(link.displayName), -1);
+                                // Ensure simong's private info is *nowhere* to be found
+                                assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                                assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                                assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                    // Ensure simong's private info is *nowhere* to be found
-                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
+                                // The message probably contains the public alias, though
+                                assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
 
-                                    // The message probably contains the public alias, though
-                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+                                // The message should have escaped the HTML content in the original message
+                                assert.strictEqual(stringEmail.indexOf('<b>Nice link.</b>'), -1);
 
-                                    // The message should have escaped the HTML content in the original message
-                                    assert.strictEqual(stringEmail.indexOf('<b>Nice link.</b>'), -1);
+                                // The new line characters should've been converted into paragraphs
+                                assert.notEqual(stringEmail.indexOf('Would click again</p>'), -1);
 
-                                    // The new line characters should've been converted into paragraphs
-                                    assert.notEqual(stringEmail.indexOf('Would click again</p>'), -1);
+                                // Post a comment as nicolaas and ensure the recent commenter, simong receives an email about it
+                                RestAPI.Content.createComment(nicolaas.restContext, link.id, 'It 404d', null, function(err, nicolaasComment) {
+                                    assert.ok(!err);
 
-                                    // Post a comment as nicolaas and ensure the recent commenter, simong receives an email about it
-                                    RestAPI.Content.createComment(nicolaas.restContext, link.id, 'It 404d', null, function(err, nicolaasComment) {
-                                        assert.ok(!err);
+                                    EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                                        // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
+                                        assert.equal(emails.length, 2);
 
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                            // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
-                                            assert.equal(emails.length, 2);
-
-                                            var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
-                                            assert.ok(_.contains(emailAddresses, simong.user.email));
-                                            assert.ok(_.contains(emailAddresses, mrvisser.user.email));
-                                            return callback();
-                                        });
+                                        var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
+                                        assert.ok(_.contains(emailAddresses, simong.user.email));
+                                        assert.ok(_.contains(emailAddresses, mrvisser.user.email));
+                                        return callback();
                                     });
                                 });
                             });
@@ -2292,58 +2146,44 @@ describe('Content Activity', function() {
          * appropriately scrubbed.
          */
         it('verify content-create email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
+                    RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [mrvisser.user.id], [], function(err, link) {
                         assert.ok(!err);
 
-                        // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
-                        RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [mrvisser.user.id], [], function(err, link) {
-                            assert.ok(!err);
+                        // Mrvisser should get an email, with simong's information scrubbed
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            // There should be exactly one message, the one sent to mrvisser
+                            assert.equal(messages.length, 1);
 
-                            // Mrvisser should get an email, with simong's information scrubbed
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
-                                // There should be exactly one message, the one sent to mrvisser
-                                assert.equal(messages.length, 1);
+                            var stringEmail = JSON.stringify(messages[0]);
+                            var message = messages[0];
 
-                                var stringEmail = JSON.stringify(messages[0]);
-                                var message = messages[0];
+                            // Sanity check that the message is to mrvisser
+                            assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                // Sanity check that the message is to mrvisser
-                                assert.equal(message.to[0].address, mrvisser.user.email);
+                            // Ensure some data expected to be in the email is there
+                            assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
+                            assert.notEqual(stringEmail.indexOf(link.displayName), -1);
 
-                                // Ensure some data expected to be in the email is there
-                                assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
-                                assert.notEqual(stringEmail.indexOf(link.displayName), -1);
+                            // Ensure simong's private info is *nowhere* to be found
+                            assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                // Ensure simong's private info is *nowhere* to be found
-                                assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                assert.equal(stringEmail.indexOf(simong.user.locale), -1);
+                            // The message probably contains the public alias, though
+                            assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
 
-                                // The message probably contains the public alias, though
-                                assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-
-                                return callback();
-                            });
+                            return callback();
                         });
                     });
                 });
@@ -2355,63 +2195,49 @@ describe('Content Activity', function() {
          * appropriately scrubbed.
          */
         it('verify content-share email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
+                    RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
                         assert.ok(!err);
 
-                        // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
-                        RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
-                            assert.ok(!err);
+                        // Collect the createLink activity
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                            // Collect the createLink activity
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            RestAPI.Content.shareContent(simong.restContext, link.id, [mrvisser.user.id], function(err) {
+                                assert.ok(!err);
 
-                                RestAPI.Content.shareContent(simong.restContext, link.id, [mrvisser.user.id], function(err) {
-                                    assert.ok(!err);
+                                // Mrvisser should get an email, with simong's information scrubbed
+                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                    // There should be exactly one message, the one sent to mrvisser
+                                    assert.equal(messages.length, 1);
 
-                                    // Mrvisser should get an email, with simong's information scrubbed
-                                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
-                                        // There should be exactly one message, the one sent to mrvisser
-                                        assert.equal(messages.length, 1);
+                                    var stringEmail = JSON.stringify(messages[0]);
+                                    var message = messages[0];
 
-                                        var stringEmail = JSON.stringify(messages[0]);
-                                        var message = messages[0];
+                                    // Sanity check that the message is to mrvisser
+                                    assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                        // Sanity check that the message is to mrvisser
-                                        assert.equal(message.to[0].address, mrvisser.user.email);
+                                    // Ensure some data expected to be in the email is there
+                                    assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
+                                    assert.notEqual(stringEmail.indexOf(link.displayName), -1);
 
-                                        // Ensure some data expected to be in the email is there
-                                        assert.notEqual(stringEmail.indexOf(link.profilePath), -1);
-                                        assert.notEqual(stringEmail.indexOf(link.displayName), -1);
+                                    // Ensure simong's private info is *nowhere* to be found
+                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                        // Ensure simong's private info is *nowhere* to be found
-                                        assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.locale), -1);
-
-                                        // The message probably contains the public alias, though
-                                        assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-                                        return callback();
-                                    });
+                                    // The message probably contains the public alias, though
+                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+                                    return callback();
                                 });
                             });
                         });
@@ -2421,4 +2247,3 @@ describe('Content Activity', function() {
         });
     });
 });
-

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -106,7 +106,8 @@ describe('Content', function() {
         var contexts = {};
         var createUser = function(identifier, visibility, displayName) {
             var userId = TestsUtil.generateTestUserId(identifier);
-            RestAPI.User.createUser(camAdminRestContext, userId, 'password', displayName, {'visibility' : visibility}, function(err, createdUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId, 'password', displayName, email, {'visibility' : visibility}, function(err, createdUser) {
                 if (err) {
                     assert.fail('Could not create test user');
                 }

--- a/node_modules/oae-content/tests/test-library-search.js
+++ b/node_modules/oae-content/tests/test-library-search.js
@@ -31,7 +31,7 @@ describe('Library Search', function() {
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
-        callback();
+        return callback();
     });
 
     /**
@@ -100,64 +100,47 @@ describe('Library Search', function() {
          * Test that verifies all users can search public user library items
          */
         it('verify all users see public user library item', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                        RestAPI.Content.shareContent(doer.restContext, content.id, [jack.user.id], function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                            // Verify anonymous can see the content item
+                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.equal(results.total, 1);
+                                assert.equal(results.results[0].id, content.id);
 
-                                RestAPI.Content.shareContent(doerRestContext, content.id, [jack.id], function(err) {
+                                // Verify tenant admin can see the content item
+                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Verify anonymous can see the content item
-                                    SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                    // Verify the target user can see the content item
+                                    SearchTestsUtil.searchAll(jack.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                         assert.ok(!err);
                                         assert.equal(results.total, 1);
                                         assert.equal(results.results[0].id, content.id);
 
-                                        // Verify tenant admin can see the content item
-                                        SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                        // Verify a different loggedin user can see the content item
+                                        SearchTestsUtil.searchAll(jane.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
                                             assert.equal(results.total, 1);
                                             assert.equal(results.results[0].id, content.id);
 
-                                            // Verify the target user can see the content item
-                                            SearchTestsUtil.searchAll(jackRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                            // Verify the cross-tenant user can see the content item
+                                            SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
                                                 assert.equal(results.total, 1);
                                                 assert.equal(results.results[0].id, content.id);
-
-                                                // Verify a different loggedin user can see the content item
-                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 1);
-                                                    assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify the cross-tenant user can see the content item
-                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-                                                        callback();
-                                                    });
-                                                });
+                                                return callback();
                                             });
                                         });
                                     });
@@ -173,65 +156,48 @@ describe('Library Search', function() {
          * Test that verifies that anonymous and cross-tenant users cannot search loggedin user library items.
          */
         it('verify anonymous and cross-tenant user cannot see loggedin user library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    // Create the content item as 'loggedin'
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                        RestAPI.Content.shareContent(doer.restContext, content.id, [jack.user.id], function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            // Create the content item as 'loggedin'
-                            RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                            // Verify anonymous cannot see it
+                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.equal(results.total, 0);
+                                assert.ok(!results.results[0]);
 
-                                RestAPI.Content.shareContent(doerRestContext, content.id, [jack.id], function(err) {
+                                // Verify tenant admin can see it
+                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Verify anonymous cannot see it
-                                    SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                    // Verify the target user can see it
+                                    SearchTestsUtil.searchAll(jack.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                         assert.ok(!err);
-                                        assert.equal(results.total, 0);
-                                        assert.ok(!results.results[0]);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        // Verify tenant admin can see it
-                                        SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                        // Verify another loggedin user can see it
+                                        SearchTestsUtil.searchAll(jane.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
                                             assert.equal(results.total, 1);
                                             assert.equal(results.results[0].id, content.id);
 
-                                            // Verify the target user can see it
-                                            SearchTestsUtil.searchAll(jackRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                            // Verify the cross-tenant user cannot see it
+                                            SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.equal(results.total, 1);
-                                                assert.equal(results.results[0].id, content.id);
-
-                                                // Verify another loggedin user can see it
-                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 1);
-                                                    assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify the cross-tenant user cannot see it
-                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 0);
-                                                        assert.ok(!results.results[0]);
-                                                        callback();
-                                                    });
-                                                });
+                                                assert.equal(results.total, 0);
+                                                assert.ok(!results.results[0]);
+                                                return callback();
                                             });
                                         });
                                     });
@@ -247,65 +213,48 @@ describe('Library Search', function() {
          * Test that verifies only admin and the user themselves can search private user library items.
          */
         it('verify only self and admin can see private user library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    // Create the private content item
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                        RestAPI.Content.shareContent(doer.restContext, content.id, [jack.user.id], function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            // Create the private content item
-                            RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                            // Verify anonymous cannot search it
+                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.equal(results.total, 0);
+                                assert.ok(!results.results[0]);
 
-                                RestAPI.Content.shareContent(doerRestContext, content.id, [jack.id], function(err) {
+                                // Verify tenant admin can search it
+                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Verify anonymous cannot search it
-                                    SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                    // Verify the target user can search it
+                                    SearchTestsUtil.searchAll(jack.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                         assert.ok(!err);
-                                        assert.equal(results.total, 0);
-                                        assert.ok(!results.results[0]);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        // Verify tenant admin can search it
-                                        SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                        // Verify another loggedin user cannot search it
+                                        SearchTestsUtil.searchAll(jane.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
-                                            assert.equal(results.total, 1);
-                                            assert.equal(results.results[0].id, content.id);
+                                            assert.equal(results.total, 0);
+                                            assert.ok(!results.results[0]);
 
-                                            // Verify the target user can search it
-                                            SearchTestsUtil.searchAll(jackRestContext, 'content-library', [jack.id], null, function(err, results) {
+                                            // Verify the cross-tenant user cannot search it
+                                            SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.equal(results.total, 1);
-                                                assert.equal(results.results[0].id, content.id);
-
-                                                // Verify another loggedin user cannot search it
-                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 0);
-                                                    assert.ok(!results.results[0]);
-
-                                                    // Verify the cross-tenant user cannot search it
-                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [jack.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 0);
-                                                        assert.ok(!results.results[0]);
-                                                        callback();
-                                                    });
-                                                });
+                                                assert.equal(results.total, 0);
+                                                assert.ok(!results.results[0]);
+                                                return callback();
                                             });
                                         });
                                     });
@@ -324,74 +273,51 @@ describe('Library Search', function() {
          * Test that verifies all users can see public group library items.
          */
         it('verify all users see public group library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 4, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [], function(err, group) {
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [jack.user.id], function(err, group) {
                         assert.ok(!err);
 
-                        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                        // Create the public content item and share it with the group
+                        RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                             assert.ok(!err);
-                            var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                            var membership = {};
-                            membership[jack.id] = 'member';
-                            RestAPI.Group.setGroupMembers(doerRestContext, group.id, membership, function(err) {
+                            RestAPI.Content.shareContent(doer.restContext, content.id, [group.id], function(err) {
                                 assert.ok(!err);
 
-                                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                                // Verify anonymous can see it
+                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
                                     assert.ok(!err);
-                                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                                    assert.equal(results.total, 1);
+                                    assert.equal(results.results[0].id, content.id);
 
-                                    // Create the public content item and share it with the group
-                                    RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                                    // Verify tenant admin can see it
+                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
                                         assert.ok(!err);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        RestAPI.Content.shareContent(doerRestContext, content.id, [group.id], function(err) {
+                                        // Verify a member can see it
+                                        SearchTestsUtil.searchAll(jack.restContext, 'content-library', [group.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 1);
+                                            assert.equal(results.results[0].id, content.id);
 
-                                            // Verify anonymous can see it
-                                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
+                                            // Verify a loggedin non-member can see it
+                                            SearchTestsUtil.searchAll(jane.restContext, 'content-library', [group.id], null, function(err, results) {
                                                 assert.ok(!err);
                                                 assert.equal(results.total, 1);
                                                 assert.equal(results.results[0].id, content.id);
 
-                                                // Verify tenant admin can see it
-                                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                // Verify a cross-tenant user can see it
+                                                SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [group.id], null, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.equal(results.total, 1);
                                                     assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify a member can see it
-                                                    SearchTestsUtil.searchAll(jackRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-
-                                                        // Verify a loggedin non-member can see it
-                                                        SearchTestsUtil.searchAll(janeRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.equal(results.total, 1);
-                                                            assert.equal(results.results[0].id, content.id);
-
-                                                            // Verify a cross-tenant user can see it
-                                                            SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.equal(results.total, 1);
-                                                                assert.equal(results.results[0].id, content.id);
-                                                                callback();
-                                                            });
-                                                        });
-                                                    });
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -408,74 +334,51 @@ describe('Library Search', function() {
          * Test that verifies that anonymous and cross-tenant users cannot search loggedin group library items.
          */
         it('verify anonymous and cross-tenant users cannot see loggedin group library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 4, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [], function(err, group) {
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [jack.user.id], function(err, group) {
                         assert.ok(!err);
 
-                        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                        // Create the loggedin content item and share it with the group
+                        RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                             assert.ok(!err);
-                            var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                            var membership = {};
-                            membership[jack.id] = 'member';
-                            RestAPI.Group.setGroupMembers(doerRestContext, group.id, membership, function(err) {
+                            RestAPI.Content.shareContent(doer.restContext, content.id, [group.id], function(err) {
                                 assert.ok(!err);
 
-                                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                                // Verify anonymous cannot see it
+                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
                                     assert.ok(!err);
-                                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                                    assert.equal(results.total, 0);
+                                    assert.ok(!results.results[0]);
 
-                                    // Create the loggedin content item and share it with the group
-                                    RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'loggedin', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                                    // Verify tenant admin can see it
+                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
                                         assert.ok(!err);
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        RestAPI.Content.shareContent(doerRestContext, content.id, [group.id], function(err) {
+                                        // Verify member user can see it
+                                        SearchTestsUtil.searchAll(jack.restContext, 'content-library', [group.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 1);
+                                            assert.equal(results.results[0].id, content.id);
 
-                                            // Verify anonymous cannot see it
-                                            SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
+                                            // Verify a loggedin non-member can see it
+                                            SearchTestsUtil.searchAll(jane.restContext, 'content-library', [group.id], null, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.equal(results.total, 0);
-                                                assert.ok(!results.results[0]);
+                                                assert.equal(results.total, 1);
+                                                assert.equal(results.results[0].id, content.id);
 
-                                                // Verify tenant admin can see it
-                                                SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                // Verify a cross-tenant user cannot see it
+                                                SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [group.id], null, function(err, results) {
                                                     assert.ok(!err);
-                                                    assert.equal(results.total, 1);
-                                                    assert.equal(results.results[0].id, content.id);
-
-                                                    // Verify member user can see it
-                                                    SearchTestsUtil.searchAll(jackRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                        assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-
-                                                        // Verify a loggedin non-member can see it
-                                                        SearchTestsUtil.searchAll(janeRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.equal(results.total, 1);
-                                                            assert.equal(results.results[0].id, content.id);
-
-                                                            // Verify a cross-tenant user cannot see it
-                                                            SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.equal(results.total, 0);
-                                                                assert.ok(!results.results[0]);
-                                                                callback();
-                                                            });
-                                                        });
-                                                    });
+                                                    assert.equal(results.total, 0);
+                                                    assert.ok(!results.results[0]);
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -493,87 +396,57 @@ describe('Library Search', function() {
          * belong to a different tenant.
          */
         it('verify only member and admin users can see private group library items', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy McSithypants', null, function(err, sith) {
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [sith.user.id, jack.user.id], function(err, group) {
                         assert.ok(!err);
-                        var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
 
-                        // create group with sith as a member
-                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('group'), TestsUtil.generateTestUserId('group'), 'public', 'no', [], [sith.id], function(err, group) {
+                        // Create the private content item and share it with the group
+                        RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                             assert.ok(!err);
 
-                            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                            RestAPI.Content.shareContent(doer.restContext, content.id, [group.id], function(err) {
                                 assert.ok(!err);
-                                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                                var membership = {};
-                                membership[jack.id] = 'member';
-                                RestAPI.Group.setGroupMembers(doerRestContext, group.id, membership, function(err) {
+                                // Verify anonymous cannot see the private content item
+                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
                                     assert.ok(!err);
+                                    assert.equal(results.total, 0);
+                                    assert.ok(!results.results[0]);
 
-                                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                                    // Verify cam admin can see the private content item
+                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
                                         assert.ok(!err);
-                                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                                        assert.equal(results.total, 1);
+                                        assert.equal(results.results[0].id, content.id);
 
-                                        // Create the private content item and share it with the group
-                                        RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'private', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                                        // Verify the same-tenant member can see the private content item
+                                        SearchTestsUtil.searchAll(jack.restContext, 'content-library', [group.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 1);
+                                            assert.equal(results.results[0].id, content.id);
 
-                                            RestAPI.Content.shareContent(doerRestContext, content.id, [group.id], function(err) {
+                                            // Verify the cross-tenant member can see the private content item
+                                            SearchTestsUtil.searchAll(sith.restContext, 'content-library', [group.id], null, function(err, results) {
                                                 assert.ok(!err);
+                                                assert.equal(results.total, 1);
+                                                assert.equal(results.results[0].id, content.id);
 
-                                                // Verify anonymous cannot see the private content item
-                                                SearchTestsUtil.searchAll(anonymousRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                // Verify another loggedin user cannot see the private content item
+                                                SearchTestsUtil.searchAll(jane.restContext, 'content-library', [group.id], null, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.equal(results.total, 0);
                                                     assert.ok(!results.results[0]);
 
-                                                    // Verify cam admin can see the private content item
-                                                    SearchTestsUtil.searchAll(camAdminRestContext, 'content-library', [group.id], null, function(err, results) {
+                                                    // Verify cross-tenant non-member user cannot see the private content item
+                                                    SearchTestsUtil.searchAll(darthVader.restContext, 'content-library', [group.id], null, function(err, results) {
                                                         assert.ok(!err);
-                                                        assert.equal(results.total, 1);
-                                                        assert.equal(results.results[0].id, content.id);
-
-                                                        // Verify the same-tenant member can see the private content item
-                                                        SearchTestsUtil.searchAll(jackRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.equal(results.total, 1);
-                                                            assert.equal(results.results[0].id, content.id);
-
-                                                            // Verify the cross-tenant member can see the private content item
-                                                            SearchTestsUtil.searchAll(sithRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.equal(results.total, 1);
-                                                                assert.equal(results.results[0].id, content.id);
-
-                                                                // Verify another loggedin user cannot see the private content item
-                                                                SearchTestsUtil.searchAll(janeRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                    assert.ok(!err);
-                                                                    assert.equal(results.total, 0);
-                                                                    assert.ok(!results.results[0]);
-
-                                                                    // Verify cross-tenant non-member user cannot see the private content item
-                                                                    SearchTestsUtil.searchAll(darthVaderRestContext, 'content-library', [group.id], null, function(err, results) {
-                                                                        assert.ok(!err);
-                                                                        assert.equal(results.total, 0);
-                                                                        assert.ok(!results.results[0]);
-                                                                        callback();
-                                                                    });
-                                                                });
-                                                            });
-                                                        });
+                                                        assert.equal(results.total, 0);
+                                                        assert.ok(!results.results[0]);
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -594,19 +467,16 @@ describe('Library Search', function() {
          * Test that verifies paging of library search works correctly
          */
         it('verify paging the library search feed works correctly', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Website', 'The website of the Apereo Foundation', 'public', 'http://www.apereofoundation.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(doerRestContext, 'Google Website', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, content) {
+                    RestAPI.Content.createLink(doer.restContext, 'Google Website', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, content) {
                         assert.ok(!err);
 
-                        SearchTestsUtil.searchRefreshed(doerRestContext, 'content-library', [doer.id], {'limit': 2, 'start': 0}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(doer.restContext, 'content-library', [doer.user.id], {'limit': 2, 'start': 0}, function(err, results) {
                             assert.ok(!err);
                             assert.ok(results.results);
                             assert.equal(results.results.length, 2);
@@ -618,19 +488,19 @@ describe('Library Search', function() {
                             assert.ok(secondId);
 
                             // Verify the first item comes on the first page. We don't need to refresh this search because we haven't indexed anything since the previous search
-                            RestAPI.Search.search(doerRestContext, 'content-library', [doer.id], {'limit': 1, 'start': 0}, function(err, results) {
+                            RestAPI.Search.search(doer.restContext, 'content-library', [doer.user.id], {'limit': 1, 'start': 0}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(results.results);
                                 assert.equal(results.results.length, 1);
                                 assert.equal(results.results[0].id, firstId);
 
                                 // Verify the second item comes on the first page.
-                                RestAPI.Search.search(doerRestContext, 'content-library', [doer.id], {'limit': 1, 'start': 1}, function(err, results) {
+                                RestAPI.Search.search(doer.restContext, 'content-library', [doer.user.id], {'limit': 1, 'start': 1}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(results.results);
                                     assert.equal(results.results.length, 1);
                                     assert.equal(results.results[0].id, secondId);
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-content/tests/test-search.js
+++ b/node_modules/oae-content/tests/test-search.js
@@ -139,16 +139,14 @@ describe('Search', function() {
          * item.
          */
         it('verify indexing without full content item', function(callback) {
-            // Create a content item to verify re-indexing
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'test-search index-without-full-content-item', 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
+                RestAPI.Content.createLink(doer.restContext, 'test-search index-without-full-content-item', 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Verify the content item exists
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
                         assert.ok(!err);
                         var contentDoc = _getDocById(results, link.id);
                         assert.ok(contentDoc);
@@ -158,7 +156,7 @@ describe('Search', function() {
                             assert.ok(!err);
 
                             // Verify the content item no longer exists
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
+                            SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
                                 assert.ok(!err);
                                 var contentDoc = _getDocById(results, link.id);
                                 assert.ok(!contentDoc);
@@ -168,7 +166,7 @@ describe('Search', function() {
                                     assert.ok(!err);
 
                                     // Ensure that the full content item is now back in the search index
-                                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
+                                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'index-without-full-content-item'}, function(err, results) {
                                         assert.ok(!err);
                                         var contentDoc = _getDocById(results, link.id);
                                         assert.ok(contentDoc);
@@ -177,7 +175,7 @@ describe('Search', function() {
                                         assert.ok(_.isObject(contentDoc.tenant));
                                         assert.ok(contentDoc.tenant.displayName);
                                         assert.ok(contentDoc.tenant.alias);
-                                        callback();
+                                        return callback();
                                     });
                                 });
                             });
@@ -191,16 +189,15 @@ describe('Search', function() {
          * Verify that the mime property only returns on search results of type 'file'.
          */
         it('verify mime type', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
                 // Make sure links don't have mime field
                 var description = TestsUtil.generateTestUserId('mimetype-test');
-                RestAPI.Content.createLink(doerRestContext, 'Test Content 1', description, 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
+                RestAPI.Content.createLink(doer.restContext, 'Test Content 1', description, 'public', 'http://www.oaeproject.org/',  [], [], [], function(err, link) {
                     assert.ok(!err);
 
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
                         assert.ok(!err);
                         var contentDoc = _getDocById(results, link.id);
                         assert.ok(contentDoc);
@@ -209,18 +206,18 @@ describe('Search', function() {
                         // Make sure files do get mime field
                         var file = fs.createReadStream( __dirname + '/data/oae-video.png');
                         description = TestsUtil.generateTestUserId('mimetype-test');
-                        RestAPI.Content.createFile(doerRestContext, 'Test Content 2', description, 'public', file,  [], [], [], function(err, contentObj) {
+                        RestAPI.Content.createFile(doer.restContext, 'Test Content 2', description, 'public', file,  [], [], [], function(err, contentObj) {
                             assert.ok(!err);
                             assert.ok(contentObj);
                             assert.equal(contentObj.mime, 'image/png');
 
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
+                            SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': description}, function(err, results) {
                                 assert.ok(!err);
                                 var contentDoc = _getDocById(results, contentObj.id);
                                 assert.ok(contentDoc);
                                 assert.equal(contentDoc.mime, 'image/png');
 
-                                callback();
+                                return callback();
                             });
                         });
                     });

--- a/node_modules/oae-content/tests/test-tenant-separation.js
+++ b/node_modules/oae-content/tests/test-tenant-separation.js
@@ -51,7 +51,7 @@ describe('Content', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
-        callback();
+        return callback();
     });
 
     describe('Tenant separation', function() {
@@ -375,46 +375,33 @@ describe('Content', function() {
          * Test that verifies that a user from an external tenant is limited to only the public content library of users
          */
         it('verify user sees only public libraries of external tenant users', function(callback) {
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A (cam)
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create 2 users in tenant A (cam)
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                // Create a second user in tenant A (A2)
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User A2', null, function(err, userA2) {
+                // Create a user in tenant B (gt)
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create user in tenant B (gt)
-                    RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                    // Create "public" content in tenant A
+                    RestAPI.Content.createLink(userA.restContext, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.user.id], [], [], function(err, publicContentA) {
                         assert.ok(!err);
-                        var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
-                        // Create "public" content in tenant A
-                        RestAPI.Content.createLink(restCtxA, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.id], [], [], function(err, publicContentA) {
+                        // Create "loggedin" content in tenant A
+                        RestAPI.Content.createLink(userA.restContext, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.user.id], [], [], function(err, loggedInContentA) {
                             assert.ok(!err);
 
-                            // Create "loggedin" content in tenant A
-                            RestAPI.Content.createLink(restCtxA, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.id], [], [], function(err, loggedInContentA) {
+                            // Verify user A2 can see both public and logged in content items
+                            RestAPI.Content.getLibrary(userA2.restContext, userA.user.id, null, 10, function(err, libraryA) {
                                 assert.ok(!err);
+                                assert.equal(libraryA.results.length, 2);
 
-                                // Verify user A2 can see both public and logged in content items
-                                RestAPI.Content.getLibrary(restCtxA2, userA.id, null, 10, function(err, libraryA) {
+                                // Verify user B cannot see the loggedin content item, but can see the public content item
+                                RestAPI.Content.getLibrary(userB.restContext, userA.user.id, null, 10, function(err, libraryA) {
                                     assert.ok(!err);
-                                    assert.equal(libraryA.results.length, 2);
-
-                                    // Verify user B cannot see the loggedin content item, but can see the public content item
-                                    RestAPI.Content.getLibrary(restCtxB, userA.id, null, 10, function(err, libraryA) {
-                                        assert.ok(!err);
-                                        assert.equal(libraryA.results.length, 1);
-                                        assert.equal(libraryA.results[0].id, publicContentA.id);
-                                        callback();
-                                    });
+                                    assert.equal(libraryA.results.length, 1);
+                                    assert.equal(libraryA.results[0].id, publicContentA.id);
+                                    return callback();
                                 });
                             });
                         });
@@ -427,43 +414,38 @@ describe('Content', function() {
          * Test that verifies that users from an external tenant are limited to a group's public content library
          */
         it('verify user sees only public library of external tenant groups', function(callback) {
-            var usernameA = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A (cam)
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create a user in tenant A (cam)
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, userA) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                // Create a group in tenant A
-                RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'public', 'no', [], [], function(err, groupA) {
+                // Create a user in tenant B (gt)
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
 
-                    // Create user in tenant B (gt)
-                    RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                    // Create a group in tenant A
+                    var groupName = TestsUtil.generateTestUserId();
+                    RestAPI.Group.createGroup(userA.restContext, groupName, groupName, 'public', 'no', [], [], function(err, groupA) {
                         assert.ok(!err);
-                        var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
                         // Create "public" content in tenant A
-                        RestAPI.Content.createLink(restCtxA, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.id], [groupA.id], [], function(err, publicContentA) {
+                        RestAPI.Content.createLink(userA.restContext, 'Yahoo', 'Yahoo Website', 'public', 'http://www.yahoo.ca', [userA.user.id], [groupA.id], [], function(err, publicContentA) {
                             assert.ok(!err);
 
                             // Create "loggedin" content in tenant A
-                            RestAPI.Content.createLink(restCtxA, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.id], [groupA.id], [], function(err, loggedInContentA) {
+                            RestAPI.Content.createLink(userA.restContext, 'Google', 'Google Website', 'loggedin', 'http://google.com', [userA.user.id], [groupA.id], [], function(err, loggedInContentA) {
                                 assert.ok(!err);
 
                                 // Verify user A can see both public and logged in content items for the group
-                                RestAPI.Content.getLibrary(restCtxA, groupA.id, null, 10, function(err, libraryA) {
+                                RestAPI.Content.getLibrary(userA.restContext, groupA.id, null, 10, function(err, libraryA) {
                                     assert.ok(!err);
                                     assert.equal(libraryA.results.length, 2);
 
                                     // Verify user B cannot see the loggedin content item, but can see the public content item
-                                    RestAPI.Content.getLibrary(restCtxB, groupA.id, null, 10, function(err, libraryB) {
+                                    RestAPI.Content.getLibrary(userB.restContext, groupA.id, null, 10, function(err, libraryB) {
                                         assert.ok(!err);
                                         assert.equal(libraryB.results.length, 1);
                                         assert.equal(libraryB.results[0].id, publicContentA.id);
-                                        callback();
+                                        return callback();
                                     });
                                 });
                             });

--- a/node_modules/oae-context/tests/test-context.js
+++ b/node_modules/oae-context/tests/test-context.js
@@ -28,8 +28,8 @@ describe('Context', function() {
      * Test that verifies a simple context
      */
     it('verify simple context', function(callback) {
-        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'public', 'Bert', 'Pareyn', 'PhysX');
-        var imposter = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:simong', 'simong', 'private', 'Simon', 'Gaeremynck', 'simong');
+        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'bert@apereo.org');
+        var imposter = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:simong', 'simong', 'simon@apereo.org');
         var ctx = new Context(global.oaeTests.tenants.cam, user, 'twitter', null, imposter);
         assert.deepEqual(ctx.tenant(), global.oaeTests.tenants.cam);
         assert.deepEqual(ctx.user(), user);
@@ -43,7 +43,7 @@ describe('Context', function() {
      * Test that verifies the locale setter can handle defaulted locales
      */
     it('verify the locale setter can handle defaulted locales', function(callback) {
-        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'public', 'Bert', 'Pareyn', 'PhysX');
+        var user = new User(global.oaeTests.tenants.cam.alias, 'u:camtest:physx', 'physx', 'bert@apereo.org');
         var ctx = new Context(global.oaeTests.tenants.cam, user, 'twitter', 'en_UK');
         assert.deepEqual(ctx.tenant(), global.oaeTests.tenants.cam);
         assert.deepEqual(ctx.user(), user);

--- a/node_modules/oae-discussions/tests/test-activity.js
+++ b/node_modules/oae-discussions/tests/test-activity.js
@@ -21,6 +21,7 @@ var ShortId = require('shortid');
 var AuthzUtil = require('oae-authz/lib/util');
 var log = require('oae-logger').logger('test-activity');
 var PreviewConstants = require('oae-preview-processor/lib/constants');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
 var Sanitization = require('oae-util/lib/sanitization');
@@ -66,8 +67,7 @@ describe('Discussion Activity', function() {
              * Test that verifies the properties of the discussion entity
              */
             it('verify the discussion entity model contains the correct information', function(callback) {
-                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
-                    var simon = _.values(users)[0];
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simon) {
 
                     RestAPI.Discussions.createDiscussion(simon.restContext, 'Goats', 'Start discussing this sweet topic', 'loggedin', null, null, function(err, discussion) {
                         assert.ok(!err);
@@ -98,8 +98,7 @@ describe('Discussion Activity', function() {
              * Test that verifies the properties of the discussion entity when updating.
              */
             it('verify the discussion entity model contains the correct information when updating a discussion', function(callback) {
-                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users) {
-                    var simon = _.values(users)[0];
+                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simon) {
 
                     RestAPI.Discussions.createDiscussion(simon.restContext, 'Bonobos', 'Start discussing this sweet topic', 'loggedin', null, null, function(err, discussion) {
                         assert.ok(!err);
@@ -476,131 +475,28 @@ describe('Discussion Activity', function() {
          * are appropriately scrubbed.
          */
         it('verify discussion message email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, mrvisser, simong, nicolaas) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-                var nicolaas = _.values(users)[2];
-
-                // Generate e-mail addresses
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
 
-                // Update the users
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
+                // Update Simon
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the discussion
+                    RestAPI.Discussions.createDiscussion(mrvisser.restContext, 'A talk', 'about computers', 'public', [], [], function(err, discussion) {
                         assert.ok(!err);
 
-                        // Create the discussion
-                        RestAPI.Discussions.createDiscussion(mrvisser.restContext, 'A talk', 'about computers', 'public', [], [], function(err, discussion) {
+                        // Post a new message
+                        RestAPI.Discussions.createMessage(simong.restContext, discussion.id, '<b>Nice discussion.</b>\n\nWould read again', null, function(err, simongMessage) {
                             assert.ok(!err);
 
-                            // Post a new message
-                            RestAPI.Discussions.createMessage(simong.restContext, discussion.id, '<b>Nice discussion.</b>\n\nWould read again', null, function(err, simongMessage) {
-                                assert.ok(!err);
-
-                                EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                    // There should be exactly one email, the one sent to mrvisser (manager of discussion receives discussion-message notification)
-                                    assert.equal(emails.length, 1);
-
-                                    var stringEmail = JSON.stringify(emails[0]);
-                                    var email = emails[0];
-
-                                    // Sanity check that the email is to mrvisser
-                                    assert.equal(email.to[0].address, mrvisser.user.email);
-
-                                    // Ensure that the subject of the email contains the poster's name
-                                    assert.notEqual(email.subject.indexOf('swappedFromPublicAlias'), -1);
-
-                                    // Ensure some data expected to be in the email is there
-                                    assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
-                                    assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
-                                    assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
-
-                                    // Ensure simong's private info is nowhere to be found
-                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
-
-                                    // The email should contain the public alias
-                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-
-                                    // The message should have escaped the HTML content in the original message
-                                    assert.strictEqual(stringEmail.indexOf('<b>Nice discussion.</b>'), -1);
-
-                                    // The new line characters should've been converted into paragraphs
-                                    assert.notEqual(stringEmail.indexOf('Would read again</p>'), -1);
-
-                                    // Send a message as nicolaas and ensure the recent commenter, simong receives an email about it
-                                    RestAPI.Discussions.createMessage(nicolaas.restContext, discussion.id, 'I have a computer, too', null, function(err, nicolaasMessage) {
-                                        assert.ok(!err);
-
-                                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                            // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
-                                            assert.equal(emails.length, 2);
-
-                                            var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
-                                            assert.ok(_.contains(emailAddresses, simong.user.email));
-                                            assert.ok(_.contains(emailAddresses, mrvisser.user.email));
-                                            return callback();
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-
-        /**
-         * Test that verifies an email is sent to the members when a discussion is created, and that private users are
-         * appropriately scrubbed.
-         */
-        it('verify discussion-create email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
-                assert.ok(!err);
-
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                // Generate e-mail addresses
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
-                // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
-                var simongUpdate = {
-                    'email': simong.user.email,
-                    'visibility': 'private',
-                    'publicAlias': 'swappedFromPublicAlias'
-                };
-
-                // Update the users
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
-                        assert.ok(!err);
-
-                        // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
-                        RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'not about computers', 'public', [], [mrvisser.user.id], function(err, discussion) {
-                            assert.ok(!err);
-
-                            // Mrvisser should get an email, with simong's information scrubbed
                             EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                // There should be exactly one email, the one sent to mrvisser
+                                // There should be exactly one email, the one sent to mrvisser (manager of discussion receives discussion-message notification)
                                 assert.equal(emails.length, 1);
 
                                 var stringEmail = JSON.stringify(emails[0]);
@@ -608,6 +504,9 @@ describe('Discussion Activity', function() {
 
                                 // Sanity check that the email is to mrvisser
                                 assert.equal(email.to[0].address, mrvisser.user.email);
+
+                                // Ensure that the subject of the email contains the poster's name
+                                assert.notEqual(email.subject.indexOf('swappedFromPublicAlias'), -1);
 
                                 // Ensure some data expected to be in the email is there
                                 assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
@@ -622,8 +521,79 @@ describe('Discussion Activity', function() {
                                 // The email should contain the public alias
                                 assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
 
-                                callback();
+                                // The message should have escaped the HTML content in the original message
+                                assert.strictEqual(stringEmail.indexOf('<b>Nice discussion.</b>'), -1);
+
+                                // The new line characters should've been converted into paragraphs
+                                assert.notEqual(stringEmail.indexOf('Would read again</p>'), -1);
+
+                                // Send a message as nicolaas and ensure the recent commenter, simong receives an email about it
+                                RestAPI.Discussions.createMessage(nicolaas.restContext, discussion.id, 'I have a computer, too', null, function(err, nicolaasMessage) {
+                                    assert.ok(!err);
+
+                                    EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                                        // There should be 2 emails this time, one to the manager and one to the recent commenter, simong
+                                        assert.equal(emails.length, 2);
+
+                                        var emailAddresses = [emails[0].to[0].address, emails[1].to[0].address];
+                                        assert.ok(_.contains(emailAddresses, simong.user.email));
+                                        assert.ok(_.contains(emailAddresses, mrvisser.user.email));
+                                        return callback();
+                                    });
+                                });
                             });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies an email is sent to the members when a discussion is created, and that private users are
+         * appropriately scrubbed.
+         */
+        it('verify discussion-create email and privacy', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
+                assert.ok(!err);
+
+                // Simon is private and mrvisser is public
+                var simongUpdate = {
+                    'visibility': 'private',
+                    'publicAlias': 'swappedFromPublicAlias'
+                };
+
+                // Update Simon
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
+
+                    // Create the link, sharing it with mrvisser during the creation step. We will ensure he gets an email about it
+                    RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'not about computers', 'public', [], [mrvisser.user.id], function(err, discussion) {
+                        assert.ok(!err);
+
+                        // Mrvisser should get an email, with simong's information scrubbed
+                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                            // There should be exactly one email, the one sent to mrvisser
+                            assert.equal(emails.length, 1);
+
+                            var stringEmail = JSON.stringify(emails[0]);
+                            var email = emails[0];
+
+                            // Sanity check that the email is to mrvisser
+                            assert.equal(email.to[0].address, mrvisser.user.email);
+
+                            // Ensure some data expected to be in the email is there
+                            assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
+                            assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
+                            assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
+
+                            // Ensure simong's private info is nowhere to be found
+                            assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                            assert.equal(stringEmail.indexOf(simong.user.locale), -1);
+
+                            // The email should contain the public alias
+                            assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+
+                            return callback();
                         });
                     });
                 });
@@ -635,66 +605,52 @@ describe('Discussion Activity', function() {
          * appropriately scrubbed.
          */
         it('verify discussion-share email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                // Generate e-mail addresses
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
 
-                // Update the users
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
+                // Update Simon
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
+                    RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'about the moon', 'public', [], [], function(err, discussion) {
                         assert.ok(!err);
 
-                        // Create the link, then share it with mrvisser. We will ensure that mrvisser gets the email about the share
-                        RestAPI.Discussions.createDiscussion(simong.restContext, 'A talk', 'about the moon', 'public', [], [], function(err, discussion) {
-                            assert.ok(!err);
+                        // Collect the createLink activity
+                        EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
 
-                            // Collect the createLink activity
-                            EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                            RestAPI.Discussions.shareDiscussion(simong.restContext, discussion.id, [mrvisser.user.id], function(err) {
+                                assert.ok(!err);
 
-                                RestAPI.Discussions.shareDiscussion(simong.restContext, discussion.id, [mrvisser.user.id], function(err) {
-                                    assert.ok(!err);
+                                // Mrvisser should get an email, with simong's information scrubbed
+                                EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
+                                    // There should be exactly one email, the one sent to mrvisser
+                                    assert.equal(emails.length, 1);
 
-                                    // Mrvisser should get an email, with simong's information scrubbed
-                                    EmailTestsUtil.collectAndFetchAllEmails(function(emails) {
-                                        // There should be exactly one email, the one sent to mrvisser
-                                        assert.equal(emails.length, 1);
+                                    var stringEmail = JSON.stringify(emails[0]);
+                                    var email = emails[0];
 
-                                        var stringEmail = JSON.stringify(emails[0]);
-                                        var email = emails[0];
+                                    // Sanity check that the email is to mrvisser
+                                    assert.equal(email.to[0].address, mrvisser.user.email);
 
-                                        // Sanity check that the email is to mrvisser
-                                        assert.equal(email.to[0].address, mrvisser.user.email);
+                                    // Ensure some data expected to be in the email is there
+                                    assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
+                                    assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
+                                    assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
 
-                                        // Ensure some data expected to be in the email is there
-                                        assert.notEqual(stringEmail.indexOf(simong.restContext.hostHeader), -1);
-                                        assert.notEqual(stringEmail.indexOf(discussion.profilePath), -1);
-                                        assert.notEqual(stringEmail.indexOf(discussion.displayName), -1);
+                                    // Ensure simong's private info is nowhere to be found
+                                    assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.email), -1);
+                                    assert.equal(stringEmail.indexOf(simong.user.locale), -1);
 
-                                        // Ensure simong's private info is nowhere to be found
-                                        assert.equal(stringEmail.indexOf(simong.user.displayName), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.email), -1);
-                                        assert.equal(stringEmail.indexOf(simong.user.locale), -1);
-
-                                        // The email should contain the public alias
-                                        assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
-                                        callback();
-                                    });
+                                    // The email should contain the public alias
+                                    assert.notEqual(stringEmail.indexOf('swappedFromPublicAlias'), -1);
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-email/emailTemplates/email.css.jst
+++ b/node_modules/oae-email/emailTemplates/email.css.jst
@@ -1,0 +1,105 @@
+/*************
+ * CORE CSS **
+ *************/
+
+body {
+    background-color: <%= skinVariables['body-background-color'] %>;
+    color: <%= skinVariables['text-color'] %>;
+    font-size: 13px;
+    height: 100%;
+    padding: 20px;
+    -webkit-font-smoothing: antialiased;
+    -webkit-text-size-adjust: 150%;
+}
+
+body, h1, h2, h3, h4, h5, h6, a, span, td, div {
+    font-family: HelveticaNeue-Light, "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+}
+
+body > table {
+    margin: 0 auto;
+}
+
+a {
+    color: <%= skinVariables['link-color'] %>;
+    text-decoration: none;
+}
+
+a:hover {
+    color: <%= skinVariables['link-hover-color'] %>;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: <%= skinVariables['text-color']%>;
+    line-height: 1.1;
+}
+
+h1, h2 {
+    font-weight: 200;
+}
+
+h3 {
+    font-weight: 500;
+}
+
+img {
+    border: 0;
+}
+
+.muted {
+    color: <%= skinVariables['secondary-text-color'] %>;
+    font-size: 12px;
+}
+
+.wrapped {
+    word-wrap: break-word;
+}
+
+.row > td {
+    max-width: 700px;
+    min-width:400px;
+}
+
+
+/************
+ ** HEADER **
+ ************/
+
+#header table {
+    width: 100%;
+}
+
+#header td {
+    text-align: center;
+    max-width: 650px;
+}
+
+#header #logo img {
+    margin: 0 0 30px;
+
+    /* GMail always converts `height` to `min-height` on at least images, so use
+       `min-height` with `max-height` for some client consistency */
+    max-height: 50px;
+    min-height: 50px;
+}
+
+#header #greeting h1 {
+    font-size: 24px;
+    font-weight: bold;
+    margin: 0 0 5px;
+    word-wrap: break-word;
+}
+
+#header #summary td {
+    font-size: 15px;
+    padding-bottom: 10px;
+}
+
+/************
+ ** FOOTER **
+ ************/
+
+#footer {
+    font-size: 10px;
+    margin: 40px auto 0;
+}

--- a/node_modules/oae-email/emailTemplates/footer.html.jst
+++ b/node_modules/oae-email/emailTemplates/footer.html.jst
@@ -1,0 +1,56 @@
+<%
+    /**
+     * Render the email footer
+     */
+    var renderFooter = function(includeChangePreferences) {
+        var oaeNameI18n = util.i18n.translate('__MSG__OPEN_ACADEMIC_ENVIRONMENT__');
+        var url = baseUrl + '/me?emailpreferences';
+
+        var oaeLink = '<a href="http://www.oaeproject.org">' + util.html.encodeForHTML(oaeNameI18n) + '</a>';
+
+        var instanceLink = util.html.encodeForHTML(instance.name);
+        if (instance.URL) {
+            instanceLink =
+                '<a href="' + util.html.encodeForHTMLAttribute(instance.URL) + '">' +
+                    instanceLink +
+                '</a>';
+        }
+
+        var hostingOrganizationLink = util.html.encodeForHTML(hostingOrganization.name);
+        if (hostingOrganization.URL) {
+            hostingOrganizationLink =
+                '<a href="' + util.html.encodeForHTMLAttribute(hostingOrganization.URL) + '">' +
+                    hostingOrganizationLink +
+                '</a>';
+        }
+
+        var footerContentData = {
+            'oaeLink': oaeLink,
+            'instanceLink': instanceLink,
+            'hostingOrganizationLink': hostingOrganizationLink
+        };
+
+        var footerContent = '__MSG__POWERED_BY_APEREO_OAE__';
+        if (instanceLink && hostingOrganizationLink) {
+            footerContent = '__MSG__POWERED_BY_APEREO_OAE_INSTANCE_HOSTING_ORGANIZATION__';
+        } else if (instanceLink) {
+            footerContent = '__MSG__POWERED_BY_APEREO_OAE_INSTANCE__';
+        } else if (hostingOrganizationLink) {
+            footerContent = '__MSG__POWERED_BY_APEREO_OAE_HOSTING_ORGANIZATION__';
+        }
+
+        // Aggregate the footer content into an array of lines of HTML content
+        var lines = [];
+        lines.push('<tr id="footer" class="row">');
+        lines.push(     '<td align="center">');
+        if (includeChangePreferences) {
+            lines.push(     util.i18n.translate('__MSG__ACTIVITY_EMAIL_CHANGE_PREFRENCES__', {'url': url}) + '<br />');
+        }
+        lines.push(         util.i18n.translate(footerContent, footerContentData));
+        lines.push(     '</td>');
+        lines.push('</tr>');
+
+        // Join the lines together by new line, adding the trailing new line to the end
+        print(lines.join('\n') + '\n');
+    };
+%>

--- a/node_modules/oae-email/emailTemplates/header.html.jst
+++ b/node_modules/oae-email/emailTemplates/header.html.jst
@@ -1,0 +1,27 @@
+<%
+    /**
+     * Render the email header
+     */
+    var renderHeader = function() {
+        var institutionalLogoURL = util.url.ensureAbsoluteLink(util.ui.getHashedPath(skinVariables['institutional-logo-url'].replace(/\'/g, '')), baseUrl);
+        var greeting = util.i18n.translate('__MSG__ACTIVITY_EMAIL_GREETING__', {'displayName': util.html.encodeForHTML(user.displayName)});
+
+        // Aggregate the header content into an array of lines of HTML content
+        var lines = [];
+        lines.push('<tr id="header" class="row">');
+        lines.push(     '<td align="center">');
+        lines.push(         '<table cellpadding="0" cellspacing="0">');
+        lines.push(             '<tr id="logo">');
+        lines.push(                 '<td><img src="' + institutionalLogoURL + '" /></td>');
+        lines.push(             '</tr>');
+        lines.push(             '<tr id="greeting">');
+        lines.push(                 '<td><h1>' + util.url.ensureAbsoluteLinks(greeting, baseUrl) + '</h1></td>');
+        lines.push(             '</tr>');
+        lines.push(         '</table>');
+        lines.push(     '</td>');
+        lines.push('</tr>');
+
+        // Join the lines together by new line, adding the trailing new line to the end
+        print(lines.join('\n') + '\n');
+    };
+%>

--- a/node_modules/oae-email/emailTemplates/test_include.css.jst
+++ b/node_modules/oae-email/emailTemplates/test_include.css.jst
@@ -1,0 +1,4 @@
+/* Define a CSS rule that has underscore logic in it to ensure the file gets interpreted */
+body p {
+    background-color: <%= "red" %>;
+}

--- a/node_modules/oae-email/emailTemplates/test_include.html.jst
+++ b/node_modules/oae-email/emailTemplates/test_include.html.jst
@@ -1,0 +1,10 @@
+<html>
+<head>
+<style>
+    <% include node_modules/oae-email/emailTemplates/test_include.css.jst %>
+</style>
+</head>
+<body>
+<p>test include</p>
+</body>
+</html>

--- a/node_modules/oae-email/emailTemplates/test_include.meta.json.jst
+++ b/node_modules/oae-email/emailTemplates/test_include.meta.json.jst
@@ -1,0 +1,3 @@
+{
+    "subject": "test include"
+}

--- a/node_modules/oae-email/lib/api.js
+++ b/node_modules/oae-email/lib/api.js
@@ -212,6 +212,7 @@ var refreshTemplates = module.exports.refreshTemplates = function(callback) {
  * @param  {String}     templateId          The id of the template
  * @param  {User}       toUser              The user that will be receiving the email. This is accessible in the email templates (e.g., `<%= user.displayName %>`)
  * @param  {String}     toUser.email        The email address of the user. If this is not available an error with code 400 is returned and no email is sent
+ * @param  {Tenant}     toUser.tenant       The tenant to which the user belongs
  * @param  {Object}     [data]              An object that represents the data of the email. This will be accessible in the email templates (e.g., `<%= data.activity['displayName'] %>`)
  * @param  {Object}     [opts]              Additional options
  * @param  {String}     [opts.hash]         See method summary for more information
@@ -298,7 +299,7 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
     var htmlContent = null;
     var txtContent = null;
 
-    var metaRendered = _renderTemplate(metaTemplate, templateCtx, toUser.locale);
+    var metaRendered = UIAPI.renderTemplate(metaTemplate, templateCtx, toUser.locale);
 
     try {
         // Try and parse the meta template into JSON
@@ -320,7 +321,7 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
     // Try and render the html template
     if (htmlTemplate) {
         try {
-            htmlContent = _renderTemplate(htmlTemplate, templateCtx, toUser.locale);
+            htmlContent = UIAPI.renderTemplate(htmlTemplate, templateCtx, toUser.locale);
         } catch (htmlErr) {
             log().warn({
                 'err': htmlErr,
@@ -337,7 +338,7 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
     // Try and render the text template
     if (txtTemplate) {
         try {
-            txtContent = _renderTemplate(txtTemplate, templateCtx, toUser.locale);
+            txtContent = UIAPI.renderTemplate(txtTemplate, templateCtx, toUser.locale);
         } catch (txtErr) {
             log().warn({
                 'err': txtErr,
@@ -396,6 +397,7 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
     // If we're sending HTML, we should inline all the CSS
     _inlineCSS(emailInfo.html, function(err, inlinedHtml) {
         if (err) {
+            log().error({'err': err, 'emailInfo': emailInfo}, 'Unable to inline CSS');
             return callback(err);
         }
 
@@ -598,17 +600,17 @@ var _getTemplatesForTemplateIds = function(basedir, module, templateIds, callbac
     var templateTxtPath = _templatesPath(basedir, module, templateId + '.txt.jst');
 
     // Get each template individually
-    _getTemplateContents(templateMetaPath, function(err, metaTemplate) {
+    _getCompiledTemplate(templateMetaPath, function(err, metaTemplate) {
         if (err) {
             return callback(err);
         }
 
-        _getTemplateContents(templateHtmlPath, function(err, htmlTemplate) {
+        _getCompiledTemplate(templateHtmlPath, function(err, htmlTemplate) {
             if (err) {
                 return callback(err);
             }
 
-            _getTemplateContents(templateTxtPath, function(err, txtTemplate) {
+            _getCompiledTemplate(templateTxtPath, function(err, txtTemplate) {
                 if (err) {
                     return callback(err);
                 }
@@ -639,10 +641,10 @@ var _getTemplatesForTemplateIds = function(basedir, module, templateIds, callbac
  * @param  {String}     templatePath            The path to the template file to be retrieved
  * @param  {Function}   callback                Standard callback function
  * @param  {Object}     callback.err            An error that occurred, if any
- * @param  {Function}   callback.template       The templates content
+ * @param  {Function}   callback.template       The compiled template
  * @api private
  */
-var _getTemplateContents = function(templatePath, callback) {
+var _getCompiledTemplate = function(templatePath, callback) {
     fs.exists(templatePath, function(exists) {
         if (!exists) {
             return callback();
@@ -654,7 +656,8 @@ var _getTemplateContents = function(templatePath, callback) {
             }
 
             if (templateContent) {
-                return callback(null, templateContent);
+                var compiledTemplate = UIAPI.compileTemplate(templateContent);
+                return callback(null, compiledTemplate);
             } else {
                 return callback({'code': 500, 'msg': 'Template file ' + templatePath + ' had no content'});
             }
@@ -698,19 +701,6 @@ var _getTemplate = function(templateModule, templateId, templateType) {
         templates[templateModule][templateId][templateType];
 
     return template;
-};
-
-/**
- * Render an underscore.js template and internationalize the output
- *
- * @param  {String}     templateContent     The underscore.js template that should be rendered
- * @param  {Object}     data                The data that should be fed to the template
- * @param  {String}     locale              The locale in which the output should be translated
- * @return {String}                         The rendered content
- * @api private
- */
-var _renderTemplate = function(templateContent, data, locale) {
-    return UIAPI.renderTemplate(templateContent, data, locale);
 };
 
 /**

--- a/node_modules/oae-email/lib/test/util.js
+++ b/node_modules/oae-email/lib/test/util.js
@@ -130,7 +130,9 @@ var collectAndFetchAllEmails = module.exports.collectAndFetchAllEmails = functio
                         //
                         // @see https://github.com/oaeproject/Hilary/issues/1168
                         _.each(messages, function(message) {
-                            assert.ok(_.isString(message.html));
+                            _assertEmailTemplateFieldValid(message, 'subject');
+                            _assertEmailTemplateFieldValid(message, 'html');
+                            _assertEmailTemplateFieldValid(message, 'text');
                             _.each(message.html.split('\n'), function(line) {
                                 assert.ok(line.length <= 500, util.format('Expected no email line to be more than 500 characters, but found: (%s) %s', line.length, line));
                                 assert.ok(line.split('<a').length < 3, util.format('Expected no email line to have more than 1 link, but found: %s', line));
@@ -208,4 +210,17 @@ var clearEmailCollections = module.exports.clearEmailCollections = function(call
             });
         });
     });
+};
+
+/**
+ * Ensure the specified field for the message is a valid well-templated string
+ *
+ * @param  {Object}         mail        The mail message object
+ * @param  {String}         fieldName   The field name of the message to check
+ * @throws {AssertionError}             Thrown if the field content is not valid
+ */
+var _assertEmailTemplateFieldValid = function(mail, fieldName) {
+    var content = mail[fieldName];
+    assert.ok(_.isString(content), util.format('Expected email field "%s" be a string, but was: %s', fieldName, JSON.stringify(content, null, 2)));
+    assert.strictEqual(content.indexOf('__MSG__'), -1, util.format('Email field "%s" contained "__MSG__" placeholder: %s', fieldName, content));
 };

--- a/node_modules/oae-email/tests/test-email.js
+++ b/node_modules/oae-email/tests/test-email.js
@@ -361,6 +361,22 @@ describe('Emails', function() {
                 });
             });
         });
+
+        /**
+         * Test that verifies that other template files can be included
+         */
+        it('verify other template files can be included', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, mrvisser) {
+                assert.ok(!err);
+
+                EmailTestsUtil.sendEmail('oae-email', 'test_include', mrvisser.user, {}, null, function(err, message) {
+                    assert.ok(!err);
+                    assert.ok(message.html);
+                    assert.ok(message.html.indexOf('<p\n style="background-color: red;">') > -1);
+                    return callback();
+                });
+            });
+        });
     });
 
     describe('Email configuration', function() {

--- a/node_modules/oae-folders/lib/test/util.js
+++ b/node_modules/oae-folders/lib/test/util.js
@@ -377,7 +377,7 @@ var assertCreateFolderSucceeds = module.exports.assertCreateFolderSucceeds = fun
                 );
 
                 // The current user is only made a manager if he can't manage any other managers
-                var user = new User(me.tenant.alias, me.id, me.displayName, me);
+                var user = new User(me.tenant.alias, me.id, me.displayName, me.email, me);
                 var ctx = new Context(me.tenant, user);
                 PrincipalsAPI.canManageAny(ctx, managerIds, function(err, canManage) {
                     assert.ok(!err);

--- a/node_modules/oae-logger/tests/test-logger.js
+++ b/node_modules/oae-logger/tests/test-logger.js
@@ -47,7 +47,7 @@ describe('Logger', function() {
         TelemetryAPI.init({'enabled': false}, function(err) {
             assert.ok(!err);
             return callback();
-        }); 
+        });
     });
 
     /**

--- a/node_modules/oae-principals/emailTemplates/verify.html.jst
+++ b/node_modules/oae-principals/emailTemplates/verify.html.jst
@@ -36,6 +36,7 @@
                         <% } %>
                         </p>
                         <p><a href="<%= verificationUrl %>">__MSG__EMAIL_VERIFY_LINK__</a></p>
+                        <p>__MSG__EMAIL_VERIFY_YOU_RECEIVED_THIS_BECAUSE__</p>
                     </td>
                 </tr>
 

--- a/node_modules/oae-principals/emailTemplates/verify.html.jst
+++ b/node_modules/oae-principals/emailTemplates/verify.html.jst
@@ -1,0 +1,46 @@
+<% include node_modules/oae-email/emailTemplates/header.html.jst %>
+<% include node_modules/oae-email/emailTemplates/footer.html.jst %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http: //www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http: //www.w3.org/1999/xhtml">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="viewport" content="width=device-width" />
+        <style>
+
+            /*
+             * Include the general styles. Note that we need to include them through
+             * Underscore as otherwise the skinVariable settings would be inaccessible
+             */
+            <% include node_modules/oae-email/emailTemplates/email.css.jst %>
+
+            .content td {
+                background-color: #FFF;
+                padding: 20px;
+            }
+
+        </style>
+    </head>
+    <body>
+        <table cellspacing="10" cellpadding="0">
+            <tbody>
+                <% renderHeader(); %>
+
+                <tr class="row content">
+                    <td>
+                        <p>
+                        <% if (actor && actor.isAdmin(user.tenant.alias)) { %>
+                            __MSG__EMAIL_VERIFY_ADMIN_BODY_EXPLANATION__
+                        <% } else { %>
+                            __MSG__EMAIL_VERIFY_BODY_EXPLANATION__
+                        <% } %>
+                        </p>
+                        <p><a href="<%= verificationUrl %>">__MSG__EMAIL_VERIFY_LINK__</a></p>
+                    </td>
+                </tr>
+
+                <% renderFooter(false); %>
+            </tbody>
+        </table>
+    </body>
+</html>

--- a/node_modules/oae-principals/emailTemplates/verify.meta.json.jst
+++ b/node_modules/oae-principals/emailTemplates/verify.meta.json.jst
@@ -1,0 +1,3 @@
+{
+    "subject": "__MSG__EMAIL_VERIFY_SUBJECT__"
+}

--- a/node_modules/oae-principals/emailTemplates/verify.txt.jst
+++ b/node_modules/oae-principals/emailTemplates/verify.txt.jst
@@ -1,0 +1,23 @@
+<%
+    var greeting = util.i18n.translate('__MSG__ACTIVITY_EMAIL_GREETING__', {'displayName': util.html.encodeForHTML(user.displayName)});
+    greeting = util.html.toText(greeting, false);
+%>
+
+<%= greeting %>
+
+<% if (actor && actor.isAdmin(user.tenant.alias)) { %>
+__MSG__EMAIL_VERIFY_ADMIN_BODY_EXPLANATION__
+<% } else { %>
+__MSG__EMAIL_VERIFY_BODY_EXPLANATION__
+<% } %>
+<%= verificationUrl %>
+
+<%
+var apereoFoundationI18n = util.i18n.translate('__MSG__APEREO_FOUNDATION__');
+var copyrightSymbolI18n = util.i18n.translate('__MSG__COPYRIGHT__');
+var url = baseUrl + '/me?emailpreferences';
+
+var footer = '';
+footer += copyrightSymbolI18n + ' ' + new Date().getFullYear() + ' ' + apereoFoundationI18n;
+print(footer);
+%>

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -29,6 +29,7 @@ var AuthzUtil = require('oae-authz/lib/util');
 var Cassandra = require('oae-util/lib/cassandra');
 var ConfigAPI = require('oae-config');
 var Context = require('oae-context').Context;
+var EmailAPI = require('oae-email');
 var log = require('oae-logger').logger('oae-principals');
 var OaeUtil = require('oae-util/lib/util');
 var Redis = require('oae-util/lib/redis');
@@ -45,6 +46,7 @@ var PrincipalsEmitter = require('./internal/emitter');
 var PrincipalsModel = require('./model');
 var PrincipalsTermsAndConditionsAPI = require('./api.termsAndConditions');
 var PrincipalsUtil = require('./util');
+var User = require('./model').User;
 
 var fullUserProfileDecorators = {};
 
@@ -83,7 +85,9 @@ var registerFullUserProfileDecorator = module.exports.registerFullUserProfileDec
  * @param  {String}    [opts.locale]            The locale for the user
  * @param  {String}    [opts.publicAlias]       The name to show when the user is inaccessible to a user
  * @param  {Boolean}   [opts.acceptedTC]        Whether or not the user has accepted the Terms & Conditions
+ * @param  {String}    [opts.email]             The email address for the user
  * @param  {String}    [opts.emailPreference]   The email preference for the user. One of PrincipalsConstants.emailPreference
+ * @param  {Boolean}   [opts.emailVerified]     Whether the user's email address is considered verified
  * @param  {String}    [opts.smallPictureUri]   The URI for the small picture
  * @param  {String}    [opts.mediumPictureUri]  The URI for the medium picture
  * @param  {String}    [opts.largePictureUri]   The URI for the large picture
@@ -118,6 +122,7 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
         }
     }
 
+    var isAdmin = (ctx.user() && ctx.user().isAdmin(tenantAlias));
     opts.visibility = opts.visibility || PrincipalsConfig.getValue(tenantAlias, 'user', 'visibility');
     opts.publicAlias = opts.publicAlias || displayName;
     opts.acceptedTC = opts.acceptedTC || false;
@@ -129,52 +134,77 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
     validator.check(opts.visibility, {'code': 400, 'msg': 'The specified visibility setting is unknown'}).isIn(_.values(AuthzConstants.visibility));
     validator.check(opts.emailPreference, {'code': 400, 'msg': 'The specified email preference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
 
+    // If an administrator is creating an account, we consider the email address to be verified
+    opts.emailVerified = opts.emailVerified || (ctx.user() && ctx.user().isAdmin(tenantAlias)) || false;
+
+    // Because some SSO strategies do not release an email address, we allow user accounts to be
+    // created without providing the email
+    if (!_.isUndefined(opts.email)) {
+        // E-mail addresses are always lower-cased as it makes them easier to deal with
+        opts.email = opts.email.toLowerCase();
+        validator.check(opts.email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
+    }
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
 
     var id = AuthzUtil.toId('u', tenantAlias, ShortId.generate());
-
-    var values = {
-        'tenantAlias': tenantAlias,
-        'displayName': displayName,
+    var user = new User(tenantAlias, id, displayName, null, {
         'visibility': opts.visibility,
-        'email': opts.email,
-        'emailPreference': opts.emailPreference,
         'locale': opts.locale,
         'publicAlias': opts.publicAlias,
+        'emailPreference': opts.emailPreference,
         'smallPictureUri': opts.smallPictureUri,
         'mediumPictureUri': opts.mediumPictureUri,
-        'largePictureUri': opts.largePictureUri
-    };
+        'largePictureUri': opts.largePictureUri,
+        'acceptedTC': 0
+    });
+
+    // Only add the email address if it's been verified
+    if (opts.email && opts.emailVerified) {
+        user.email = opts.email;
+    }
 
     // We store the timestamp at which the user accepted the Terms and Conditions
-    // This allows for allowing users to re-accept the Terms and Conditions after they have been updated
-    var tcEnabled = PrincipalsConfig.getValue(tenantAlias, 'termsAndConditions', 'enabled');
-    if (tcEnabled && opts.acceptedTC) {
-        // Store the acceptedTC on the return user object
-        opts.acceptedTC = Date.now();
-
-        // Also persist it, but it must be a String because that is the column data-type in Cassandra
-        values.acceptedTC = opts.acceptedTC.toString();
+    // This allows users to re-accept the Terms and Conditions after they have been updated
+    user.needsToAcceptTC = PrincipalsConfig.getValue(tenantAlias, 'termsAndConditions', 'enabled');
+    if (user.needsToAcceptTC && opts.acceptedTC) {
+        user.acceptedTC = Date.now();
+        user.needsToAcceptTC = false;
     }
 
-    var q = Cassandra.constructUpsertCQL('Principals', 'principalId', id, values);
-    if (!q) {
-        return callback({'code': 500, 'msg': 'Could not create a proper CQL query'});
-    }
+    return _createUser(ctx, user, opts.email, callback);
+};
 
-    // Create the user
-    Cassandra.runQuery(q.query, q.parameters, function(err) {
+/**
+ * Create a new user record. This assumes all validation has happened
+ * at an earlier point in time
+ *
+ * @param  {Context}    ctx                         Standard context object containing the current user and the current tenant
+ * @param  {User}       user                        The user to create
+ * @param  {String}     [email]                     The email address of the user. If an email address was specified but not persisted on the `user` object, a verification email will be sent to the given email address
+ * @param  {Function}   callback                    Standard callback function
+ * @param  {Object}     callback.err                An error that occurred, if any
+ * @param  {User}       callback.createdUser        The created user
+ */
+var _createUser = function(ctx, user, email, callback) {
+    PrincipalsDAO.createUser(user, function(err) {
         if (err) {
             return callback(err);
         }
 
-        var createdUser = new PrincipalsModel.User(tenantAlias, id, displayName, opts);
-        createdUser.needsToAcceptTC = false;
+        // Emit an event indicating a user account has been created
+        PrincipalsEmitter.emit(PrincipalsConstants.events.CREATED_USER, ctx, user);
 
-        PrincipalsEmitter.emit(PrincipalsConstants.events.CREATED_USER, ctx, createdUser);
-        return callback(null, createdUser);
+        // If the email address hasn't been verified we ask the user to verify it
+        var hasUnverifiedEmail = (email && !user.email);
+        OaeUtil.invokeIfNecessary(hasUnverifiedEmail, _sendEmailToken, ctx, user, email, null, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            return callback(null, user);
+        });
     });
 };
 
@@ -281,7 +311,6 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                 var user = data.pop();
 
                 // Extract the password in case local authentication is used
-                var opts = {};
                 var providerProperties = null;
                 if (authenticationStrategy === AuthenticationConstants.providers.LOCAL) {
                     providerProperties = {'password': user.splice(1, 1)};
@@ -289,9 +318,15 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
 
                 // Extract the basic profile data
                 var externalId = user[0];
+
                 // Construct the first name and last name into a display name
                 var displayName = util.format('%s %s', user[2], user[1]).trim();
-                opts.email = user[3];
+
+                // Email addresses provided through a CSV import are always considered to be verified
+                var opts = {
+                    'email': user[3],
+                    'emailVerified': true
+                };
 
                 /*!
                  * Gets called when the user has been created or updated
@@ -353,9 +388,6 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                             if (!user.publicAlias || user.publicAlias === externalId) {
                                 update['publicAlias'] = displayName;
                             }
-                            if (!user.email) {
-                                update['email'] = opts.email;
-                            }
                         }
 
                         if (!_.isEmpty(update)) {
@@ -363,8 +395,8 @@ var importUsers = module.exports.importUsers = function(ctx, tenantAlias, userCS
                                 'externalId': externalId,
                                 'user': user,
                                 'update': update
-                            }, 'Updating display name and/or email during import from CSV');
-                            updateUser(adminCtx, user.id, update, finishImportUser);
+                            }, 'Updating display name, public alias and/or email during import from CSV');
+                            _updateUser(adminCtx, user, update, finishImportUser);
                         } else {
                             finishImportUser();
                         }
@@ -420,7 +452,7 @@ var _cleanUpCSVFile = function(userCSV, callback) {
  * Update a user
  *
  * @param  {Context}        ctx             Standard context object containing the current user and the current tenant
- * @param  {String}         userId          TThe id of the user to update
+ * @param  {String}         userId          The id of the user to update
  * @param  {Object}         profileFields   Object that represent the profile fields that should be updated. Possible keys are `visibility`, `displayName`, `publicAlias`, `locale`, `email` and `emailPreference`
  * @param  {Function}       callback        Standard callback function
  * @param  {Object}         callback.err    An error that occurred, if any
@@ -437,24 +469,29 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
     validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).notEmpty();
     validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).isUserId();
 
-    // Check that there is at least one updated profile field.
+    // Check that there is at least one updated profile field
     validator.check(profileFieldKeys.length, {'code': 400, 'msg': 'At least one basic profile field should be specified'}).min(1);
 
-    // verify that restricted properties aren't set here
-    var invalidKeys = _.intersection(PrincipalsDAO.getRestrictedFields(), profileFieldKeys);
+    // Verify that restricted properties aren't set here
+    var validKeys = ['displayName', 'visibility', 'email', 'emailPreference', 'publicAlias', 'locale'];
+    var invalidKeys = _.difference(profileFieldKeys, validKeys);
     validator.check(invalidKeys.length, {'code': 400, 'msg': 'Restricted property was attempted to be set.'}).max(0);
 
-    if (profileFields['displayName']) {
-        validator.check(profileFields['displayName'], {'code': 400, 'msg': 'A display name cannot be empty'}).notEmpty();
-        validator.check(profileFields['displayName'], {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
+    // Apply special restrictions on some profile fields
+    if (!_.isUndefined(profileFields.displayName)) {
+        validator.check(profileFields.displayName, {'code': 400, 'msg': 'A display name cannot be empty'}).notEmpty();
+        validator.check(profileFields.displayName, {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
     }
-
-    // In case a new visibility has been passed in, we check for its validity
-    if (profileFields['visibility']) {
-        validator.check(profileFields['visibility'], {'code': 400, 'msg': 'An invalid visibility option has been specified'}).isIn(_.values(AuthzConstants.visibility));
+    if (!_.isUndefined(profileFields.visibility)) {
+        validator.check(profileFields.visibility, {'code': 400, 'msg': 'An invalid visibility option has been specified'}).isIn(_.values(AuthzConstants.visibility));
     }
-    if (profileFields['emailPreference']) {
-        validator.check(profileFields['emailPreference'], {'code': 400, 'msg': 'The specified emailPreference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
+    if (!_.isUndefined(profileFields.emailPreference)) {
+        validator.check(profileFields.emailPreference, {'code': 400, 'msg': 'The specified emailPreference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
+    }
+    if (!_.isUndefined(profileFields.email)) {
+        // E-mail addresses are always lower-cased as it makes them easier to deal with
+        profileFields.email = profileFields.email.toLowerCase();
+        validator.check(profileFields.email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
     }
 
     validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to update a user'}).isLoggedInUser(ctx);
@@ -462,7 +499,7 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
         return callback(validator.getFirstError());
     }
 
-    // Only the user themself or an admin can update a user
+    // Regular users cannot update other users
     var principalResource = AuthzUtil.getResourceFromId(userId);
     if (ctx.user().id !== userId && !ctx.user().isAdmin(principalResource.tenantAlias)) {
         return callback({'code': 401, 'msg': 'You are not authorized to update this user\'s profile.'});
@@ -478,15 +515,57 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
 
         // Overlay the correct lastModified date
         profileFields = _.extend({}, profileFields, {'lastModified': Date.now().toString()});
-        PrincipalsDAO.updatePrincipal(userId, profileFields, function(err) {
+
+        // If the user wants to change their own email address, we don't change it immediately.
+        // We will make that change once they have verified they own it. We will persist the
+        // desired email address in a separate column family
+        var newEmailAddress = null;
+        var isEmailChange = (!_.isUndefined(profileFields.email) && profileFields.email !== oldUser.email);
+        if (isEmailChange) {
+            newEmailAddress = profileFields.email;
+            delete profileFields.email;
+        }
+
+        _updateUser(ctx, oldUser, profileFields, function(err, newUser) {
             if (err) {
                 return callback(err);
             }
 
-            var newUser = PrincipalsUtil.createUpdatedUser(oldUser, profileFields);
-            PrincipalsEmitter.emit(PrincipalsConstants.events.UPDATED_USER, ctx, newUser, oldUser);
-            return getUser(ctx, userId, callback);
+            // If the email address changed but isn't verified, we have to send a verification email
+            OaeUtil.invokeIfNecessary(isEmailChange, _sendEmailToken, ctx, newUser, newEmailAddress, null, function(err) {
+                if (err) {
+                    return callback(err);
+                }
+
+                return getUser(ctx, userId, callback);
+            });
         });
+    });
+};
+
+/**
+ * Update a user record in the database. This is an internal method that performs no validation.
+ * It will also not send out any email verification tokens if an email address were to change
+ *
+ * @param  {Context}        ctx             Standard context object containing the current user and the current tenant
+ * @param  {String}         userId          The user to update
+ * @param  {Object}         profileFields   Object that represent the profile fields that should be updated. Possible keys are `visibility`, `displayName`, `publicAlias`, `locale`, `email` and `emailPreference`
+ * @param  {Function}       callback        Standard callback function
+ * @param  {Object}         callback.err    An error that occurred, if any
+ * @param  {User}           callback.user   The updated user
+ * @api private
+ */
+var _updateUser = function(ctx, oldUser, profileFields, callback) {
+    PrincipalsDAO.updatePrincipal(oldUser.id, profileFields, function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Emit an event indicating the user has been updated
+        var newUser = PrincipalsUtil.createUpdatedUser(oldUser, profileFields);
+        PrincipalsEmitter.emit(PrincipalsConstants.events.UPDATED_USER, ctx, newUser, oldUser);
+
+        return callback(null, newUser);
     });
 };
 
@@ -850,5 +929,229 @@ var _setAdmin = function(ctx, adminType, isAdmin, principalId, callback) {
         }
 
         return PrincipalsDAO.setAdmin(adminType, isAdmin, principalId, callback);
+    });
+};
+
+/**
+ * Send an email token to a user that can be used to verify the user owns the email address
+ *
+ * @param  {Context}    ctx             Standard context object containing the current user and the current tenant
+ * @param  {User}       user            The user to send the email token to
+ * @param  {String}     email           The email address where to send the token to
+ * @param  {String}     [token]         The token to send. If left null, a new one will be generated
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error that occurred, if any
+ * @api private
+ */
+var _sendEmailToken = function(ctx, user, email, token, callback) {
+    callback = callback || function(err) {
+        if (err) {
+            log().error({'err': err, 'userId': user.id}, 'Unable to send a user a verification email');
+        }
+    };
+
+    // Generate a token if none was specified
+    token = token || ShortId.generate();
+
+    // Store the token
+    PrincipalsDAO.storeEmailToken(user.id, email, token, function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        // The EmailAPI expects a user to have a verified email address. As this is not the case
+        // when sending an email token, we send in a patched user object
+        var userToEmail = _.extend({}, user, {'email': email});
+
+        var tenant = TenantsAPI.getTenant(user.tenant.alias);
+        var verificationUrl = TenantsUtil.getBaseUrl(tenant) + '/email-verification?token=' + token;
+
+        // Send an email to the specified e-mail address
+        var data = {
+            'actor': ctx.user(),
+            'tenant': ctx.tenant(),
+            'user': userToEmail,
+            'baseUrl': TenantsUtil.getBaseUrl(ctx.tenant()),
+            'skinVariables': require('oae-ui').getTenantSkinVariables(ctx.tenant().alias),
+            'token': token,
+            'verificationUrl': verificationUrl
+        };
+
+        // We pass the current date in as the "hashCode" for this email. We need to be able to send
+        // a copy of the same email for the "resend email token" functionality. As we don't expect
+        // that this logic will get stuck in a loop this is probably OK
+        EmailAPI.sendEmail('oae-principals', 'verify', userToEmail, data, {'hash': Date.now()}, callback);
+    });
+};
+
+/**
+ * Resend an email token
+ *
+ * @param  {Context}    ctx             Standard context object containing the current user and the current tenant
+ * @param  {String}     userId          The id of the user for who to resend the email token
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error that occurred, if any
+ */
+var resendEmailToken = module.exports.resendEmailToken = function(ctx, userId, callback) {
+    var validator = new Validator();
+    validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).isUserId();
+    validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to resend an email token'}).isLoggedInUser(ctx);
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    // Ensure that you need to either be the user for which a token is being sent or a tenant admin
+    var principalResource = AuthzUtil.getResourceFromId(userId);
+    if (ctx.user().id !== userId && !ctx.user().isAdmin(principalResource.tenantAlias)) {
+        return callback({'code': 401, 'msg': 'You are not authorized to resend an email token'});
+    }
+
+    // Get the email token for the user
+    PrincipalsDAO.getEmailToken(userId, function(err, email, persistedToken) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Get the user object
+        PrincipalsDAO.getPrincipal(userId, function(err, user) {
+            if (err) {
+                return callback(err);
+            }
+
+            // Send the email token
+            return _sendEmailToken(ctx, user, email, persistedToken, callback);
+        });
+    });
+};
+
+/**
+ * Verify an email token
+ *
+ * @param  {Context}    ctx             Standard context object containing the current user and the current tenant
+ * @param  {String}     userId          The id of the user to verify the email address for
+ * @param  {String}     token           The token with which to verify the email address
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error that occurred, if any
+ * @param  {User}       callback.user   The updated user
+ */
+var verifyEmail = module.exports.verifyEmail = function(ctx, userId, token, callback) {
+    var validator = new Validator();
+    validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).isUserId();
+    validator.check(token, {'code': 400, 'msg': 'A token must be provided'}).notEmpty();
+    validator.check(token, {'code': 400, 'msg': 'An invalid token was provided'}).regex(/^[a-zA-Z0-9-_]{7,14}$/);
+    validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to verify an email address'}).isLoggedInUser(ctx);
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    var principalResource = AuthzUtil.getResourceFromId(userId);
+    if (ctx.user().id !== userId && !ctx.user().isAdmin(principalResource.tenantAlias)) {
+        return callback({'code': 401, 'msg': 'You are not authorized to verify the email address of this user'});
+    }
+
+    // Get the user object as we need to know the old email address so we can take it out of the mapping
+    PrincipalsDAO.getPrincipal(userId, function(err, user) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Ensure the token is correct
+        PrincipalsDAO.getEmailToken(userId, function(err, email, persistedToken) {
+            if (err) {
+                return callback(err);
+            } else if (persistedToken !== token) {
+                return callback({'code': 401, 'msg': 'Wrong token'});
+            }
+
+            // Set the email address
+            PrincipalsDAO.setEmailAddress(user, email, function(err, user) {
+                if (err) {
+                    return callback(err);
+                }
+
+                // Emit an event that an email address has been verified
+                PrincipalsEmitter.emit(PrincipalsConstants.events.VERIFIED_EMAIL, ctx, user);
+
+                return callback(null, user);
+            });
+        });
+    });
+};
+
+/**
+ * Check whether a user has a pending email token
+ *
+ * @param  {Context}    ctx                 Standard context object containing the current user and the current tenant
+ * @param  {String}     userId              The id of the user for which to check whether they have a pending email token
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error that occurred, if any
+ * @param  {String}     callback.email      The email address for which there is a token
+ */
+var getEmailToken = module.exports.getEmailToken = function(ctx, userId, callback) {
+    var validator = new Validator();
+    validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).isUserId();
+    validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to check for the existence of a pending email token'}).isLoggedInUser(ctx);
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    var principalResource = AuthzUtil.getResourceFromId(userId);
+    if (ctx.user().id !== userId && !ctx.user().isAdmin(principalResource.tenantAlias)) {
+        return callback({'code': 401, 'msg': 'You are not authorized to check for the existence of a pending email token'});
+    }
+
+    // Check if there's a token and return the email address if there is one
+    PrincipalsDAO.getEmailToken(userId, function(err, email, persistedToken) {
+        if (err) {
+            return callback(err);
+        }
+
+        return callback(null, email);
+    });
+};
+
+/**
+ * Delete a pending email token for a user
+ *
+ * @param  {Context}    ctx                 Standard context object containing the current user and the current tenant
+ * @param  {String}     userId              The id of the user for which to delete the pending email token
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error that occurred, if any
+ * @param  {String}     callback.email      The email address for which there is a token
+ */
+var deleteEmailToken = module.exports.deleteEmailToken = function(ctx, userId, callback) {
+    var validator = new Validator();
+    validator.check(userId, {'code': 400, 'msg': 'A valid user id must be provided'}).isUserId();
+    validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to delete a pending email token'}).isLoggedInUser(ctx);
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    var principalResource = AuthzUtil.getResourceFromId(userId);
+    if (ctx.user().id !== userId && !ctx.user().isAdmin(principalResource.tenantAlias)) {
+        return callback({'code': 401, 'msg': 'You are not authorized to delete a pending email token'});
+    }
+
+    // Check if there is a token
+    getEmailToken(ctx, userId, function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Delete the email token
+        PrincipalsDAO.deleteEmailToken(userId, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            // Emit an event that an email token has been deleted
+            PrincipalsEmitter.emit(PrincipalsConstants.events.DELETED_EMAIL_TOKEN, ctx, userId, function(errs) {
+                if (errs) {
+                    return callback(_.first(errs));
+                }
+
+                return callback();
+            });
+        });
     });
 };

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -139,11 +139,15 @@ var createUser = module.exports.createUser = function(ctx, tenantAlias, displayN
 
     // Because some SSO strategies do not release an email address, we allow user accounts to be
     // created without providing the email
-    if (!_.isUndefined(opts.email)) {
+    if (_.isString(opts.email)) {
         // E-mail addresses are always lower-cased as it makes them easier to deal with
         opts.email = opts.email.toLowerCase();
         validator.check(opts.email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
+    } else {
+        // Avoid setting a falsey email address
+        delete opts.email;
     }
+
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
@@ -488,10 +492,14 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
     if (!_.isUndefined(profileFields.emailPreference)) {
         validator.check(profileFields.emailPreference, {'code': 400, 'msg': 'The specified emailPreference is invalid'}).isIn(_.values(PrincipalsConstants.emailPreferences));
     }
-    if (!_.isUndefined(profileFields.email)) {
+
+    if (_.isString(profileFields.email)) {
         // E-mail addresses are always lower-cased as it makes them easier to deal with
         profileFields.email = profileFields.email.toLowerCase();
         validator.check(profileFields.email, {'code': 400, 'msg': 'The specified email address is invalid'}).isEmail();
+    } else {
+        // Ensure we never set a false-y email
+        delete profileFields.email;
     }
 
     validator.check(null, {'code': 401, 'msg': 'You have to be logged in to be able to update a user'}).isLoggedInUser(ctx);

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -964,7 +964,7 @@ var _sendEmailToken = function(ctx, user, email, token, callback) {
         var userToEmail = _.extend({}, user, {'email': email});
 
         var tenant = TenantsAPI.getTenant(user.tenant.alias);
-        var verificationUrl = TenantsUtil.getBaseUrl(tenant) + '/email-verification?token=' + token;
+        var verificationUrl = TenantsUtil.getBaseUrl(tenant) + '/me?verifyEmail=' + encodeURIComponent(token);
 
         // Send an email to the specified e-mail address
         var data = {

--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -980,7 +980,9 @@ var _sendEmailToken = function(ctx, user, email, token, callback) {
         // We pass the current date in as the "hashCode" for this email. We need to be able to send
         // a copy of the same email for the "resend email token" functionality. As we don't expect
         // that this logic will get stuck in a loop this is probably OK
-        EmailAPI.sendEmail('oae-principals', 'verify', userToEmail, data, {'hash': Date.now()}, callback);
+        EmailAPI.sendEmail('oae-principals', 'verify', userToEmail, data, {'hash': Date.now()});
+
+        return callback();
     });
 };
 

--- a/node_modules/oae-principals/lib/constants.js
+++ b/node_modules/oae-principals/lib/constants.js
@@ -28,10 +28,12 @@ PrincipalsConstants.events = {
     'UPDATED_GROUP': 'updatedGroup',
     'UPDATED_GROUP_MEMBERS': 'updatedGroupMembers',
     'UPDATED_USER': 'updatedUser',
+    'DELETED_EMAIL_TOKEN': 'deletedEmailToken',
     'DELETED_GROUP': 'deletedGroup',
     'DELETED_USER': 'deletedUser',
     'RESTORED_GROUP': 'restoredGroup',
     'RESTORED_USER': 'restoredUser',
+    'VERIFIED_EMAIL': 'verifiedEmail'
 };
 
 PrincipalsConstants.picture = {};

--- a/node_modules/oae-principals/lib/init.js
+++ b/node_modules/oae-principals/lib/init.js
@@ -56,7 +56,15 @@ module.exports = function(config, callback) {
  */
 var _ensureSchema = function(callback) {
     // Both user and group information will be stored inside of the Principals CF
-    Cassandra.createColumnFamily('Principals', 'CREATE TABLE "Principals" ("principalId" text PRIMARY KEY, "tenantAlias" text, "displayName" text, "description" text, "email" text, "emailPreference" text, "visibility" text, "joinable" text, "lastModified" text, "locale" text, "publicAlias" text, "largePictureUri" text, "mediumPictureUri" text, "smallPictureUri" text, "admin:global" text, "admin:tenant" text, "notificationsUnread" text, "notificationsLastRead" text, "acceptedTC" text, "createdBy" text, "created" timestamp, "deleted" timestamp)', callback);
+    Cassandra.createColumnFamilies({
+        'Principals': 'CREATE TABLE "Principals" ("principalId" text PRIMARY KEY, "tenantAlias" text, "displayName" text, "description" text, "email" text, "emailPreference" text, "visibility" text, "joinable" text, "lastModified" text, "locale" text, "publicAlias" text, "largePictureUri" text, "mediumPictureUri" text, "smallPictureUri" text, "admin:global" text, "admin:tenant" text, "notificationsUnread" text, "notificationsLastRead" text, "acceptedTC" text, "createdBy" text, "created" timestamp, "deleted" timestamp)',
+
+        // Map an email address to user ids. An e-mail address can be used by *multiple* users
+        'PrincipalsByEmail': 'CREATE TABLE "PrincipalsByEmail" ("email" text, "principalId" text, PRIMARY KEY ("email", "principalId"))',
+
+        // Map a user id to a desired email address and verification token
+        'PrincipalsEmailToken': 'CREATE TABLE "PrincipalsEmailToken" ("principalId" text PRIMARY KEY, "email" text, "token" text)'
+    }, callback);
 };
 
 /**
@@ -71,12 +79,13 @@ var _ensureSchema = function(callback) {
 var _ensureGlobalAdmin = function(config, callback) {
     // Mock a global admin request context so we can create a proper global administrator in the system
     var globalTenant = TenantsAPI.getTenant(config.servers.globalAdminAlias);
-    var globalUser = new User(globalTenant.alias, 'u:' + globalTenant.alias + ':admin', 'Global Administrator', {
+    var globalAdminId = 'u:' + globalTenant.alias + ':admin';
+    var globalAdmin = new User(globalTenant.alias, globalAdminId, 'Global Administrator', 'admin@example.com', {
         'visibility': AuthzConstants.visibility.PRIVATE,
         'isGlobalAdmin': true
     });
-    var globalContext = new Context(globalTenant, globalUser);
+    var globalContext = new Context(globalTenant, globalAdmin);
 
     // Create the global admin user if they don't exist yet with the username "administrator"
-    AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', null, callback);
+    return AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', globalAdmin.displayName, globalAdmin, callback);
 };

--- a/node_modules/oae-principals/lib/init.js
+++ b/node_modules/oae-principals/lib/init.js
@@ -80,7 +80,7 @@ var _ensureGlobalAdmin = function(config, callback) {
     // Mock a global admin request context so we can create a proper global administrator in the system
     var globalTenant = TenantsAPI.getTenant(config.servers.globalAdminAlias);
     var globalAdminId = 'u:' + globalTenant.alias + ':admin';
-    var globalAdmin = new User(globalTenant.alias, globalAdminId, 'Global Administrator', 'admin@example.com', {
+    var globalAdmin = new User(globalTenant.alias, globalAdminId, 'Global Administrator', null, {
         'visibility': AuthzConstants.visibility.PRIVATE,
         'isGlobalAdmin': true
     });

--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -34,6 +34,40 @@ var User = require('oae-principals/lib/model').User;
 var RESTRICTED_FIELDS = ['acceptedTC', 'admin:tenant', 'admin:global', 'deleted'];
 
 /**
+ * Create a user record in the database
+ *
+ * @param  {User}       user            The user to persist
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ */
+var createUser = module.exports.createUser = function(user, callback) {
+    var queries = [];
+
+    // Persist the user object
+    var values = {
+        'tenantAlias': user.tenant.alias,
+        'displayName': user.displayName,
+        'visibility': user.visibility,
+        'email': user.email,
+        'emailPreference': user.emailPreference,
+        'locale': user.locale,
+        'publicAlias': user.publicAlias,
+        'smallPictureUri': user.picture.smallUri,
+        'mediumPictureUri': user.picture.mediumUri,
+        'largePictureUri': user.picture.largeUri,
+        'acceptedTC': (user.acceptedTC ? user.acceptedTC.toString() : null)
+    };
+    queries.push(Cassandra.constructUpsertCQL('Principals', 'principalId', user.id, values));
+
+    // Only map the email address to the user if it's verified
+    if (user.email) {
+        queries.push({'query': 'INSERT INTO "PrincipalsByEmail" ("email", "principalId") VALUES (?, ?)', 'parameters': [user.email, user.id]});
+    }
+
+    return Cassandra.runBatchQuery(queries, callback);
+};
+
+/**
  * Create a group record in the database
  *
  * @param  {String}     groupId             The ID of the new group
@@ -306,6 +340,119 @@ var setAdmin = module.exports.setAdmin = function(adminType, isAdmin, userId, ca
 };
 
 /**
+ * Get the email token for a user
+ *
+ * @param  {String}     userId              The id of the user for who to get the email token
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {String}     callback.email      The email that is associated with the token
+ * @param  {String}     callback.token      The token that can be used to verify the email with
+ */
+var getEmailToken = module.exports.getEmailToken = function(userId, callback) {
+    Cassandra.runQuery('SELECT * FROM "PrincipalsEmailToken" WHERE "principalId" = ?', [userId], function(err, rows) {
+        if (err) {
+            return callback(err);
+        } else if (_.isEmpty(rows)) {
+            return callback({'code': 404, 'msg': 'No email token found for the given user id'});
+        }
+
+        var token = _.first(rows).get('token').value;
+        var email = _.first(rows).get('email').value;
+        return callback(null, email, token);
+    });
+};
+
+/**
+ * Delete a pending email token for a user
+ *
+ * @param  {String}     userId              The id of the user to for whom to delete the pending email token
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error that occurred, if any
+ */
+var deleteEmailToken = module.exports.deleteEmailToken = function(userId, callback) {
+    Cassandra.runQuery('DELETE FROM "PrincipalsEmailToken" WHERE "principalId" = ?', [userId], callback);
+};
+
+/**
+ * Get a set of users by their email address
+ *
+ * @param  {String}     email               The email address that is associated with users
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {User[]}     callback.users      The users that are associated with the email address
+ */
+var getUsersByEmail = module.exports.getUsersByEmail = function(email, callback) {
+    Cassandra.runQuery('SELECT * FROM "PrincipalsByEmail" WHERE "email" = ?', [email], function(err, rows) {
+        if (err) {
+            return callback(err);
+        }
+
+        var userIds = _.map(rows, function(row) {
+            return row.get('principalId').value;
+        });
+        return getPrincipals(userIds, null, callback);
+    });
+};
+
+/**
+ * Store an email token
+ *
+ * @param  {String}     userId          The id of the user for whom the token is associated
+ * @param  {String}     email           The email address to store the token for
+ * @param  {String}     token           The token to store
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ */
+var storeEmailToken = module.exports.storeEmailToken = function(userId, email, token, callback) {
+    var q = Cassandra.constructUpsertCQL('PrincipalsEmailToken', 'principalId', userId, {'email': email, 'token': token});
+    Cassandra.runQuery(q.query, q.parameters, callback);
+};
+
+/**
+ * Set the email address for a user. This will also map the user to the email address
+ *
+ * @param  {User}       user            The user to update
+ * @param  {String}     email           The new email address of the user
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ * @param  {User}       callback.user   The updated user
+ */
+var setEmailAddress = module.exports.setEmailAddress = function(user, email, callback) {
+    var queries = [];
+
+    // The token is correct, change the email address
+    var principalsUpdate = {'email': email};
+    queries.push(Cassandra.constructUpsertCQL('Principals', 'principalId', user.id, principalsUpdate));
+
+    // Remove the token
+    queries.push({'query': 'DELETE FROM "PrincipalsEmailToken" WHERE "principalId" = ?', 'parameters': [user.id]});
+
+    // Create the mapping for the new email address
+    queries.push({'query': 'INSERT INTO "PrincipalsByEmail" ("email", "principalId") VALUES (?, ?)', 'parameters': [email, user.id]});
+
+    // Remove the old mapping, if any
+    if (user.email && user.email !== email) {
+        queries.push({'query': 'DELETE FROM "PrincipalsByEmail" WHERE "email" = ? AND "principalId" = ?', 'parameters': [user.email, user.id]});
+    }
+
+    Cassandra.runBatchQuery(queries, function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Invalidate the cached user object as it has changed
+        _updateCachedUser(user.id, principalsUpdate, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            // Return the new user
+            return getPrincipal(user.id, callback);
+        });
+    });
+};
+
+/**
  * Iterate through all the principals. This will return just the raw principal properties that are specified in the `properties`
  * parameter, and only `batchSize` principals at a time. On each iteration of `batchSize` principals, the `onEach` callback
  * will be invoked, and the next batch will not be fetched until you have invoked the `onEach.done` function parameter. When
@@ -385,20 +532,33 @@ var _updatePrincipal = function(principalId, profileFields, callback) {
         return callback(validator.getFirstError());
     }
 
-    // Create the cassandra query from object fields
-    var q = Cassandra.constructUpsertCQL('Principals', 'principalId', principalId, profileFields);
-    if (!q) {
-        return callback({'code': 500, 'msg': 'Unable to update profile fields'});
-    }
 
-    // Perform the update
-    Cassandra.runQuery(q.query, q.parameters, function(err) {
+    // If a change is being made to the email address, we need to update the mapping
+    _isEmailAddressUpdate(principalId, profileFields, function(err, isEmailAddressUpdate, oldEmail) {
         if (err) {
             return callback(err);
         }
 
-        // Update the cache, if necessary
-        return OaeUtil.invokeIfNecessary(isUser(principalId), _updateCachedUser, principalId, profileFields, callback);
+        var queries = [];
+
+        // Update the principal record
+        queries.push(Cassandra.constructUpsertCQL('Principals', 'principalId', principalId, profileFields));
+
+        // If the user's email address needs to be updated, we remove the old one from the mapping
+        if (isEmailAddressUpdate) {
+            queries.push({'query': 'DELETE FROM "PrincipalsByEmail" WHERE "email" = ?', 'parameters': [oldEmail]});
+            queries.push({'query': 'INSERT INTO "PrincipalsByEmail" ("email", "principalId") VALUES (?, ?)', 'parameters': [profileFields.email, principalId]});
+        }
+
+        // Execute the queries
+        Cassandra.runBatchQuery(queries, function(err) {
+            if (err) {
+                return callback(err);
+            }
+
+            // Update the cache, if necessary
+            return OaeUtil.invokeIfNecessary(isUser(principalId), _updateCachedUser, principalId, profileFields, callback);
+        });
     });
 };
 
@@ -439,6 +599,35 @@ var _deletePrincipalFields = function(principalId, profileFields, callback) {
                 return callback();
             });
         });
+    });
+};
+
+/**
+ * Check whether the email address for a user would be updated when updating a set of `profileFields`
+ *
+ * @param  {String}     principalId                         The id of the principal to update
+ * @param  {Object}     profileFields                       An object containing the profile field updates to apply
+ * @param  {Function}   callback                            Standard callback function
+ * @param  {Object}     callback.err                        An error that occurred, if any
+ * @param  {Boolean}    calllback.isEmailAddressUpdate      Whether the email address will be updated
+ * @param  {String}     callback.oldEmail                   The user's old email address
+ * @api private
+ */
+var _isEmailAddressUpdate = function(principalId, profileFields, callback) {
+    if (!isUser(principalId) || !profileFields.email) {
+        return callback(null, false);
+    }
+
+    getPrincipal(principalId, function(err, user) {
+        if (err) {
+            return callback(err);
+        }
+
+        if (user.email !== profileFields.email) {
+            return callback(null, true, user.email);
+        }
+
+        return callback(null, false);
     });
 };
 
@@ -599,10 +788,9 @@ var _transformUserFieldTypes = function(hash) {
  * @api private
  */
 var _hashToUser = function(hash) {
-    var user = new User(hash.tenantAlias, hash.principalId, hash.displayName, {
+    var user = new User(hash.tenantAlias, hash.principalId, hash.displayName, hash.email, {
         'visibility': hash.visibility,
         'deleted': hash.deleted,
-        'email': hash.email,
         'locale': hash.locale,
         'publicAlias': hash.publicAlias,
         'isGlobalAdmin': sanitize(hash['admin:global']).toBooleanStrict(),

--- a/node_modules/oae-principals/lib/model.user.js
+++ b/node_modules/oae-principals/lib/model.user.js
@@ -24,10 +24,10 @@ var TenantsAPI = require('oae-tenants');
  * @param  {String}     tenantAlias                     The tenant this user belongs to.
  * @param  {String}     id                              The globally unique userId for this user. e.g.: u:cam:johndoe
  * @param  {String}     displayName                     The display name of the user
+ * @param  {String}     email                           The email address of the user
  * @param  {Object}     [opts]                          Optional additional user properties
  * @param  {String}     [opts.visibility]               The visibility of this user account. e.g.: loggedin
  * @param  {Date}       [opts.deleted]                  The date and time the user was deleted, if deleted
- * @param  {String}     [opts.email]                    The email of the user
  * @param  {String}     [opts.locale]                   The user's locale
  * @param  {String}     [opts.publicAlias]              The name of the user which is displayed to a user who does not have access to view the user
  * @param  {String}     [opts.smallPictureUri]          The uri of the small picture. It will be made available at user.picture.smallUri
@@ -41,7 +41,7 @@ var TenantsAPI = require('oae-tenants');
  * @param  {Boolean}    [opts.isGlobalAdmin]            Whether or not the user is a global admin
  * @param  {Boolean}    [opts.isTenantAdmin]            Whether or not the user is a tenant admin
  */
-module.exports.User = function(tenantAlias, id, displayName, opts) {
+module.exports.User = function(tenantAlias, id, displayName, email, opts) {
     opts = opts || {};
 
     // Explicit checks on true for admin.
@@ -55,9 +55,9 @@ module.exports.User = function(tenantAlias, id, displayName, opts) {
     that.tenant = tenant.compact();
     that.id = id;
     that.displayName = displayName;
+    that.email = email;
     that.visibility = opts.visibility;
     that.deleted = opts.deleted;
-    that.email = opts.email;
     that.locale = opts.locale;
     that.publicAlias = opts.publicAlias;
     that.picture = {};

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -18,6 +18,7 @@ var util = require('util');
 
 var AuthenticationAPI = require('oae-authentication');
 var AuthenticationConstants = require('oae-authentication/lib/constants').AuthenticationConstants;
+var AuthenticationUtil = require('oae-authentication/lib/util');
 var LoginId = require('oae-authentication/lib/model').LoginId;
 var OAE = require('oae-util/lib/oae');
 var OaeUtil = require('oae-util/lib/util');
@@ -83,7 +84,7 @@ OAE.tenantRouter.on('post', '/api/user/:userId/termsAndConditions', function(req
  * @FormParam   {string}        displayName             The display name for the global administrator
  * @FormParam   {string}        password                The password for the global administrator
  * @FormParam   {string}        username                The unique username for the global administrator
- * @FormParam   {string}        [email]                 The email address for the global administrator
+ * @FormParam   {string}        email                   The email address for the global administrator
  * @FormParam   {string}        [emailPreference]       The email preference for the global administrator   [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the global administrator
  * @FormParam   {string}        [publicAlias]           The name to show when the global administrator is inaccessible to a user
@@ -124,8 +125,8 @@ OAE.globalAdminRouter.on('post', '/api/user/createGlobalAdminUser', function(req
  * @FormParam   {string}        displayName             The display name for the tenant administrator
  * @FormParam   {string}        password                The password for the tenant administrator
  * @FormParam   {string}        username                The unique username for the tenant administrator
+ * @FormParam   {string}        email                   The email address for the tenant administrator
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the tenant administrator has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the tenant administrator
  * @FormParam   {string}        [emailPreference]       The email preference for the tenant administrator   [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the tenant administrator
  * @FormParam   {string}        [publicAlias]           The name to show when the tenant administrator is inaccessible to a user
@@ -151,8 +152,8 @@ OAE.globalAdminRouter.on('post', '/api/user/createGlobalAdminUser', function(req
  * @FormParam   {string}        displayName             The display name for the tenant administrator
  * @FormParam   {string}        password                The password for the tenant administrator
  * @FormParam   {string}        username                The unique username for the tenant administrator
+ * @FormParam   {string}        email                   The email address for the global administrator
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the tenant administrator has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the global administrator
  * @FormParam   {string}        [emailPreference]       The email preference for the tenant administrator   [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the tenant administrator
  * @FormParam   {string}        [publicAlias]           The name to show when the tenant administrator is inaccessible to a user
@@ -171,7 +172,7 @@ var _handleCreateTenantAdminUser = function(req, res) {
     var loginId = new LoginId(tenantAlias, AuthenticationConstants.providers.LOCAL, req.body.username, {'password': req.body.password});
     var opts = _getOptionalProfileParameters(req.body);
 
-    // Create the user as a tenant admin
+    // Create the user as a tenant administrator
     AuthenticationAPI.createTenantAdminUser(ctx, loginId, req.body.displayName, opts, function(err, user) {
         if (err) {
             return res.send(err.code, err.msg);
@@ -197,8 +198,8 @@ OAE.tenantRouter.on('post', '/api/user/createTenantAdminUser', _handleCreateTena
  * @FormParam   {string}        displayName             The display name for the user
  * @FormParam   {string}        password                The password for the user
  * @FormParam   {string}        username                The unique username for the user
+ * @FormParam   {string}        email                   The email address for the user
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the user has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the user
  * @FormParam   {string}        [emailPreference]       The email preference for the user       [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the user
  * @FormParam   {string}        [publicAlias]           The name to show when the user is inaccessible to a user
@@ -245,8 +246,8 @@ OAE.globalAdminRouter.on('post', '/api/user/:tenantAlias/create', function(req, 
  * @FormParam   {string}        displayName             The display name for the user
  * @FormParam   {string}        password                The password for the user
  * @FormParam   {string}        username                The unique username for the user
+ * @FormParam   {string}        email                   The email address for the user
  * @FormParam   {boolean}       [acceptedTC]            Whether or not the user has accepted the Terms and Conditions
- * @FormParam   {string}        [email]                 The email address for the user
  * @FormParam   {string}        [emailPreference]       The email preference for the user       [daily,immediate,weekly]
  * @FormParam   {string}        [locale]                The locale for the user
  * @FormParam   {string}        [publicAlias]           The name to show when the user is inaccessible to a user
@@ -268,14 +269,20 @@ OAE.tenantRouter.on('post', '/api/user/create', function(req, res) {
     var user = ctx.user();
     var opts = _getOptionalProfileParameters(req.body);
 
+    // We enforce an email address, the API will take care of validating the actual value
+    if (!opts.email) {
+        return res.status(400).send('A valid email address is required when creating a local account');
+    }
+
     /*!
      * Create a local user account
      */
     var createUser = function() {
-        var loginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, req.body.username, { password: req.body.password });
-        AuthenticationAPI.createUser(ctx, loginId, req.body.displayName, opts, function(err, newUser) {
+        AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.LOCAL, req.body.username, {'password': req.body.password}, req.body.displayName, opts, function(err, newUser, loginId, created) {
             if (err) {
                 return res.send(err.code, err.msg);
+            } else if (!created) {
+                return res.send(400, 'A user with that username already exists');
             }
 
             return res.send(201, newUser);
@@ -622,6 +629,110 @@ OAE.tenantRouter.on('post', '/api/user/:userId/picture', function(req, res) {
         return res.send(200, principal);
     });
 });
+
+/**
+ * @REST postUserEmailVerify
+ *
+ * Verify an email token
+ *
+ * @Server      tenant
+ * @Method      POST
+ * @Path        /user/{userId}/email/verify
+ * @PathParam   {string}        userId                      The id of the user to verify the email address for
+ * @FormParam   {string}        token                       The token with which to verify the email address
+ * @HttpResponse                200                         The token was valid and the email address for the user that was associated with it is verified
+ * @HttpResponse                400                         A token was not specified
+ * @HttpResponse                404                         The token was not associated with a user
+ */
+OAE.tenantRouter.on('post', '/api/user/:userId/email/verify', function(req, res) {
+    PrincipalsAPI.verifyEmail(req.ctx, req.params.userId, req.body.token, function(err, user) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        return res.send(200, user);
+    });
+});
+
+/**
+ * @REST postUserIdEmailResend
+ *
+ * Send a new email token to a user
+ *
+ * @Server      admin,tenant
+ * @Method      POST
+ * @Path        /user/{userId}/email/resend
+ * @PathParam   {string}        userId                      The id of the user to who a new email token should be sent
+ * @HttpResponse                200                         The token was sent
+ * @HttpResponse                400                         Invalid user id or the email address is already verified
+ * @HttpResponse                401                         You do not have sufficient rights to resend a token for a user
+ */
+var _handleResendEmailToken = function(req, res) {
+    PrincipalsAPI.resendEmailToken(req.ctx, req.params.userId, function(err) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        res.send(200);
+    });
+};
+
+OAE.globalAdminRouter.on('post', '/api/user/:userId/email/resend', _handleResendEmailToken);
+OAE.tenantRouter.on('post', '/api/user/:userId/email/resend', _handleResendEmailToken);
+
+/**
+ * @REST getUserIdEmailToken
+ *
+ * Check whether a user has a pending email token
+ *
+ * @Server      admin,tenant
+ * @Method      POST
+ * @Path        /user/{userId}/email/token
+ * @PathParam   {string}        userId                      The id of the user to for which to check whether they have a pending email token
+ * @HttpResponse                200                         There is a pending token. The email address for which the token is valid, will be returned
+ * @HttpResponse                400                         Invalid user id
+ * @HttpResponse                401                         You do not have sufficient rights to check whether the user has a pending token
+ * @HttpResponse                404                         There is no pending token for the user
+ */
+var _getEmailToken = function(req, res) {
+    PrincipalsAPI.getEmailToken(req.ctx, req.params.userId, function(err, email) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        res.send(200, {'email': email});
+    });
+};
+
+OAE.globalAdminRouter.on('get', '/api/user/:userId/email/token', _getEmailToken);
+OAE.tenantRouter.on('get', '/api/user/:userId/email/token', _getEmailToken);
+
+/**
+ * @REST deleteUserIdEmailToken
+ *
+ * Delete a pending email token for a user
+ *
+ * @Server      admin,tenant
+ * @Method      DELETE
+ * @Path        /user/{userId}/email/token
+ * @PathParam   {string}        userId                      The id of the user to for which to delete the pending email token
+ * @HttpResponse                200                         The token has been deleted
+ * @HttpResponse                400                         Invalid user id
+ * @HttpResponse                401                         You do not have sufficient rights to delete this user's email token
+ * @HttpResponse                404                         There is no pending token for the user
+ */
+var _deleteEmailToken = function(req, res) {
+    PrincipalsAPI.deleteEmailToken(req.ctx, req.params.userId, function(err) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        res.send(200);
+    });
+};
+
+OAE.globalAdminRouter.on('delete', '/api/user/:userId/email/token', _deleteEmailToken);
+OAE.tenantRouter.on('delete', '/api/user/:userId/email/token', _deleteEmailToken);
 
 /**
  * Extract the optional user profile parameters from the given set of request parameters

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -689,18 +689,19 @@ OAE.tenantRouter.on('post', '/api/user/:userId/email/resend', _handleResendEmail
  * @Method      POST
  * @Path        /user/{userId}/email/token
  * @PathParam   {string}        userId                      The id of the user to for which to check whether they have a pending email token
- * @HttpResponse                200                         There is a pending token. The email address for which the token is valid, will be returned
+ * @HttpResponse                200                         If there is a pending token, the address for which it is valid is returned. Otherwise, `null` is returned in its place
  * @HttpResponse                400                         Invalid user id
  * @HttpResponse                401                         You do not have sufficient rights to check whether the user has a pending token
- * @HttpResponse                404                         There is no pending token for the user
  */
 var _getEmailToken = function(req, res) {
     PrincipalsAPI.getEmailToken(req.ctx, req.params.userId, function(err, email) {
-        if (err) {
+        if (err && err.code !== 404) {
             return res.send(err.code, err.msg);
+        } else if (err) {
+            email = null;
         }
 
-        res.send(200, {'email': email});
+        return res.send(200, {'email': email});
     });
 };
 

--- a/node_modules/oae-principals/lib/search.js
+++ b/node_modules/oae-principals/lib/search.js
@@ -304,7 +304,7 @@ var _transformUserDocuments = function(ctx, docs, callback) {
         // First we need to convert the data in this document back into the source user object so that we may use PrincipalsUtil.hideUserData
         // to hide its information. We will then after convert the user *back* to a search document once the user information has been
         // scrubbed
-        var user = new User(tenantAlias, docId, displayName, {
+        var user = new User(tenantAlias, docId, displayName, null, {
             'visibility': visibility,
             'publicAlias': extra.publicAlias,
             'mediumPictureUri': thumbnailUrl

--- a/node_modules/oae-principals/lib/test/util.js
+++ b/node_modules/oae-principals/lib/test/util.js
@@ -16,12 +16,16 @@
 var _ = require('underscore');
 var assert = require('assert');
 var fs = require('fs');
+var util = require('util');
 
 var AuthzAPI = require('oae-authz');
 var AuthzUtil = require('oae-authz/lib/util');
 var ConfigTestsUtil = require('oae-config/lib/test/util');
+var EmailAPI = require('oae-email');
 var LibraryAPI = require('oae-library');
 var OaeUtil = require('oae-util/lib/util');
+var PrincipalsAPI = require('oae-principals');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
 var RestAPI = require('oae-rest');
 var SearchTestUtil = require('oae-search/lib/test/util');
 var TestsUtil = require('oae-tests/lib/util');
@@ -354,6 +358,47 @@ var assertUpdateGroupFails = module.exports.assertUpdateGroupFails = function(re
 };
 
 /**
+ * Assert that a user can be created
+ *
+ * @param  {RestContext}    restCtx             The REST context of a user who can create a user account
+ * @param  {Object}         params              The parameters to create the user with
+ * @param  {Function}       callback            Invoked when the user has been created an the verification email has been sent
+ * @param  {String}         callback.user       The created user
+ * @param  {String}         [callback.token]    The email verification token. Is `null` when a tenant administrator creates a user
+ * @throws {AssertionError}                     Thrown if the create is unsuccessful
+ */
+var assertCreateUserSucceeds = module.exports.assertCreateUserSucceeds = function(restCtx, params, callback) {
+    // Determine if the current user is an administrator. User accounts created by an administrator
+    // won't have to verify their email address, so we shouldn't wait for such an email when the
+    // passed in `restCtx` is an administrator
+    RestAPI.User.getMe(restCtx, function(err, me) {
+        assert.ok(!err);
+        var isAdmin = (me.isTenantAdmin || me.isGlobalAdmin);
+
+        var user = null;
+        var token = null;
+
+        // Wait until both the request is done and the email has been delivered
+        var done = _.after(2, function() {
+            return callback(user, token);
+        });
+
+        // Create the user account
+        RestAPI.User.createUser(restCtx, params.username, params.password, params.displayName, params.email, params, function(err, _user) {
+            assert.ok(!err);
+            user = _user;
+            done();
+        });
+
+        // Wait until the verification email has been delivered, if any
+        OaeUtil.invokeIfNecessary(!isAdmin, onceVerificationEmailSent, params.email, {'expectAdminMessage': false}, function(_token) {
+            token = _token;
+            done();
+        });
+    });
+};
+
+/**
  * Update all users, ensuring the requests and simple updates have succeeded
  *
  * @param  {RestContext}    restCtx         The REST context of the user with which to update the user
@@ -378,44 +423,80 @@ var assertUpdateUsersSucceeds = module.exports.assertUpdateUsersSucceeds = funct
 };
 
 /**
- * Update a user, ensuring the request and simple updates have succeeded
+ * Attempt to update a user's profile, ensuring it succeeds. It will:
+ *  - verify the changes were persisted correctly by retrieving the user's profile
+ *  - wait until a verification email has been sent if the change was not made by a tenant administrator
  *
- * @param  {RestContext}    restCtx         The REST context of the user with which to update the user
- * @param  {String}         userId          The id of the user to update
- * @param  {Object}         profileFields   An object keyed by profile fields whose values are the updates to apply
- * @param  {Function}       callback        Invoked when all assertions have succeeded
- * @param  {User}           callback.user   The updated full profile of the user
- * @throws {AssertionError}                 Thrown if any of the assertions fail
+ * @param  {RestContext}    restCtx             The REST context of a user who can perform the update
+ * @param  {String}         userId              The id of the user to update
+ * @param  {Object}         update              Object representing the profile fields that need to be updated. The keys are the profile fields, the values are the profile field values
+ * @param  {Function}       callback            Invoked when the user has been updated
+ * @param  {User}           callback.user       The updated user profile
+ * @param  {String}         callback.token      The email verification token
+ * @throws {AssertionError}                     Thrown if the update is unsuccessful or the expected results of updating a user don't hold true
  */
-var assertUpdateUserSucceeds = module.exports.assertUpdateUserSucceeds = function(restCtx, userId, profileFields, callback) {
-    // Get the user before we update them
-    RestAPI.User.getUser(restCtx, userId, function(err, fullUserBeforeUpdates) {
+var assertUpdateUserSucceeds = module.exports.assertUpdateUserSucceeds = function(restCtx, userId, update, callback) {
+    // Get the user's profile to determine if there is an update to the email address, as we might
+    // have to wait until the verification email is sent out
+    RestAPI.User.getUser(restCtx, userId, function(err, user) {
         assert.ok(!err);
+        var isEmailChange = (update.email && update.email.toLowerCase() !== user.email);
 
-        // Update the user
-        RestAPI.User.updateUser(restCtx, userId, profileFields, function(err, updatedUser) {
+        // Determine if the current user is an administrator. User accounts updated by an administrator
+        // still have to verify their email address, but the text in the email should be different
+        RestAPI.User.getMe(restCtx, function(err, me) {
             assert.ok(!err);
+            var isAdmin = (me.isTenantAdmin || me.isGlobalAdmin);
 
-            _.each(profileFields, function(value, key) {
-                assert.strictEqual(updatedUser[key], value);
+            var updatedUser = null;
+            var token = null;
+            var done = _.after(2, function() {
+                return callback(updatedUser, token);
             });
 
-            LibraryAPI.Index.whenUpdatesComplete(function() {
-                SearchTestUtil.whenIndexingComplete(function() {
+            // Update the user profile
+            RestAPI.User.updateUser(restCtx, userId, update, function(err) {
+                assert.ok(!err);
 
-                    // Ensure that the full user profile after updates exherts the new values
-                    RestAPI.User.getUser(restCtx, userId, function(err, fullUserAfterUpdates) {
-                        assert.ok(!err);
-
-                        _.each(profileFields, function(value, key) {
-                            assert.strictEqual(updatedUser[key], value);
-                        });
-
-                        return callback(fullUserAfterUpdates);
+                // Assert the changes were persisted correctly
+                RestAPI.User.getUser(restCtx, userId, function(err, _user) {
+                    assert.ok(!err);
+                    _.each(update, function(value, key) {
+                        // Email changes only get reflected once they have been verified
+                        if (key !== 'email') {
+                            assert.strictEqual(_user[key], value);
+                        }
                     });
+
+                    updatedUser = _user;
+                    return done();
                 });
             });
+
+            // Only attach a listener when we expect a verification email to be sent out
+            OaeUtil.invokeIfNecessary(isEmailChange, onceVerificationEmailSent, update.email, {'expectAdminMessage': isAdmin}, function(_token) {
+                token = _token;
+                return done();
+            });
         });
+    });
+};
+
+/**
+ * Attempt to update a user's profile, ensuring that the operation fails with the given HTTP code
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who can perform the update
+ * @param  {String}         userId          The id of the user to update
+ * @param  {Object}         update          Object representing the profile fields that need to be updated. The keys are the profile fields, the values are the profile field values
+ * @param  {Number}         httpCode        The expected HTTP code of the failed update operation
+ * @param  {Function}       callback        Invoked when the update user operation fails as expected
+ * @throws {AssertionError}                 Thrown if the update operation does not fail as expected
+ */
+var assertUpdateUserFails = module.exports.assertUpdateUserFails = function(restCtx, userId, update, httpCode, callback) {
+    RestAPI.User.updateUser(restCtx, userId, update, function(err) {
+        assert.ok(err);
+        assert.strictEqual(err.code, httpCode);
+        return callback();
     });
 };
 
@@ -1336,6 +1417,265 @@ var assertGetAllMembersLibrarySucceeds = module.exports.assertGetAllMembersLibra
         _members = _.union(_members, response.results);
         _nextToken = response.nextToken;
         return assertGetAllMembersLibrarySucceeds(restCtx, groupId, opts, callback, _nextToken, _members, _responses);
+    });
+};
+
+/**
+ * Assert that an email address can be verified
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who can perform the request
+ * @param  {String}         email           The email address to verify
+ * @param  {String}         token           The token that can be used to verify the email address
+ * @param  {Function}       callback        Invoked when the verify operation succeeds
+ * @param  {Object}         callback.err    An error that occurred, if any
+ * @throws {AssertionError}                 Thrown if the operation is unsuccessful or the expected results of verifying an email don't hold true
+ */
+var assertVerifyEmailSucceeds = module.exports.assertVerifyEmailSucceeds = function(restCtx, userId, token, callback) {
+    // Get the profile for the user before we verify their email address. This will allow
+    // us to assert that a new email address has been persisted
+    RestAPI.User.getUser(restCtx, userId, function(err, user) {
+        assert.ok(!err);
+        var oldEmailAddress = user.email;
+
+        // Verify the user has a pending email token
+        assertGetEmailTokenSucceeds(restCtx, userId, function(email) {
+
+            // Verify the email address
+            RestAPI.User.verifyEmail(restCtx, userId, token, function(err, user, response) {
+                assert.ok(!err);
+
+                // Verify the email address has changed
+                RestAPI.User.getUser(restCtx, userId, function(err, user) {
+                    assert.ok(!err);
+                    assert.notStrictEqual(user.email, oldEmailAddress);
+
+                    // Verify the email token has been removed
+                    return assertGetEmailTokenFails(restCtx, userId, 404, callback);
+                });
+            });
+        });
+    });
+};
+
+/**
+ * Assert that an email address can not be verified
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who can perform the request
+ * @param  {String}         userId          The id of the user to verify the email address for
+ * @param  {String}         token           The token that can be used to verify the email address
+ * @param  {Number}         httpCode        The expected HTTP code of the failed verify operation
+ * @param  {Function}       callback        Invoked when the verify operation fails as expected
+ * @param  {Object}         callback.err    An error that occurred, if any
+ * @throws {AssertionError}                 Thrown if the operation is unsuccessful or the expected results of verifying an email don't hold true
+ */
+var assertVerifyEmailFails = module.exports.assertVerifyEmailFails = function(restCtx, userId, token, httpCode, callback) {
+    // Under no circumstance should we ever be signed in after verifying an email
+    RestAPI.User.getMe(restCtx, function(err, me) {
+        assert.ok(!err);
+        var wasAnon = me.anon;
+
+        RestAPI.User.verifyEmail(restCtx, userId, token, function(err, user, response) {
+            assert.ok(err);
+            assert.strictEqual(err.code, httpCode);
+
+            // Verify we're still anonymous (if we were anonymous to being with)
+            RestAPI.User.getMe(restCtx, function(err, me) {
+                assert.ok(!err);
+                if (wasAnon) {
+                    assert.strictEqual(me.anon, true);
+                }
+
+                return callback();
+            });
+        });
+    });
+};
+
+/**
+ * Assert that an email verification token can be resent
+ *
+ * @param  {RestContext}    restCtx             The REST context of a user who will perform the request
+ * @param  {String}         userId              The id of the user who needs a new token
+ * @param  {Function}       callback            Invoked when the resend operation succeeds as expected and an email has been sent
+ * @param  {String}         callback.token      The new token
+ * @throws {AssertionError}                     Thrown if the operation is unsuccessful
+ */
+var assertResendEmailTokenSucceeds = module.exports.assertResendEmailTokenSucceeds = function(restCtx, userId, callback) {
+    RestAPI.User.getMe(restCtx, function(err, me) {
+        assert.ok(!err);
+        var isAdmin = (me.isTenantAdmin || me.isGlobalAdmin);
+
+        // Get the "new" email address from the database as the one that is in the user's profile
+        // is probably the old verified email address
+        PrincipalsDAO.getEmailToken(userId, function(err, email) {
+            assert.ok(!err);
+
+            var token = null;
+            var done = _.after(2, function() {
+                return callback(token);
+            });
+
+            // Resend the token
+            RestAPI.User.resendEmailToken(restCtx, userId, function(err) {
+                assert.ok(!err);
+                done();
+            });
+
+            // Wait until the email has been sent so we can pass the token back to the caller
+            onceVerificationEmailSent(email, {'expectAdminMessage': isAdmin}, function(_token) {
+                token = _token;
+                done();
+            });
+        });
+    });
+};
+
+/**
+ * Assert that an email verification token can not be resent
+ *
+ * @param  {RestContext}    restCtx             The REST context of a user who will perform the request
+ * @param  {String}         userId              The id of the user who needs a new token
+ * @param  {Number}         httpCode            The expected HTTP code of the failed resend operation
+ * @param  {Function}       callback            Invoked when the resend operation fails as expected
+ * @throws {AssertionError}                     Thrown if the operation is successful
+ */
+var assertResendEmailTokenFails = module.exports.assertResendEmailTokenFails = function(restCtx, userId, httpCode, callback) {
+    RestAPI.User.resendEmailToken(restCtx, userId, function(err) {
+        assert.ok(err);
+        assert.strictEqual(err.code, httpCode);
+        return callback();
+    });
+};
+
+/**
+ * Assert that a user has a pending email token
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who will perform the request
+ * @param  {String}         userId          The id of the user for which to check whether they have a pending email token
+ * @param  {Function}       callback        Invoked when the check has been performed
+ * @param  {String}         callback.email  The email address for which there is a token
+ * @throws {AssertionError}                 Thrown if the operation is unsuccessful
+ */
+var assertGetEmailTokenSucceeds = module.exports.assertGetEmailTokenSucceeds = function(restCtx, userId, callback) {
+    RestAPI.User.getEmailToken(restCtx, userId, function(err, data) {
+        assert.ok(!err);
+        return callback(data.email);
+    });
+};
+
+/**
+ * Assert that a user has no pending email token or that the operation fails
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who will perform the request
+ * @param  {String}         userId          The id of the user for which to check whether they have a pending email token
+ * @param  {Number}         httpCode        The expected HTTP code of the failed has pending email token operation
+ * @param  {Function}       callback        Invoked when the check has been performed
+ * @param  {String}         callback.email  The email address for which there is a token
+ * @throws {AssertionError}                 Thrown if the operation is successful
+ */
+var assertGetEmailTokenFails = module.exports.assertGetEmailTokenFails = function(restCtx, userId, httpCode, callback) {
+    RestAPI.User.getEmailToken(restCtx, userId, function(err, data) {
+        assert.ok(err);
+        assert.strictEqual(err.code, httpCode);
+        return callback();
+    });
+};
+
+/**
+ * Assert that an email token can be deleted
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who will perform the request
+ * @param  {String}         userId          The id of the user for which to delete the pending email token
+ * @param  {Function}       callback        Invoked when the delete operation has been performed
+ * @throws {AssertionError}                 Thrown if the operation is unsuccessful
+ */
+var assertDeleteEmailTokenSucceeds = module.exports.assertDeleteEmailTokenSucceeds = function(restCtx, userId, callback) {
+    // Delete the token
+    RestAPI.User.deleteEmailToken(restCtx, userId, function(err) {
+        assert.ok(!err);
+
+        // Verify the token is gone
+        return assertDeleteEmailTokenFails(restCtx, userId, 404, callback);
+    });
+};
+
+/**
+ * Assert that an email token can be deleted
+ *
+ * @param  {RestContext}    restCtx         The REST context of a user who will perform the request
+ * @param  {String}         userId          The id of the user for which to delete the pending email token
+ * @param  {Number}         httpCode        The expected HTTP code of the failed has pending email token operation
+ * @param  {Function}       callback        Invoked when the delete operation has been performed
+ * @throws {AssertionError}                 Thrown if the operation is successful
+ */
+var assertDeleteEmailTokenFails = module.exports.assertDeleteEmailTokenFails = function(restCtx, userId, httpCode, callback) {
+    RestAPI.User.deleteEmailToken(restCtx, userId, function(err, data) {
+        assert.ok(err);
+        assert.strictEqual(err.code, httpCode);
+        return callback();
+    });
+};
+
+/**
+ * Assert that the correct user ids are mapped to an email address
+ *
+ * @param  {String}     email               The email address for which to check the mapping
+ * @param  {String[]}   expectedUserIds     The expected ids of the users who should be mapped to the email address
+ * @param  {Function}   callback            Invoked when the mapping has been verified
+ * @throws {AssertionError}                 Thrown if the operation is unsuccessful or the mapping is incorrect
+ */
+var assertUserEmailMappingEquals = module.exports.assertUserEmailMappingEquals = function(email, expectedUserIds, callback) {
+    PrincipalsDAO.getUsersByEmail(email.toLowerCase(), function(err, usersByEmail) {
+        assert.ok(!err);
+
+        // Get the ids of the mapped users, don't care about sorting
+        var userIds = _.chain(usersByEmail)
+            .pluck('id')
+            .sort()
+            .value();
+        expectedUserIds = expectedUserIds.sort();
+
+        // Assert the retrieved user ids are what we expected
+        assert.deepEqual(userIds, expectedUserIds);
+        return callback();
+    });
+};
+
+/**
+ * Execute a callback function once a verification email is sent
+ *
+ * @param  {String}     [email]                             The email address too which the token should have been sent
+ * @param  {Object}     [assertions]                        A set of flags that specify how some extra assertions should be made
+ * @param  {Boolean}    [assertions.expectAdminMessage]     Whether it's expected that the message was triggered by an admin
+ * @param  {Function}   callback                            Invoked once the verification email was sent to the user
+ * @param  {String}     callback.token                      The email verification token that was sent to the user
+ * @throws {AssertionError}                                 Thrown if an email was sent to the wrong email address or does not contain a proper token
+ */
+var onceVerificationEmailSent = module.exports.onceVerificationEmailSent = function(email, assertions, callback) {
+    EmailAPI.once('debugSent', function(message) {
+        // Verify the email address
+        if (email) {
+            assert.strictEqual(message.to[0].address, email.toLowerCase());
+        }
+
+        if (assertions.expectAdminMessage) {
+            assert.ok(message.html.match(/admin/), util.format('Expected string "admin" in email html, but got: %s', message.html));
+            assert.ok(message.text.match(/admin/));
+        } else {
+            assert.ok(!message.html.match(/admin/));
+            assert.ok(!message.text.match(/admin/));
+        }
+
+        // Verify a token is passed in both the html and text email
+        assert.ok(message.html.match(/\?token=([a-zA-Z0-9-_]{7,14})/));
+        assert.ok(message.text.match(/\?token=([a-zA-Z0-9-_]{7,14})/));
+
+        // Verify a token is passed in the email
+        var token = message.text.match(/\?token=([a-zA-Z0-9-_]{7,14})/)[1];
+        assert.ok(token);
+        token = decodeURIComponent(token);
+
+        return callback(token);
     });
 };
 

--- a/node_modules/oae-principals/lib/test/util.js
+++ b/node_modules/oae-principals/lib/test/util.js
@@ -1427,7 +1427,6 @@ var assertGetAllMembersLibrarySucceeds = module.exports.assertGetAllMembersLibra
  * @param  {String}         email           The email address to verify
  * @param  {String}         token           The token that can be used to verify the email address
  * @param  {Function}       callback        Invoked when the verify operation succeeds
- * @param  {Object}         callback.err    An error that occurred, if any
  * @throws {AssertionError}                 Thrown if the operation is unsuccessful or the expected results of verifying an email don't hold true
  */
 var assertVerifyEmailSucceeds = module.exports.assertVerifyEmailSucceeds = function(restCtx, userId, token, callback) {
@@ -1450,7 +1449,10 @@ var assertVerifyEmailSucceeds = module.exports.assertVerifyEmailSucceeds = funct
                     assert.notStrictEqual(user.email, oldEmailAddress);
 
                     // Verify the email token has been removed
-                    return assertGetEmailTokenFails(restCtx, userId, 404, callback);
+                    assertGetEmailTokenSucceeds(restCtx, userId, function(email) {
+                        assert.ok(!email);
+                        return callback();
+                    });
                 });
             });
         });
@@ -1666,12 +1668,14 @@ var onceVerificationEmailSent = module.exports.onceVerificationEmailSent = funct
             assert.ok(!message.text.match(/admin/));
         }
 
+        var tokenRegex = /\?verifyEmail=([a-zA-Z0-9-_]{7,14})/;
+
         // Verify a token is passed in both the html and text email
-        assert.ok(message.html.match(/\?token=([a-zA-Z0-9-_]{7,14})/));
-        assert.ok(message.text.match(/\?token=([a-zA-Z0-9-_]{7,14})/));
+        assert.ok(message.html.match(tokenRegex));
+        assert.ok(message.text.match(tokenRegex));
 
         // Verify a token is passed in the email
-        var token = message.text.match(/\?token=([a-zA-Z0-9-_]{7,14})/)[1];
+        var token = message.text.match(tokenRegex)[1];
         assert.ok(token);
         token = decodeURIComponent(token);
 

--- a/node_modules/oae-principals/lib/util.js
+++ b/node_modules/oae-principals/lib/util.js
@@ -170,9 +170,9 @@ var hideUserData = module.exports.hideUserData = function(ctx, user) {
  */
 var createUpdatedUser = module.exports.createUpdatedUser = function(user, fieldUpdates) {
     var newDisplayName = fieldUpdates.displayName || user.displayName;
-    var newUser = new User(user.tenant.alias, user.id, newDisplayName, {
+    var newEmail = fieldUpdates.email || user.email;
+    var newUser = new User(user.tenant.alias, user.id, newDisplayName, newEmail, {
         'visibility': fieldUpdates.visibility || user.visibility,
-        'email': fieldUpdates.email || user.email,
         'emailPreference': fieldUpdates.emailPreference || user.emailPreference,
         'locale': fieldUpdates.locale || user.locale,
         'publicAlias': fieldUpdates.publicAlias || user.publicAlias,

--- a/node_modules/oae-principals/tests/data/users-emails-updated.csv
+++ b/node_modules/oae-principals/tests/data/users-emails-updated.csv
@@ -1,0 +1,1 @@
+users-emails-abc123,password,Bar,Foo,bar@users.emails.com

--- a/node_modules/oae-principals/tests/data/users-emails.csv
+++ b/node_modules/oae-principals/tests/data/users-emails.csv
@@ -1,0 +1,1 @@
+users-emails-abc123,password,Bar,Foo,foo@users.emails.com

--- a/node_modules/oae-principals/tests/data/users-with-password-alias.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password-alias.csv
@@ -1,0 +1,25 @@
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@alias.test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@alias.test.com
+user-mIAUwkeNS,password3,Visser,Branden,branden@alias.test.com
+user-HlKKreaDP,password4,Gaeremynck,,simon@alias.test.com
+user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@alias.test.com
+user-JjuyZssJQ,password6,Reynolds,Malcom,mal@alias.test.com
+user-HgRNdDzQd,password7,Washburn,Zoe,zoe@alias.test.com
+user-DGdlFUNzv,password8,Washburn,Hoban,wash@alias.test.com
+user-gPvjYjVHh,password9,Serra,Inara,inara@alias.test.com
+user-TUolZGzsm,password10,Cobb,Jayne,jayne@alias.test.com
+user-CIwpSRwXk,password11,Frye,Kaylee,kaylee@alias.test.com
+user-SUMbWTWKD,password13,Tam,River,river@alias.test.com
+user-PZCWYjPkm,password14,Book,Derrial,book@alias.test.com
+user-crqhYVPaO,password15,Grant,Alan,alan@alias.test.com
+user-sXzLFyWDK,password16,Malcom,Ian,ian@alias.test.com
+user-czkFzYYOD,password17,Sattler,Ellie,ellie@alias.test.com
+user-Tibmrtgvc,password18,Guitierrez,Martin,marty@alias.test.com
+user-jUDvjjySh,password19,Muldoon,Robert,robert@alias.test.com
+user-daHPDePdl,password20,Hammond,John,john@alias.test.com
+user-RwONmsFaM,password21,Nedry,Dennis,nedry@alias.test.com
+user-TEnUBtlRL,password22,Gennaro,Donald,don@alias.test.com
+user-lJJTHWYTX,password23,Arnold,John,ray@alias.test.com
+user-KhfBKaGwy,password24,Wu,Henry,henry@alias.test.com
+user-XUclyraoP,password25,Murphy,Lex,lex@alias.test.com
+user-bbLwAWxpd,password26,Thomas,Stephen,stephen@alias.test.com

--- a/node_modules/oae-principals/tests/data/users-with-password-displayname.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password-displayname.csv
@@ -1,0 +1,25 @@
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@displayname.test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@displayname.test.com
+user-mIAUwkeNS,password3,Visser,Branden,branden@displayname.test.com
+user-HlKKreaDP,password4,Gaeremynck,,simon@displayname.test.com
+user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@displayname.test.com
+user-JjuyZssJQ,password6,Reynolds,Malcom,mal@displayname.test.com
+user-HgRNdDzQd,password7,Washburn,Zoe,zoe@displayname.test.com
+user-DGdlFUNzv,password8,Washburn,Hoban,wash@displayname.test.com
+user-gPvjYjVHh,password9,Serra,Inara,inara@displayname.test.com
+user-TUolZGzsm,password10,Cobb,Jayne,jayne@displayname.test.com
+user-CIwpSRwXk,password11,Frye,Kaylee,kaylee@displayname.test.com
+user-SUMbWTWKD,password13,Tam,River,river@displayname.test.com
+user-PZCWYjPkm,password14,Book,Derrial,book@displayname.test.com
+user-crqhYVPaO,password15,Grant,Alan,alan@displayname.test.com
+user-sXzLFyWDK,password16,Malcom,Ian,ian@displayname.test.com
+user-czkFzYYOD,password17,Sattler,Ellie,ellie@displayname.test.com
+user-Tibmrtgvc,password18,Guitierrez,Martin,marty@displayname.test.com
+user-jUDvjjySh,password19,Muldoon,Robert,robert@displayname.test.com
+user-daHPDePdl,password20,Hammond,John,john@displayname.test.com
+user-RwONmsFaM,password21,Nedry,Dennis,nedry@displayname.test.com
+user-TEnUBtlRL,password22,Gennaro,Donald,don@displayname.test.com
+user-lJJTHWYTX,password23,Arnold,John,ray@displayname.test.com
+user-KhfBKaGwy,password24,Wu,Henry,henry@displayname.test.com
+user-XUclyraoP,password25,Murphy,Lex,lex@displayname.test.com
+user-bbLwAWxpd,password26,Thomas,Stephen,stephen@displayname.test.com

--- a/node_modules/oae-principals/tests/data/users-with-password-email.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password-email.csv
@@ -1,0 +1,25 @@
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@email.test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@email.test.com
+user-mIAUwkeNS,password3,Visser,Branden,branden@email.test.com
+user-HlKKreaDP,password4,Gaeremynck,,simon@email.test.com
+user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@email.test.com
+user-JjuyZssJQ,password6,Reynolds,Malcom,mal@email.test.com
+user-HgRNdDzQd,password7,Washburn,Zoe,zoe@email.test.com
+user-DGdlFUNzv,password8,Washburn,Hoban,wash@email.test.com
+user-gPvjYjVHh,password9,Serra,Inara,inara@email.test.com
+user-TUolZGzsm,password10,Cobb,Jayne,jayne@email.test.com
+user-CIwpSRwXk,password11,Frye,Kaylee,kaylee@email.test.com
+user-SUMbWTWKD,password13,Tam,River,river@email.test.com
+user-PZCWYjPkm,password14,Book,Derrial,book@email.test.com
+user-crqhYVPaO,password15,Grant,Alan,alan@email.test.com
+user-sXzLFyWDK,password16,Malcom,Ian,ian@email.test.com
+user-czkFzYYOD,password17,Sattler,Ellie,ellie@email.test.com
+user-Tibmrtgvc,password18,Guitierrez,Martin,marty@email.test.com
+user-jUDvjjySh,password19,Muldoon,Robert,robert@email.test.com
+user-daHPDePdl,password20,Hammond,John,john@email.test.com
+user-RwONmsFaM,password21,Nedry,Dennis,nedry@email.test.com
+user-TEnUBtlRL,password22,Gennaro,Donald,don@email.test.com
+user-lJJTHWYTX,password23,Arnold,John,ray@email.test.com
+user-KhfBKaGwy,password24,Wu,Henry,henry@email.test.com
+user-XUclyraoP,password25,Murphy,Lex,lex@email.test.com
+user-bbLwAWxpd,password26,Thomas,Stephen,stephen@email.test.com

--- a/node_modules/oae-principals/tests/data/users-with-password.csv
+++ b/node_modules/oae-principals/tests/data/users-with-password.csv
@@ -1,5 +1,5 @@
-user-zfdHliPLa, password1, Matthijs, Nicolaas, nicolaas@test.com
-user-plOPperDe, password2, Pareyn, Bert, bert@test.com
+user-zfdHliPLa,password1,Matthijs,Nicolaas,nicolaas@test.com
+user-plOPperDe,password2,Pareyn,Bert,bert@test.com
 user-mIAUwkeNS,password3,Visser,Branden,branden@test.com
 user-HlKKreaDP,password4,Gaeremynck,,simon@test.com
 user-IrewPDSAw,password5,Freeman,Stuart D.,stuart@test.com

--- a/node_modules/oae-principals/tests/test-activity.js
+++ b/node_modules/oae-principals/tests/test-activity.js
@@ -28,6 +28,8 @@ var RestContext = require('oae-rest/lib/model').RestContext;
 var RestUtil = require('oae-rest/lib/util');
 var TestsUtil = require('oae-tests');
 
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
+
 describe('Principals Activity', function() {
 
     // Rest context that can be used every time we need to make a request as an anonymous user
@@ -46,7 +48,7 @@ describe('Principals Activity', function() {
         anonymousGtRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host);
         // Fill up global admin rest context
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
-        callback();
+        return callback();
     });
 
     /**
@@ -95,66 +97,58 @@ describe('Principals Activity', function() {
     describe('Routes', function() {
 
         it('verify cyclic group memberships terminate while routing an activity', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var jackUsername = TestsUtil.generateTestUserId('jack');
             var group1Alias = TestsUtil.generateTestUserId('group1');
             var group2Alias = TestsUtil.generateTestUserId('group2');
             var group3Alias = TestsUtil.generateTestUserId('group3');
             var group4Alias = TestsUtil.generateTestUserId('group4');
 
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
                 assert.ok(!err);
-                var doerCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                // Create the 4 groups that will form a cycle
+                RestAPI.Group.createGroup(doer.restContext, group1Alias, group1Alias, 'public', 'no', [], [], function(err, group1) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    // Create the 4 groups that will form a cycle
-                    RestAPI.Group.createGroup(doerCtx, group1Alias, group1Alias, 'public', 'no', [], [], function(err, group1) {
+                    RestAPI.Group.createGroup(doer.restContext, group2Alias, group2Alias, 'public', 'no', [group1.id], [], function(err, group2) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(doerCtx, group2Alias, group2Alias, 'public', 'no', [group1.id], [], function(err, group2) {
+                        // Group 3 will be joinable, so Jack can join it to trigger an activity
+                        RestAPI.Group.createGroup(doer.restContext, group3Alias, group3Alias, 'public', 'yes', [group2.id], [], function(err, group3) {
                             assert.ok(!err);
 
-                            // Group 3 will be joinable, so Jack can join it to trigger an activity
-                            RestAPI.Group.createGroup(doerCtx, group3Alias, group3Alias, 'public', 'yes', [group2.id], [], function(err, group3) {
+                            RestAPI.Group.createGroup(doer.restContext, group4Alias, group4Alias, 'public', 'no', [group3.id], [], function(err, group4) {
                                 assert.ok(!err);
 
-                                RestAPI.Group.createGroup(doerCtx, group4Alias, group4Alias, 'public', 'no', [group3.id], [], function(err, group4) {
+                                // Add group4 as manager to group1 to complete the cycle
+                                var cycleChange = {};
+                                cycleChange[group4.id] = 'manager';
+                                RestAPI.Group.setGroupMembers(doer.restContext, group1.id, cycleChange, function(err) {
                                     assert.ok(!err);
 
-                                    // Add group4 as manager to group1 to complete the cycle
-                                    var cycleChange = {};
-                                    cycleChange[group4.id] = 'manager';
-                                    RestAPI.Group.setGroupMembers(doerCtx, group1.id, cycleChange, function(err) {
+                                    RestAPI.Group.joinGroup(jack.restContext, group3.id, function(err) {
                                         assert.ok(!err);
 
-                                        RestAPI.Group.joinGroup(jackCtx, group3.id, function(err) {
+                                        // Verify that each group now has this as its most recent activity
+                                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group1.id, null, function(err, activityStream) {
                                             assert.ok(!err);
+                                            assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
+                                            assert.equal(activityStream.items[0].object['oae:id'], group3.id);
 
-                                            // Verify that each group now has this as its most recent activity
-                                            ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group1.id, null, function(err, activityStream) {
+                                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group2.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
                                                 assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
                                                 assert.equal(activityStream.items[0].object['oae:id'], group3.id);
 
-                                                ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group2.id, null, function(err, activityStream) {
+                                                ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group3.id, null, function(err, activityStream) {
                                                     assert.ok(!err);
                                                     assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
                                                     assert.equal(activityStream.items[0].object['oae:id'], group3.id);
 
-                                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group3.id, null, function(err, activityStream) {
+                                                    ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, group4.id, null, function(err, activityStream) {
                                                         assert.ok(!err);
                                                         assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
                                                         assert.equal(activityStream.items[0].object['oae:id'], group3.id);
-
-                                                        ActivityTestsUtil.collectAndGetActivityStream(jackCtx, group4.id, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.equal(activityStream.items[0]['oae:activityType'], 'group-join');
-                                                            assert.equal(activityStream.items[0].object['oae:id'], group3.id);
-                                                            return callback();
-                                                        });
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -173,67 +167,52 @@ describe('Principals Activity', function() {
          * only be routed to managers, as well as a regular update operation which should get routed to all members.
          */
         it('verify group activities are routed to group member descendants', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var managerGroupMemberUsername = TestsUtil.generateTestUserId('managerGroupMember');
-
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, managerGroupMember) {
                 assert.ok(!err);
-                var doerCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                // Create the member group, which will be member to the group that gets updated and has a user added. This group should not receive the "user added" activity
+                RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('memberGroup'), TestsUtil.generateTestUserId('memberGroup'), 'public', 'no', [], [], function(err, memberGroup) {
                     assert.ok(!err);
-                    var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, managerGroupMemberUsername, 'password', 'Jane', null, function(err, managerGroupMember) {
+                    // Create the manager group, which should receive both update and "user added" activities
+                    RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('managerGroup'), TestsUtil.generateTestUserId('managerGroup'), 'public', 'no', [], [], function(err, managerGroup) {
                         assert.ok(!err);
-                        var managerGroupMemberCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, managerGroupMemberUsername, 'password');
 
-                        // Create the member group, which will be member to the group that gets updated and has a user added. This group should not receive the "user added" activity
-                        RestAPI.Group.createGroup(doerCtx, TestsUtil.generateTestUserId('memberGroup'), TestsUtil.generateTestUserId('memberGroup'), 'public', 'no', [], [], function(err, memberGroup) {
+                        // ManagerGroupMember should be a member of the manager group to verify indirect group member routing
+                        var membership = {};
+                        membership[managerGroupMember.user.id] = 'manager';
+                        RestAPI.Group.setGroupMembers(doer.restContext, managerGroup.id, membership, function(err) {
                             assert.ok(!err);
 
-                            // Create the manager group, which should receive both update and "user added" activities
-                            RestAPI.Group.createGroup(doerCtx, TestsUtil.generateTestUserId('managerGroup'), TestsUtil.generateTestUserId('managerGroup'), 'public', 'no', [], [], function(err, managerGroup) {
+                            // Create the target group, manager group and member group are members
+                            RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestUserId('targetGroup'), TestsUtil.generateTestUserId('targetGroup'), 'public', 'yes', [managerGroup.id], [memberGroup.id], function(err, targetGroup) {
                                 assert.ok(!err);
 
-                                // ManagerGroupMember should be a member of the manager group to verify indirect group member routing
-                                var membership = {};
-                                membership[managerGroupMember.id] = 'manager';
-                                RestAPI.Group.setGroupMembers(doerCtx, managerGroup.id, membership, function(err) {
+                                RestAPI.Group.joinGroup(jack.restContext, targetGroup.id, function(err) {
                                     assert.ok(!err);
 
-                                    // Create the target group, manager group and member group are members
-                                    RestAPI.Group.createGroup(doerCtx, TestsUtil.generateTestUserId('targetGroup'), TestsUtil.generateTestUserId('targetGroup'), 'public', 'yes', [managerGroup.id], [memberGroup.id], function(err, targetGroup) {
+                                    // Update the group to propagate an activity
+                                    RestAPI.Group.updateGroup(doer.restContext, targetGroup.id, {'displayName': 'Ha ha I make change'}, function(err) {
                                         assert.ok(!err);
 
-                                        RestAPI.Group.joinGroup(jackCtx, targetGroup.id, function(err) {
+                                        // Ensure manager group received both update and join activities
+                                        ActivityTestsUtil.collectAndGetActivityStream(doer.restContext, managerGroup.id, null, function(err, activityStream) {
                                             assert.ok(!err);
+                                            assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
+                                            assert.ok(_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
 
-                                            // Update the group to propagate an activity
-                                            RestAPI.Group.updateGroup(doerCtx, targetGroup.id, {'displayName': 'Ha ha I make change'}, function(err) {
+                                            // Ensure the member group received update, but not join
+                                            ActivityTestsUtil.collectAndGetActivityStream(doer.restContext, memberGroup.id, null, function(err, activityStream) {
                                                 assert.ok(!err);
+                                                assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
+                                                assert.ok(!_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
 
-                                                // Ensure manager group received both update and join activities
-                                                ActivityTestsUtil.collectAndGetActivityStream(doerCtx, managerGroup.id, null, function(err, activityStream) {
+                                                // Ensure member of the manager group got both update and join
+                                                ActivityTestsUtil.collectAndGetActivityStream(managerGroupMember.restContext, managerGroupMember.user.id, null, function(err, activityStream) {
                                                     assert.ok(!err);
                                                     assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
                                                     assert.ok(_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
-
-                                                    // Ensure the member group received update, but not join
-                                                    ActivityTestsUtil.collectAndGetActivityStream(doerCtx, memberGroup.id, null, function(err, activityStream) {
-                                                        assert.ok(!err);
-                                                        assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
-                                                        assert.ok(!_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
-
-                                                        // Ensure member of the manager group got both update and join
-                                                        ActivityTestsUtil.collectAndGetActivityStream(managerGroupMemberCtx, managerGroupMember.id, null, function(err, activityStream) {
-                                                            assert.ok(!err);
-                                                            assert.ok(_getActivity(activityStream, 'group-update', 'object', targetGroup.id));
-                                                            assert.ok(_getActivity(activityStream, 'group-join', 'object', targetGroup.id));
-                                                            callback();
-                                                        });
-                                                    });
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -272,32 +251,25 @@ describe('Principals Activity', function() {
          * Test that verifies the contents of the full group and user activity entity models.
          */
         it('verify the user and group activity entity model', function(callback) {
-            var publicUsername = TestsUtil.generateTestUserId('userPublic');
-            var privateUsername = TestsUtil.generateTestUserId('userPrivate');
-
-            // Create a public user so we can verify all the information is returned
-            RestAPI.User.createUser(camAdminRestContext, publicUsername, 'password', 'Jack McJackerson', {'visibility': 'public'}, function(err, publicUser) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, publicUser, privateUser) {
                 assert.ok(!err);
-                var publicUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, publicUsername, 'password');
 
-                var sizes = {
-                    'x': 0,
-                    'y': 0,
-                    'width': 35,
-                    'height': 35
-                };
-
-                // Give the users a profile picture so we can verify it is on the entity model
-                RestAPI.User.uploadPicture(publicUserRestContext, publicUser.id, _getPictureStream, sizes, function(err) {
+                RestAPI.User.updateUser(privateUser.restContext, privateUser.user.id, {'visibility': 'private'}, function(err) {
                     assert.ok(!err);
 
-                    // Create private user so we can verify information is properly hidden where appropriate
-                    RestAPI.User.createUser(camAdminRestContext, privateUsername, 'password', 'Jane Janerville', {'visibility': 'private', 'publicAlias': 'Jane'}, function(err, privateUser) {
+                    var sizes = {
+                        'x': 0,
+                        'y': 0,
+                        'width': 35,
+                        'height': 35
+                    };
+
+                    // Give the users a profile picture so we can verify it is on the entity model
+                    RestAPI.User.uploadPicture(publicUser.restContext, publicUser.user.id, _getPictureStream, sizes, function(err) {
                         assert.ok(!err);
-                        var privateUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, privateUsername, 'password');
 
                         // Add a profile picture to the private user so we can verify it gets hidden
-                        RestAPI.User.uploadPicture(privateUserRestContext, privateUser.id, _getPictureStream, sizes, function(err) {
+                        RestAPI.User.uploadPicture(privateUser.restContext, privateUser.user.id, _getPictureStream, sizes, function(err) {
                             assert.ok(!err);
 
                             // Create a group
@@ -310,13 +282,13 @@ describe('Principals Activity', function() {
 
                                     // Add both the public and private users to the group. They should receive eachother's user entities in the feeds
                                     var permissionChanges = {};
-                                    permissionChanges[publicUser.id] = 'manager';
-                                    permissionChanges[privateUser.id] = 'manager';
+                                    permissionChanges[publicUser.user.id] = 'manager';
+                                    permissionChanges[privateUser.user.id] = 'manager';
                                     RestAPI.Group.setGroupMembers(camAdminRestContext, group.id, permissionChanges, function(err) {
                                         assert.ok(!err);
 
                                         // Verify the publicUser and group model in the public user group-add-member activity
-                                        ActivityTestsUtil.collectAndGetActivityStream(publicUserRestContext, publicUser.id, null, function(err, activityStream) {
+                                        ActivityTestsUtil.collectAndGetActivityStream(publicUser.restContext, publicUser.user.id, null, function(err, activityStream) {
                                             assert.ok(!err);
 
                                             // Pluck the group-add-member activity from the user's feed
@@ -337,28 +309,28 @@ describe('Principals Activity', function() {
                                             var privateUserActivityEnity = null;
                                             _.each(object['oae:collection'], function(user) {
                                                 var resourceId = AuthzUtil.getResourceFromId(user['oae:id']).resourceId;
-                                                if (user['oae:id'] === publicUser.id) {
+                                                if (user['oae:id'] === publicUser.user.id) {
                                                     publicUserActivityEntity = user;
 
                                                     // Verify the public user model
-                                                    assert.ok(user['id'].indexOf(publicUser.id) !== -1);
-                                                    assert.equal(user['displayName'], publicUser.displayName);
+                                                    assert.ok(user['id'].indexOf(publicUser.user.id) !== -1);
+                                                    assert.equal(user['displayName'], publicUser.user.displayName);
                                                     assert.equal(user['objectType'], 'user');
-                                                    assert.equal(user['oae:id'], publicUser.id);
-                                                    assert.equal(user['oae:profilePath'], publicUser.profilePath);
-                                                    assert.equal(user['oae:visibility'], publicUser.visibility);
+                                                    assert.equal(user['oae:id'], publicUser.user.id);
+                                                    assert.equal(user['oae:profilePath'], publicUser.user.profilePath);
+                                                    assert.equal(user['oae:visibility'], 'public');
                                                     assert.equal(user['url'], 'http://' + global.oaeTests.tenants.cam.host + '/user/camtest/' + resourceId);
                                                     assert.ok(user['image']);
-                                                } else if (user['oae:id'] === privateUser.id) {
+                                                } else if (user['oae:id'] === privateUser.user.id) {
                                                     privateUserActivityEnity = user;
 
                                                     // Verify the private user model
-                                                    assert.ok(user['id'].indexOf(privateUser.id) !== -1);
-                                                    assert.equal(user['displayName'], privateUser.publicAlias);
+                                                    assert.ok(user['id'].indexOf(privateUser.user.id) !== -1);
+                                                    assert.equal(user['displayName'], privateUser.user.publicAlias);
                                                     assert.equal(user['objectType'], 'user');
-                                                    assert.equal(user['oae:id'], privateUser.id);
+                                                    assert.equal(user['oae:id'], privateUser.user.id);
                                                     assert.equal(user['oae:profilePath'], undefined);
-                                                    assert.equal(user['oae:visibility'], privateUser.visibility);
+                                                    assert.equal(user['oae:visibility'], 'private');
 
                                                     // Url and image are not defined for unprivileged users in feeds
                                                     assert.ok(!user['url']);
@@ -568,14 +540,10 @@ describe('Principals Activity', function() {
          * Test that verifies the group-create, group-update and group-update-visibility activities gets generated
          */
         it('verify group-create, group-update, group-update-visibility activities are delivered', function(callback) {
-            var username = TestsUtil.generateTestUserId('user');
-
-            // Create a user with which to create a group, then ensure the user gets the activity
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Jack McJackerson', null, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
-                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'no', [user.id], [], function(err, group) {
+                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'no', [jack.user.id], [], function(err, group) {
                     assert.ok(!err);
 
                     RestAPI.Group.updateGroup(camAdminRestContext, group.id, {'visibility': 'loggedin'}, function(err) {
@@ -584,12 +552,12 @@ describe('Principals Activity', function() {
                         RestAPI.Group.updateGroup(camAdminRestContext, group.id, {'displayName': 'har har har'}, function(err) {
                             assert.ok(!err);
 
-                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, user.id, null, function(err, activityStream) {
+                            ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                                 assert.ok(!err);
                                 assert.ok(_getActivity(activityStream, 'group-create', 'object', group.id));
                                 assert.ok(_getActivity(activityStream, 'group-update', 'object', group.id));
                                 assert.ok(_getActivity(activityStream, 'group-update-visibility', 'object', group.id));
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -601,30 +569,19 @@ describe('Principals Activity', function() {
          * Test that verifies the group-join activity gets fired
          */
         it('verify group-join activity is delivered', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var username = TestsUtil.generateTestUserId('user');
-
-            // Create the user with which to perform setup
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
                 assert.ok(!err);
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-                // Create a user with which to create a group, then ensure the user gets the activity
-                RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Jack McJackerson', null, function(err, user) {
+                RestAPI.Group.createGroup(doer.restContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
-                    var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
-                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
+                    RestAPI.Group.joinGroup(jack.restContext, group.id, function(err) {
                         assert.ok(!err);
 
-                        RestAPI.Group.joinGroup(userRestContext, group.id, function(err) {
+                        ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
-
-                            ActivityTestsUtil.collectAndGetActivityStream(userRestContext, user.id, null, function(err, activityStream) {
-                                assert.ok(!err);
-                                assert.ok(_getActivity(activityStream, 'group-join', 'object', group.id));
-                                callback();
-                            });
+                            assert.ok(_getActivity(activityStream, 'group-join', 'object', group.id));
+                            return callback();
                         });
                     });
                 });
@@ -663,22 +620,18 @@ describe('Principals Activity', function() {
          * Test that verifies the group-add-member activity gets generated
          */
         it('verify group-add-member activity gets generated', function(callback) {
-            var username = TestsUtil.generateTestUserId('user');
-
-            // Create a user with which to create a group, then ensure the user gets the activity
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Jack McJackerson', null, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                 RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
 
                     var memberships = {};
-                    memberships[user.id] = 'member';
+                    memberships[jack.user.id] = 'member';
                     RestAPI.Group.setGroupMembers(camAdminRestContext, group.id, memberships, function(err) {
                         assert.ok(!err);
 
-                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, user.id, null, function(err, activityStream) {
+                        ActivityTestsUtil.collectAndGetActivityStream(camAdminRestContext, jack.user.id, null, function(err, activityStream) {
                             assert.ok(!err);
                             assert.ok(_getActivity(activityStream, 'group-add-member', 'target', group.id));
 
@@ -729,47 +682,32 @@ describe('Principals Activity', function() {
          * Test that verifies group-join activities aggregate.
          */
         it('verify group-join activities aggregation', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('branden');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
-                    var janeCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden', null, function(err, branden) {
+                    // Join as jane
+                    RestAPI.Group.joinGroup(jane.restContext, group.id, function(err) {
                         assert.ok(!err);
-                        var brandenCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUsername, 'password');
 
-                        RestAPI.Group.createGroup(jackCtx, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
+                        // Join as branden
+                        RestAPI.Group.joinGroup(branden.restContext, group.id, function(err) {
                             assert.ok(!err);
 
-                            // Join as jane
-                            RestAPI.Group.joinGroup(janeCtx, group.id, function(err) {
+                            // Get jack's own feed
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Join as branden
-                                RestAPI.Group.joinGroup(brandenCtx, group.id, function(err) {
-                                    assert.ok(!err);
+                                // Verify 1 for the group create, plus 1 for the aggregated group-join activities
+                                assert.equal(activityStream.items.length, 2);
 
-                                    // Get jack's own feed
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                        assert.ok(!err);
-
-                                        // Verify 1 for the group create, plus 1 for the aggregated group-join activities
-                                        assert.equal(activityStream.items.length, 2);
-
-                                        // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
-                                        var entity = activityStream.items[0].actor;
-                                        assert.ok(entity['oae:collection']);
-                                        assert.equal(entity['oae:collection'].length, 2);
-                                        callback();
-                                    });
-                                });
+                                // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
+                                var entity = activityStream.items[0].actor;
+                                assert.ok(entity['oae:collection']);
+                                assert.equal(entity['oae:collection'].length, 2);
+                                return callback();
                             });
                         });
                     });
@@ -781,48 +719,35 @@ describe('Principals Activity', function() {
          * Test that verifies group-add-member activities aggregate.
          */
         it('verify group-add-member activities aggregation', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var brandenUsername = TestsUtil.generateTestUserId('branden');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, branden) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane', null, function(err, jane) {
+                RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, brandenUsername, 'password', 'Branden', null, function(err, branden) {
+                    // Join as jane
+                    var membership = {};
+                    membership[jane.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(jack.restContext, group.id, membership, function(err) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(jackCtx, TestsUtil.generateTestGroupId('group'), TestsUtil.generateTestGroupId('group'), 'public', 'yes', [], [], function(err, group) {
+                        // Join as branden
+                        membership = {};
+                        membership[branden.user.id] = 'member';
+                        RestAPI.Group.setGroupMembers(jack.restContext, group.id, membership, function(err) {
                             assert.ok(!err);
 
-                            // Join as jane
-                            var membership = {};
-                            membership[jane.id] = 'member';
-                            RestAPI.Group.setGroupMembers(jackCtx, group.id, membership, function(err) {
+                            ActivityTestsUtil.collectAndGetActivityStream(jack.restContext, null, null, function(err, activityStream) {
                                 assert.ok(!err);
 
-                                // Join as branden
-                                membership = {};
-                                membership[branden.id] = 'member';
-                                RestAPI.Group.setGroupMembers(jackCtx, group.id, membership, function(err) {
-                                    assert.ok(!err);
+                                // Verify 1 for the group create, plus 1 for the aggregated group-add-member activities
+                                assert.equal(activityStream.items.length, 2);
 
-                                    ActivityTestsUtil.collectAndGetActivityStream(jackCtx, null, null, function(err, activityStream) {
-                                        assert.ok(!err);
-
-                                        // Verify 1 for the group create, plus 1 for the aggregated group-add-member activities
-                                        assert.equal(activityStream.items.length, 2);
-
-                                        // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
-                                        var entity = activityStream.items[0].object;
-                                        assert.ok(entity['oae:collection']);
-                                        assert.equal(entity['oae:collection'].length, 2);
-                                        callback();
-                                    });
-                                });
+                                // Verify the first is the group join, with a collection of 2 actor entities (jane and branden)
+                                var entity = activityStream.items[0].object;
+                                assert.ok(entity['oae:collection']);
+                                assert.equal(entity['oae:collection'].length, 2);
+                                return callback();
                             });
                         });
                     });
@@ -838,60 +763,46 @@ describe('Principals Activity', function() {
          * that private user information is appropriately scrubbed from the email.
          */
         it('verify group-create email and privacy', function(callback) {
-            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                var mrvisser = _.values(users)[0];
-                var simong = _.values(users)[1];
-
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the group with a user. We will ensure that user receives an email
+                    RestAPI.Group.createGroup(simong.restContext, 'emailGroupCreate', 'emailGroupCreate', 'public', 'yes', [], [mrvisser.user.id], function(err, group) {
                         assert.ok(!err);
 
-                        // Create the group with a user. We will ensure that user receives an email
-                        RestAPI.Group.createGroup(simong.restContext, 'emailGroupCreate', 'emailGroupCreate', 'public', 'yes', [], [mrvisser.user.id], function(err, group) {
-                            assert.ok(!err);
+                        // Mrvisser should get an email, with simong's information scrubbed
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                            // Mrvisser should get an email, with simong's information scrubbed
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            // There should be exactly one message, the one sent to mrvisser
+                            assert.equal(messages.length, 1);
 
-                                // There should be exactly one message, the one sent to mrvisser
-                                assert.equal(messages.length, 1);
+                            var stringMessage = JSON.stringify(messages[0]);
+                            var message = messages[0];
 
-                                var stringMessage = JSON.stringify(messages[0]);
-                                var message = messages[0];
+                            // Sanity check that the message is to mrvisser
+                            assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                // Sanity check that the message is to mrvisser
-                                assert.equal(message.to[0].address, mrvisser.user.email);
+                            // Ensure some data expected to be in the email is there
+                            assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
+                            assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
+                            assert.notEqual(stringMessage.indexOf(group.displayName), -1);
 
-                                // Ensure some data expected to be in the email is there
-                                assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
-                                assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
-                                assert.notEqual(stringMessage.indexOf(group.displayName), -1);
+                            // Ensure simong's private info is *nowhere* to be found
+                            assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
+                            assert.equal(stringMessage.indexOf(simong.user.email), -1);
+                            assert.equal(stringMessage.indexOf(simong.user.locale), -1);
 
-                                // Ensure simong's private info is *nowhere* to be found
-                                assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
-                                assert.equal(stringMessage.indexOf(simong.user.email), -1);
-                                assert.equal(stringMessage.indexOf(simong.user.locale), -1);
+                            // The message probably contains the public alias, though
+                            assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
 
-                                // The message probably contains the public alias, though
-                                assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
-
-                                callback();
-                            });
+                            return callback();
                         });
                     });
                 });
@@ -918,12 +829,10 @@ describe('Principals Activity', function() {
                 };
 
                 // Make Bert loggedin
-                RestAPI.User.updateUser(bert.restContext, bert.user.id, bertUpdate, function(err) {
-                    assert.ok(!err);
+                PrincipalsTestUtil.assertUpdateUserSucceeds(bert.restContext, bert.user.id, bertUpdate, function() {
 
                     // Make Simon private
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
-                        assert.ok(!err);
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
                         // Create the group and then share it after. We will verify the share triggered an email
                         RestAPI.Group.createGroup(mrvisser.restContext, 'emailGroupAddMember', 'emailGroupAddMember', 'public', 'yes', [], [], function(err, group) {
@@ -1038,62 +947,51 @@ describe('Principals Activity', function() {
             TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
 
-                mrvisser.user.email = TestsUtil.generateTestEmailAddress('mrvisser');
-                simong.user.email = TestsUtil.generateTestEmailAddress('simong');
-
                 // Simon is private and mrvisser is public
-                var mrvisserUpdate = {'email': mrvisser.user.email};
                 var simongUpdate = {
-                    'email': simong.user.email,
                     'visibility': 'private',
                     'publicAlias': 'swappedFromPublicAlias'
                 };
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, simongUpdate, function() {
 
-                RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, mrvisserUpdate, function(err) {
-                    assert.ok(!err);
-
-                    RestAPI.User.updateUser(simong.restContext, simong.user.id, simongUpdate, function(err) {
+                    // Create the group and then share it after. We will verify the share triggered an email
+                    RestAPI.Group.createGroup(simong.restContext, 'emailGroupAddMember', 'emailGroupAddMember', 'public', 'yes', [], [], function(err, group) {
                         assert.ok(!err);
 
-                        // Create the group and then share it after. We will verify the share triggered an email
-                        RestAPI.Group.createGroup(simong.restContext, 'emailGroupAddMember', 'emailGroupAddMember', 'public', 'yes', [], [], function(err, group) {
-                            assert.ok(!err);
+                        // Collect the createGroup activity and emails before adding a member
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                            // Collect the createGroup activity and emails before adding a member
-                            EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            var roleChanges = {};
+                            roleChanges[mrvisser.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(simong.restContext, group.id, roleChanges, function(err) {
+                                assert.ok(!err);
 
-                                var roleChanges = {};
-                                roleChanges[mrvisser.user.id] = 'member';
-                                RestAPI.Group.setGroupMembers(simong.restContext, group.id, roleChanges, function(err) {
-                                    assert.ok(!err);
+                                // Mrvisser should get an email, with simong's information scrubbed
+                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
 
-                                    // Mrvisser should get an email, with simong's information scrubbed
-                                    EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                    // There should be exactly one message, the one sent to mrvisser
+                                    assert.equal(messages.length, 1);
 
-                                        // There should be exactly one message, the one sent to mrvisser
-                                        assert.equal(messages.length, 1);
+                                    var stringMessage = JSON.stringify(messages[0]);
+                                    var message = messages[0];
 
-                                        var stringMessage = JSON.stringify(messages[0]);
-                                        var message = messages[0];
+                                    // Sanity check that the message is to mrvisser
+                                    assert.equal(message.to[0].address, mrvisser.user.email);
 
-                                        // Sanity check that the message is to mrvisser
-                                        assert.equal(message.to[0].address, mrvisser.user.email);
+                                    // Ensure some data expected to be in the email is there
+                                    assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
+                                    assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
+                                    assert.notEqual(stringMessage.indexOf(group.displayName), -1);
 
-                                        // Ensure some data expected to be in the email is there
-                                        assert.notEqual(stringMessage.indexOf(simong.restContext.hostHeader), -1);
-                                        assert.notEqual(stringMessage.indexOf(group.profilePath), -1);
-                                        assert.notEqual(stringMessage.indexOf(group.displayName), -1);
+                                    // Ensure simong's private info is *nowhere* to be found
+                                    assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
+                                    assert.equal(stringMessage.indexOf(simong.user.email), -1);
+                                    assert.equal(stringMessage.indexOf(simong.user.locale), -1);
 
-                                        // Ensure simong's private info is *nowhere* to be found
-                                        assert.equal(stringMessage.indexOf(simong.user.displayName), -1);
-                                        assert.equal(stringMessage.indexOf(simong.user.email), -1);
-                                        assert.equal(stringMessage.indexOf(simong.user.locale), -1);
+                                    // The message probably contains the public alias, though
+                                    assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
 
-                                        // The message probably contains the public alias, though
-                                        assert.notEqual(stringMessage.indexOf('swappedFromPublicAlias'), -1);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-principals/tests/test-dao.js
+++ b/node_modules/oae-principals/tests/test-dao.js
@@ -32,12 +32,7 @@ describe('Principals DAO', function() {
     before(function(callback) {
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
-
-        // Log in the tenant admin so their cookie jar is set up appropriately
-        RestAPI.User.getMe(camAdminRestContext, function(err, meObj) {
-            assert.ok(!err);
-            callback();
-        });
+        return callback();
     });
 
 
@@ -68,7 +63,7 @@ describe('Principals DAO', function() {
                     assert.ok(!err);
 
                     // Create one new one, and ensure the new number of principals is numPrincipalsOrig + 1
-                    RestAPI.User.createUser(camAdminRestContext, testUsername, 'password', 'test-create-displayName', null, function(err, createdUser) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, createdUser) {
                         assert.ok(!err);
 
                         var numPrincipalsAfter = 0;
@@ -79,7 +74,7 @@ describe('Principals DAO', function() {
                             if (principalRows) {
                                 numPrincipalsAfter += principalRows.length;
                                 _.each(principalRows, function(principalRow) {
-                                    if (principalRow.principalId === createdUser.id) {
+                                    if (principalRow.principalId === createdUser.user.id) {
                                         hasNewPrincipal = true;
                                     }
                                 });

--- a/node_modules/oae-principals/tests/test-emails.js
+++ b/node_modules/oae-principals/tests/test-emails.js
@@ -1,0 +1,853 @@
+/*
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+var assert = require('assert');
+var fs = require('fs');
+var util = require('util');
+
+var AuthenticationTestUtil = require('oae-authentication/lib/test/util');
+var ConfigTestUtil = require('oae-config/lib/test/util');
+var EmailTestsUtil = require('oae-email/lib/test/util');
+var RestAPI = require('oae-rest');
+var TenantsTestUtil = require('oae-tenants/lib/test/util');
+var TestsUtil = require('oae-tests');
+
+var PrincipalsAPI = require('oae-principals');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
+
+
+describe('User emails', function() {
+
+    // REST contexts we can use to do REST requests
+    var camAdminRestContext = null;
+    var gtAdminRestContext = null;
+    var anonymousRestContext = null;
+    var globalAdminRestContext = null;
+
+    beforeEach(function(callback) {
+        anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+        camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+        gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
+        globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
+
+        // Disable reCaptcha so anonymous users can create accounts
+        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-principals/recaptcha/enabled': false}, function(err) {
+            assert.ok(!err);
+
+            // Drain the email queue
+            return EmailTestsUtil.clearEmailCollections(callback);
+        });
+    });
+
+    after(function(callback) {
+        // Re-enable reCaptcha
+        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-principals/recaptcha/enabled': true}, function(err) {
+            assert.ok(!err);
+            return callback();
+        });
+    });
+
+    describe('Verification', function() {
+
+        /**
+         * Test that verifies validation when verifying an email address
+         */
+        it('verify validation when verifying an email address', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+            PrincipalsTestUtil.assertCreateUserSucceeds(restContext, params, function(user, token) {
+                AuthenticationTestUtil.assertLocalLoginSucceeds(restContext, params.username, params.password, function() {
+
+                    // Invalid user id
+                    PrincipalsTestUtil.assertVerifyEmailFails(restContext, 'not a user id', token, 400, function() {
+
+                        // Missing token
+                        PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, null, 400, function() {
+
+                            // Invalid token
+                            PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, 'more than [7-14] characters', 400, function() {
+
+                                // Incorrect token
+                                PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, '123456789', 401, function() {
+
+                                    // Sanity-check
+                                    PrincipalsTestUtil.assertVerifyEmailSucceeds(restContext, user.id, token, function() {
+
+                                        // A token can only be verified once
+                                        PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, token, 404, function() {
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies authorization when verifying an email address
+         */
+        it('verify authorization when verifying an email address', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+            PrincipalsTestUtil.assertCreateUserSucceeds(restContext, params, function(user, token) {
+
+                // Anonymous users cannot verify an email address
+                PrincipalsTestUtil.assertVerifyEmailFails(anonymousRestContext, user.id, token, 401, function() {
+
+                    // Other users cannot verify an email address
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, badGuy) {
+                        assert.ok(!err);
+                        PrincipalsTestUtil.assertVerifyEmailFails(badGuy.restContext, user.id, token, 401, function() {
+
+                            // Tenant admins from other tenants cannot verify an email address
+                            PrincipalsTestUtil.assertVerifyEmailFails(gtAdminRestContext, user.id, token, 401, function() {
+
+                                // The user can verify their email address if they've signed in
+                                AuthenticationTestUtil.assertLocalLoginSucceeds(restContext, params.username, params.password, function() {
+                                    PrincipalsTestUtil.assertVerifyEmailSucceeds(restContext, user.id, token, function() {
+                                        return callback();
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that a token from another user cannot be used
+         */
+        it('verify a token from another user cannot be used', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var paramsUser1 = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': TestsUtil.generateTestEmailAddress()
+            };
+            var restContextUser1 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+            PrincipalsTestUtil.assertCreateUserSucceeds(restContextUser1, paramsUser1, function(user1, tokenUser1) {
+                AuthenticationTestUtil.assertLocalLoginSucceeds(restContextUser1, paramsUser1.username, 'password', function() {
+                    var paramsUser2 = {
+                        'username': TestsUtil.generateTestUserId(),
+                        'password': 'password',
+                        'displayName': TestsUtil.generateRandomText(1),
+                        'email': TestsUtil.generateTestEmailAddress()
+                    };
+                    var restContextUser2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+                    PrincipalsTestUtil.assertCreateUserSucceeds(restContextUser2, paramsUser2, function(user2, tokenUser2) {
+                        AuthenticationTestUtil.assertLocalLoginSucceeds(restContextUser2, paramsUser2.username, 'password', function() {
+
+                            // Assert we cannot user the token from the first user
+                            PrincipalsTestUtil.assertVerifyEmailFails(restContextUser2, user2.id, tokenUser1, 401, function() {
+                                return callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that an email address can be re-used by other users
+         */
+        it('verify an email address can be re-used by other users', function(callback) {
+            var tenantAlias = TenantsTestUtil.generateTestTenantAlias();
+            var tenantHost = tenantAlias + '.oae.com';
+            TestsUtil.createTenantWithAdmin(tenantAlias, tenantHost, function(err, tenant, tenantAdminRestContext, tenantAdmin) {
+                assert.ok(!err);
+
+                // Disable reCaptcha for this tenant
+                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAlias, {'oae-principals/recaptcha/enabled': false}, function(err) {
+                    assert.ok(!err);
+
+                    var username1 = TestsUtil.generateTestUserId();
+                    var username2 = TestsUtil.generateTestUserId();
+                    var email = TestsUtil.generateTestEmailAddress();
+                    var paramsUser1 = {
+                        'displayName': 'Test user 1',
+                        'email': email,
+                        'password': 'password',
+                        'username': TestsUtil.generateTestUserId()
+                    };
+                    var paramsUser2 = {
+                        'displayName': 'Test user 2',
+                        'email': email,
+                        'password': 'password',
+                        'username': TestsUtil.generateTestUserId()
+                    };
+
+                    // Create the first user as a tenant admin so the email address is considered verified
+                    PrincipalsTestUtil.assertCreateUserSucceeds(tenantAdminRestContext, paramsUser1, function(user1) {
+
+                        // Verify there's a mapping for the first user
+                        PrincipalsTestUtil.assertUserEmailMappingEquals(email, [user1.id], function() {
+
+                            // Create the second user as an anonymous user so the email address is not verified
+                            var restContext = TestsUtil.createTenantRestContext(tenantHost);
+                            PrincipalsTestUtil.assertCreateUserSucceeds(restContext, paramsUser2, function(user2, token) {
+
+                                // Verify there's no mapping yet for the second user as the email address
+                                // hasn't been verified yet
+                                PrincipalsTestUtil.assertUserEmailMappingEquals(email, [user1.id], function() {
+
+                                    // Verify the email address
+                                    AuthenticationTestUtil.assertLocalLoginSucceeds(restContext, paramsUser2.username, paramsUser2.password, function() {
+                                        PrincipalsTestUtil.assertVerifyEmailSucceeds(restContext, user2.id, token, function() {
+
+                                            // The second user should now also be mapped to the email address
+                                            PrincipalsTestUtil.assertUserEmailMappingEquals(email, [user1.id, user2.id], function() {
+                                                return callback();
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that local accounts need to verify their email address
+         */
+        it('verify local user accounts need to verify their email address', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            PrincipalsTestUtil.assertCreateUserSucceeds(anonymousRestContext, params, function(user, token) {
+
+                // Sanity check the user has no `email` property yet
+                RestAPI.User.getUser(camAdminRestContext, user.id, function(err, user) {
+                    assert.ok(!err);
+                    assert.ok(!user.email);
+
+                    // Assert that there's no mapping yet for the email address
+                    PrincipalsTestUtil.assertUserEmailMappingEquals(email, [], function() {
+
+                        // Verify the email address
+                        var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+                        AuthenticationTestUtil.assertLocalLoginSucceeds(restContext, params.username, params.password, function() {
+                            PrincipalsTestUtil.assertVerifyEmailSucceeds(restContext, user.id, token, function() {
+
+                                // Assert the mapping has been created
+                                PrincipalsTestUtil.assertUserEmailMappingEquals(email, [user.id], function() {
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that activity emails are not sent to unverified email addresses
+         */
+        it('verify activity emails are not sent to unverified email addresses', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            PrincipalsTestUtil.assertCreateUserSucceeds(anonymousRestContext, params, function(user, token) {
+
+                // Generate some more users who will be part of the activity
+                TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, simong, mrvisser) {
+                    assert.ok(!err);
+
+                    RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [user.id, mrvisser.user.id], [], function(err, link) {
+                        assert.ok(!err);
+
+                        // Mrvisser should've received an email, but not the user with the unverified email address
+                        EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                            assert.equal(messages.length, 1);
+                            assert.strictEqual(messages[0].to.length, 1);
+                            assert.equal(messages[0].to[0].address, mrvisser.user.email);
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that local users accounts created by a tenant administrator do not need to verify their email address
+         */
+        it('verify local user accounts created by a tenant administrator do not need to verify their email address', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            PrincipalsTestUtil.assertCreateUserSucceeds(camAdminRestContext, params, function(user) {
+
+                // Verify the user doesn't need to verify their email address
+                RestAPI.User.getUser(camAdminRestContext, user.id, function(err, user) {
+                    assert.ok(!err);
+                    assert.strictEqual(user.email, email.toLowerCase());
+
+                    // Assert that there's a mapping for the email address
+                    PrincipalsTestUtil.assertUserEmailMappingEquals(email, [user.id], function() {
+                        return callback();
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that user accounts created through trusted external SSO sources do not need to verify their email address
+         */
+        it('verify user accounts created through trusted external SSO sources do not need to verify their email address', function(callback) {
+            // Create a tenant and enable google authentication on it
+            var tenantAlias = TenantsTestUtil.generateTestTenantAlias();
+            var tenantHost = tenantAlias + '.oae.com';
+            TestsUtil.createTenantWithAdmin(tenantAlias, tenantHost, function(err, tenant, tenantAdminRestContext) {
+                assert.ok(!err);
+                AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(tenantAdminRestContext, null, {'oae-authentication/google/enabled': true}, function() {
+
+                    // Sign in through google
+                    var email = TestsUtil.generateTestEmailAddress();
+                    AuthenticationTestUtil.assertGoogleLoginSucceeds(tenant.host, email, function(restContext, response) {
+
+                        // As google is considered an authoritative source, the user shouldn't have
+                        // to verify their email address
+                        RestAPI.User.getMe(restContext, function(err, me) {
+                            assert.ok(!err);
+                            assert.ok(!me.anon);
+                            assert.strictEqual(me.email, email.toLowerCase());
+
+                            // Assert that there's a mapping for the email address
+                            PrincipalsTestUtil.assertUserEmailMappingEquals(email, [me.id], function() {
+                                return callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Return a function that gets a stream to a file in the 'data' directory of the current test directory
+         *
+         * @param  {String}     filename    The name of the file in the test data directory to be loaded
+         * @return {Function}               A function that, when executed without parameters, returns a stream to the file in the test data directory with the provided filename
+         */
+        var getDataFileStream = function(filename) {
+            return function() {
+                return fs.createReadStream(util.format('%s/data/%s', __dirname, filename));
+            };
+        };
+
+        /**
+         * Test that verifies that user accounts created or updated through a CSV import do not need to verify their email address
+         */
+        it('verify user accounts created or updated through a CSV import do not need to verify their email address', function(callback) {
+            var tenantAlias = TenantsTestUtil.generateTestTenantAlias();
+            var tenantHost = tenantAlias + '.oae.com';
+            TestsUtil.createTenantWithAdmin(tenantAlias, tenantHost, function(err, tenant, tenantAdminRestContext) {
+                assert.ok(!err);
+
+                // Import users as a global admin using a local authentication strategy
+                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-emails.csv'), 'local', null, function(err) {
+                    assert.ok(!err);
+
+                    // Verify the user's email address is verified
+                    var restContext = TestsUtil.createTenantRestContext(tenant.host, 'users-emails-abc123', 'password');
+                    RestAPI.User.getMe(restContext, function(err, user) {
+                        assert.ok(!err);
+                        assert.strictEqual(user.email, 'foo@users.emails.com');
+
+                        // Assert there's a mapping for the email address
+                        PrincipalsTestUtil.assertUserEmailMappingEquals('foo@users.emails.com', [user.id], function() {
+
+                            // Update the email address through a CSV import
+                            PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-emails-updated.csv'), 'local', true, function(err) {
+                                assert.ok(!err);
+
+                                RestAPI.User.getMe(restContext, function(err, user) {
+                                    assert.ok(!err);
+                                    assert.strictEqual(user.email, 'bar@users.emails.com');
+
+                                    // Assert there's a mapping for the new email address
+                                    PrincipalsTestUtil.assertUserEmailMappingEquals('bar@users.emails.com', [user.id], function() {
+
+                                        // Assert there's no mapping for the old email address
+                                        PrincipalsTestUtil.assertUserEmailMappingEquals('foo@users.emails.com', [], function() {
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that users updating their email address need to verify it
+         */
+        it('verify users updating their email address need to verify it', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+                var oldEmailAddress = simong.user.email;
+
+                // Sanity-check the email address is verified
+                RestAPI.User.getMe(simong.restContext, function(err, me) {
+                    assert.ok(!err);
+                    assert.strictEqual(me.email, oldEmailAddress);
+
+                    // Sanity-check there's a mapping for it
+                    PrincipalsTestUtil.assertUserEmailMappingEquals(me.email, [me.id], function() {
+
+                        // Update the email address
+                        var email = TestsUtil.generateTestEmailAddress();
+                        PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function(user, token) {
+
+                            // Assert the old mapping is still in place
+                            PrincipalsTestUtil.assertUserEmailMappingEquals(oldEmailAddress, [me.id], function() {
+
+                                // Assert there's no mapping for the new email address as it hasn't been verified yet
+                                PrincipalsTestUtil.assertUserEmailMappingEquals(email, [], function() {
+
+                                    // The old email address should still be in place as the new one hasn't been verified yet
+                                    RestAPI.User.getMe(simong.restContext, function(err, me) {
+                                        assert.ok(!err);
+                                        assert.strictEqual(me.email, oldEmailAddress);
+
+                                        // Assert we can verify the email address
+                                        PrincipalsTestUtil.assertVerifyEmailSucceeds(simong.restContext, simong.user.id, token, function() {
+
+                                            // Assert the old mapping is gone
+                                            PrincipalsTestUtil.assertUserEmailMappingEquals(oldEmailAddress, [], function() {
+
+                                                // Assert the new mapping is there
+                                                PrincipalsTestUtil.assertUserEmailMappingEquals(email, [me.id], function() {
+
+                                                    // The new email address should be confirmed
+                                                    RestAPI.User.getMe(simong.restContext, function(err, me) {
+                                                        assert.ok(!err);
+                                                        assert.strictEqual(me.email, email.toLowerCase());
+                                                        return callback();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that admin updates to a user's email address trigger a different email message
+         */
+        it('verify admin updates to a user\'s email address trigger a different email message', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+                var oldEmailAddress = simong.user.email;
+
+                // Let an administrator update the email address
+                var email = TestsUtil.generateTestEmailAddress();
+                PrincipalsTestUtil.assertUpdateUserSucceeds(camAdminRestContext, simong.user.id, {'email': email}, function(user, token) {
+
+                    // The email address still has to be verified
+                    assert.strictEqual(user.email, oldEmailAddress);
+                    return callback();
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that users can only verify their last updated email address
+         */
+        it('verify users can only verify their last updated email address', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+                var oldEmailAddress = simong.user.email;
+
+                // Update the email address for the first time
+                var email1 = TestsUtil.generateTestEmailAddress();
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email1}, function(user, token1) {
+
+                    // Update the email address again (with a second email address)
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email2}, function(user, token2) {
+
+                        // Using the first token to verify the email address should fail
+                        PrincipalsTestUtil.assertVerifyEmailFails(simong.restContext, simong.user.id, token1, 401, function() {
+
+                            // Using the second token we can verify the email address
+                            PrincipalsTestUtil.assertVerifyEmailSucceeds(simong.restContext, simong.user.id, token2, function() {
+
+                                // Assert the old mapping is gone
+                                PrincipalsTestUtil.assertUserEmailMappingEquals(oldEmailAddress, [], function() {
+
+                                    // Assert no mapping was created for the first email address
+                                    PrincipalsTestUtil.assertUserEmailMappingEquals(email1, [], function() {
+
+                                        // Assert a mapping for the second email address is created
+                                        PrincipalsTestUtil.assertUserEmailMappingEquals(email2, [simong.user.id], function() {
+
+                                            // The second email address should be confirmed
+                                            RestAPI.User.getMe(simong.restContext, function(err, me) {
+                                                assert.ok(!err);
+                                                assert.strictEqual(me.email, email2.toLowerCase());
+                                                return callback();
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Resending an email verification token', function() {
+
+        /**
+         * Test that verifies that an email verification token can be resent
+         */
+        it('verify an email verification token can be resent', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+            PrincipalsTestUtil.assertCreateUserSucceeds(restContext, params, function(user, token) {
+                RestAPI.Authentication.login(restContext, params.username, 'password', function(err) {
+                    assert.ok(!err);
+
+                    // Verify we can resend the email verification token
+                    PrincipalsTestUtil.assertResendEmailTokenSucceeds(restContext, user.id, function(newToken) {
+                        // Assert we've sent the same token
+                        assert.strictEqual(newToken, token);
+
+                        // Sanity-check we can use this new token to verify the email address
+                        PrincipalsTestUtil.assertVerifyEmailSucceeds(restContext, user.id, newToken, function() {
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies validation when resending an email verification token
+         */
+        it('verify validation when resending an email verification token', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+            PrincipalsTestUtil.assertCreateUserSucceeds(restContext, params, function(user, token) {
+                RestAPI.Authentication.login(restContext, params.username, 'password', function(err) {
+                    assert.ok(!err);
+
+                    // Invalid user id
+                    PrincipalsTestUtil.assertResendEmailTokenFails(restContext, 'not a user id', 400, function() {
+                        return callback();
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies authorization when resending an email verification token
+         */
+        it('verify authorization when resending an email verification token', function(callback) {
+            // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
+            var email = TestsUtil.generateTestEmailAddress();
+            var params = {
+                'username': TestsUtil.generateTestUserId(),
+                'password': 'password',
+                'displayName': TestsUtil.generateRandomText(1),
+                'email': email
+            };
+            var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+            PrincipalsTestUtil.assertCreateUserSucceeds(restContext, params, function(user, token) {
+                RestAPI.Authentication.login(restContext, params.username, 'password', function(err) {
+                    assert.ok(!err);
+
+                    // Anonymous users can't resend a token
+                    PrincipalsTestUtil.assertResendEmailTokenFails(anonymousRestContext, user.id, 401, function() {
+
+                        // Users cannot resend a token for someone else
+                        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, otherUser) {
+                            assert.ok(!err);
+                            PrincipalsTestUtil.assertResendEmailTokenFails(otherUser.restContext, user.id, 401, function() {
+
+                                // Tenant administrators from another tenant cannot resend a token
+                                PrincipalsTestUtil.assertResendEmailTokenFails(gtAdminRestContext, user.id, 401, function() {
+
+                                    // Tenant administrators from the same tenant as the user can resend a token
+                                    PrincipalsTestUtil.assertResendEmailTokenSucceeds(camAdminRestContext, user.id, function(newToken) {
+
+                                        // Global administrators can resend a token
+                                        PrincipalsTestUtil.assertResendEmailTokenSucceeds(globalAdminRestContext, user.id, function(newToken) {
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that a token can only be resent when there is a pending verification
+         */
+        it('verify that a token can only be resent when there is a pending verification', function(callback) {
+            // Create a user who has no pending email verification token
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+
+                // Resending a token should fail as there is no token to resend
+                PrincipalsTestUtil.assertResendEmailTokenFails(simong.restContext, simong.user.id, 404, function() {
+
+                    // Update the email address so we get a token
+                    var email = TestsUtil.generateTestEmailAddress();
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function(user, token) {
+
+                        // Resending a token now should be OK
+                        PrincipalsTestUtil.assertResendEmailTokenSucceeds(simong.restContext, simong.user.id, function(newToken) {
+
+                            // Use the token to verify the new email address
+                            PrincipalsTestUtil.assertVerifyEmailSucceeds(simong.restContext, simong.user.id, newToken, function() {
+
+                                // Resending a token should now fail as the token has been used and should be removed
+                                PrincipalsTestUtil.assertResendEmailTokenFails(simong.restContext, simong.user.id, 404, function() {
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Has pending email verification token', function() {
+
+        /**
+         * Test that verifies the has pending email verification token functionality
+         */
+        it('verify has pending email verification token functionality', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+
+                // Verify the user has no token
+                PrincipalsTestUtil.assertGetEmailTokenFails(simong.restContext, simong.user.id, 404, function() {
+
+                    // Update the email address
+                    var email = TestsUtil.generateTestEmailAddress();
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
+
+                        // Verify the user as a token
+                        PrincipalsTestUtil.assertGetEmailTokenSucceeds(simong.restContext, simong.user.id, function(emailForToken) {
+                            assert.strictEqual(emailForToken, email.toLowerCase());
+
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies validation when checking for a pending email verification token
+         */
+        it('verify validation when checking for a pending email verification token', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+
+                // Invalid user id
+                PrincipalsTestUtil.assertGetEmailTokenFails(simong.restContext, 'not a user id', 400, function() {
+                    PrincipalsTestUtil.assertGetEmailTokenFails(simong.restContext, 'g:camtest:1234234', 400, function() {
+                        return callback();
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies authorization when checking for a pending email verification token
+         */
+        it('verify authorization when checking for a pending email verification token', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, simong, mrvisser) {
+                assert.ok(!err);
+
+                // Update simon's email address so he has a verification token
+                var email = TestsUtil.generateTestEmailAddress();
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
+
+                    // Anonymous users cannot check anything
+                    PrincipalsTestUtil.assertGetEmailTokenFails(anonymousRestContext, simong.user.id, 401, function() {
+
+                        // Users cannot check other users their email tokens
+                        PrincipalsTestUtil.assertGetEmailTokenFails(mrvisser.restContext, simong.user.id, 401, function() {
+
+                            // Tenant administrator cannot check users from another tenant their email token
+                            PrincipalsTestUtil.assertGetEmailTokenFails(gtAdminRestContext, simong.user.id, 401, function() {
+
+                                // A user can check his own pending email verification token
+                                PrincipalsTestUtil.assertGetEmailTokenSucceeds(simong.restContext, simong.user.id, function(emailForToken) {
+
+                                    // A tenant admin can check the pending email verification token for users of their tenant
+                                    PrincipalsTestUtil.assertGetEmailTokenSucceeds(camAdminRestContext, simong.user.id, function(emailForToken) {
+                                        return callback();
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Delete an email verification token', function() {
+
+        /**
+         * Test that verifies the delete email verification functionality
+         */
+        it('verify delete email verification token functionality', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+
+                // Update the email address
+                var email = TestsUtil.generateTestEmailAddress();
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
+
+                    // Delete the token
+                    PrincipalsTestUtil.assertDeleteEmailTokenSucceeds(simong.restContext, simong.user.id, function() {
+
+                        // Verify a token can't be deleted twice
+                        PrincipalsTestUtil.assertDeleteEmailTokenFails(simong.restContext, simong.user.id, 404, function() {
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies validation when deleting a pending email verification token
+         */
+        it('verify validation when deleting a pending email verification token', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
+                assert.ok(!err);
+
+                // Invalid user id
+                PrincipalsTestUtil.assertDeleteEmailTokenFails(simong.restContext, 'not a user id', 400, function() {
+                    PrincipalsTestUtil.assertDeleteEmailTokenFails(simong.restContext, 'g:camtest:1234234', 400, function() {
+
+                        // No token should return a 404
+                        PrincipalsTestUtil.assertDeleteEmailTokenFails(simong.restContext, simong.user.id, 404, function() {
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies authorization when deleting a pending email verification token
+         */
+        it('verify authorization when deleting a pending email verification token', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, simong, mrvisser) {
+                assert.ok(!err);
+
+                // Update simon's email address so he has a verification token
+                var email = TestsUtil.generateTestEmailAddress();
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
+
+                    // Anonymous users cannot delete anything
+                    PrincipalsTestUtil.assertDeleteEmailTokenFails(anonymousRestContext, simong.user.id, 401, function() {
+
+                        // Users cannot delete other users their email tokens
+                        PrincipalsTestUtil.assertDeleteEmailTokenFails(mrvisser.restContext, simong.user.id, 401, function() {
+
+                            // Tenant administrator cannot delete users from another tenant their email token
+                            PrincipalsTestUtil.assertDeleteEmailTokenFails(gtAdminRestContext, simong.user.id, 401, function() {
+
+                                // A user can delete his own pending email verification token
+                                PrincipalsTestUtil.assertDeleteEmailTokenSucceeds(simong.restContext, simong.user.id, function(emailForToken) {
+
+                                    email = TestsUtil.generateTestEmailAddress();
+                                    PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
+                                        // A tenant admin can delete the pending email verification token for users of their tenant
+                                        PrincipalsTestUtil.assertDeleteEmailTokenSucceeds(camAdminRestContext, simong.user.id, function(emailForToken) {
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/node_modules/oae-principals/tests/test-emails.js
+++ b/node_modules/oae-principals/tests/test-emails.js
@@ -77,22 +77,16 @@ describe('User emails', function() {
             var restContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
             PrincipalsTestUtil.assertCreateUserSucceeds(restContext, params, function(user, token) {
                 AuthenticationTestUtil.assertLocalLoginSucceeds(restContext, params.username, params.password, function() {
-
                     // Invalid user id
                     PrincipalsTestUtil.assertVerifyEmailFails(restContext, 'not a user id', token, 400, function() {
-
                         // Missing token
                         PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, null, 400, function() {
-
                             // Invalid token
                             PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, 'more than [7-14] characters', 400, function() {
-
                                 // Incorrect token
                                 PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, '123456789', 401, function() {
-
                                     // Sanity-check
                                     PrincipalsTestUtil.assertVerifyEmailSucceeds(restContext, user.id, token, function() {
-
                                         // A token can only be verified once
                                         PrincipalsTestUtil.assertVerifyEmailFails(restContext, user.id, token, 404, function() {
                                             return callback();
@@ -697,8 +691,9 @@ describe('User emails', function() {
             TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, simong) {
                 assert.ok(!err);
 
-                // Verify the user has no token
-                PrincipalsTestUtil.assertGetEmailTokenFails(simong.restContext, simong.user.id, 404, function() {
+                // Verify no email is returned when the user has no pending verification
+                PrincipalsTestUtil.assertGetEmailTokenSucceeds(simong.restContext, simong.user.id, function(email) {
+                    assert.ok(!email);
 
                     // Update the email address
                     var email = TestsUtil.generateTestEmailAddress();

--- a/node_modules/oae-principals/tests/test-emails.js
+++ b/node_modules/oae-principals/tests/test-emails.js
@@ -695,8 +695,8 @@ describe('User emails', function() {
                 PrincipalsTestUtil.assertGetEmailTokenSucceeds(simong.restContext, simong.user.id, function(email) {
                     assert.ok(!email);
 
-                    // Update the email address
-                    var email = TestsUtil.generateTestEmailAddress();
+                    // Update the user's email address
+                    email = TestsUtil.generateTestEmailAddress();
                     PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
 
                         // Verify the user as a token

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -65,22 +65,18 @@ describe('Groups', function() {
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
 
         // Create the REST context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
             assert.ok(!err);
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            RestAPI.User.getMe(johnRestContext, function(err) {
+            johnRestContext = john.restContext;
+
+            // Add the full user id onto the REST context for use inside of this test
+            johnRestContext.user = john.user;
+
+            // Create the REST context for a global admin who is authenticated to a user tenant
+            RestAPI.Admin.loginOnTenant(TestsUtil.createGlobalAdminRestContext(), 'localhost', null, function(err, ctx) {
                 assert.ok(!err);
-
-                // Add the full user id onto the REST context for use inside of this test
-                johnRestContext.id = createdUser.id;
-
-                // Create the REST context for a global admin who is authenticated to a user tenant
-                RestAPI.Admin.loginOnTenant(TestsUtil.createGlobalAdminRestContext(), 'localhost', null, function(err, ctx) {
-                    assert.ok(!err);
-                    globalAdminOnTenantRestContext = ctx;
-                    return callback();
-                });
+                globalAdminOnTenantRestContext = ctx;
+                return callback();
             });
         });
     });
@@ -315,31 +311,27 @@ describe('Groups', function() {
          * Test that verifies that a list of members and meanagers can be passed in during group creation
          */
         it('verify that members can be specified on group creation', function(callback) {
-            // Create 2 users.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
-                    assert.ok(!err);
 
-                    RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.id], [jack.id], function(err, groupObj) {
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.user.id], [jack.user.id], function(err, groupObj) {
+                    assert.ok(!err);
+                    assert.ok(groupObj.id);
+                    assert.equal(groupObj.displayName, 'Group title');
+                    assert.equal(groupObj.resourceType, 'group');
+                    assert.equal(groupObj.profilePath, '/group/' + groupObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupObj.id).resourceId);
+
+                    // Get the members of this group
+                    RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, undefined, undefined, function(err, members) {
                         assert.ok(!err);
-                        assert.ok(groupObj.id);
-                        assert.equal(groupObj.displayName, 'Group title');
-                        assert.equal(groupObj.resourceType, 'group');
-                        assert.equal(groupObj.profilePath, '/group/' + groupObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupObj.id).resourceId);
-                        // Get the members of this group.
-                        RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, undefined, undefined, function(err, members) {
-                            assert.ok(!err);
-                            assert.equal(members.results.length, 3);
-                            // Morph results to hash for easy access.
-                            var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
-                            assert.equal(hash[jack.id][0].role, 'member');
-                            assert.equal(hash[jane.id][0].role, 'manager');
-                            assert.equal(hash[johnRestContext.id][0].role, 'manager');
-                            return callback();
-                        });
+                        assert.equal(members.results.length, 3);
+
+                        // Morph results to hash for easy access
+                        var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
+                        assert.equal(hash[jack.user.id][0].role, 'member');
+                        assert.equal(hash[jane.user.id][0].role, 'manager');
+                        assert.equal(hash[johnRestContext.user.id][0].role, 'manager');
+                        return callback();
                     });
                 });
             });
@@ -368,7 +360,7 @@ describe('Groups', function() {
                         assert.equal(fetchedGroup.visibility, 'private');
                         assert.equal(fetchedGroup.joinable, 'request');
                         assert.equal(fetchedGroup.createdBy.id.substr(0, 10), 'u:camtest:');
-                        assert.equal(fetchedGroup.createdBy.displayName, 'John Doe');
+                        assert.equal(fetchedGroup.createdBy.displayName, johnRestContext.user.displayName);
                         assert.ok(fetchedGroup.created);
                         assert.equal(fetchedGroup.resourceType, 'group');
                         assert.equal(createdGroup.profilePath, '/group/' + createdGroup.tenant.alias + '/' + AuthzUtil.getResourceFromId(createdGroup.id).resourceId);
@@ -444,64 +436,48 @@ describe('Groups', function() {
          * group profile in different situations
          */
         it('verify isMember and isManager', function(callback) {
-            // Create 3 users.
-            // We'll make jane a group manager and jack a group member
-            // Joe won't be a member of the group.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            var joeUserId = TestsUtil.generateTestUserId('joe');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            // Create 3 users. We'll make jane a group manager and jack a group
+            // member. Joe won't be a member of the group
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, joe) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Create a group in which Jane is a manager and Jack is a member
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.user.id], [jack.user.id], function(err, newGroup) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, joeUserId, 'password', 'Joe Doe', null, function(err, joe) {
+                    // For each of the users, check the appropriate value of the isMember and isManager property
+                    RestAPI.Group.getGroup(johnRestContext, newGroup.id, function(err, groupData) {
                         assert.ok(!err);
-                        var joeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, joeUserId, 'password');
+                        assert.ok(groupData.isMember);
+                        assert.ok(groupData.isManager);
 
-                        // Create a group in which Jane is a manager and Jack is a member
-                        RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [jane.id], [jack.id], function(err, newGroup) {
+                        RestAPI.Group.getGroup(jack.restContext, newGroup.id, function(err, groupData) {
                             assert.ok(!err);
+                            assert.ok(groupData.isMember);
+                            assert.ok(!groupData.isManager);
 
-                            // For each of the users, check the appropriate value of the isMember and isManager property
-                            RestAPI.Group.getGroup(johnRestContext, newGroup.id, function(err, groupData) {
+                            RestAPI.Group.getGroup(jane.restContext, newGroup.id, function(err, groupData) {
                                 assert.ok(!err);
                                 assert.ok(groupData.isMember);
                                 assert.ok(groupData.isManager);
 
-                                RestAPI.Group.getGroup(jackRestContext, newGroup.id, function(err, groupData) {
+                                RestAPI.Group.getGroup(joe.restContext, newGroup.id, function(err, groupData) {
                                     assert.ok(!err);
-                                    assert.ok(groupData.isMember);
+                                    assert.ok(!groupData.isMember);
                                     assert.ok(!groupData.isManager);
 
-                                    RestAPI.Group.getGroup(janeRestContext, newGroup.id, function(err, groupData) {
+                                    // Tenant admins are considered members and managers.
+                                    RestAPI.Group.getGroup(camAdminRestContext, newGroup.id, function(err, groupData) {
                                         assert.ok(!err);
                                         assert.ok(groupData.isMember);
                                         assert.ok(groupData.isManager);
 
-                                        RestAPI.Group.getGroup(joeRestContext, newGroup.id, function(err, groupData) {
+                                        // Verify another tenant admin is not a manager or member.
+                                        RestAPI.Group.getGroup(gtAdminRestContext, newGroup.id, function(err, groupData) {
                                             assert.ok(!err);
                                             assert.ok(!groupData.isMember);
                                             assert.ok(!groupData.isManager);
-
-                                            // Tenant admins are considered members and managers.
-                                            RestAPI.Group.getGroup(camAdminRestContext, newGroup.id, function(err, groupData) {
-                                                assert.ok(!err);
-                                                assert.ok(groupData.isMember);
-                                                assert.ok(groupData.isManager);
-
-                                                // Verify another tenant admin is not a manager or member.
-                                                RestAPI.Group.getGroup(gtAdminRestContext, newGroup.id, function(err, groupData) {
-                                                    assert.ok(!err);
-                                                    assert.ok(!groupData.isMember);
-                                                    assert.ok(!groupData.isManager);
-                                                    return callback();
-                                                });
-                                            });
+                                            return callback();
                                         });
                                     });
                                 });
@@ -957,34 +933,26 @@ describe('Groups', function() {
          */
         it('verify updating as a non-manager is not allowed', function(callback) {
             // We create 2 users. Jack will be a member, Jane will not be a member
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Create the group with Jack as a member
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'private', 'request', [], [jack.user.id], function(err, newGroup) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
 
-                    // Create the group with Jack as a member
-                    RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'private', 'request', [], [jack.id], function(err, newGroup) {
-                        assert.ok(!err);
-
-                        // Try to update the group as a member
-                        RestAPI.Group.updateGroup(jackRestContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
+                    // Try to update the group as a member
+                    RestAPI.Group.updateGroup(jack.restContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
+                        assert.equal(err.code, 401);
+                        assert.ok(!updatedGroup);
+                        // Try to update the group as a non-member
+                        RestAPI.Group.updateGroup(jane.restContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
                             assert.equal(err.code, 401);
                             assert.ok(!updatedGroup);
-                            // Try to update the group as a non-member
-                            RestAPI.Group.updateGroup(janeRestContext, newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
+                            // Try to update the group as an anonymous user
+                            RestAPI.Group.updateGroup(TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host), newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
                                 assert.equal(err.code, 401);
                                 assert.ok(!updatedGroup);
-                                // Try to update the group as an anonymous user
-                                RestAPI.Group.updateGroup(TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host), newGroup.id, {'visibility': 'public'}, function(err, updatedGroup) {
-                                    assert.equal(err.code, 401);
-                                    assert.ok(!updatedGroup);
-                                    return callback();
-                                });
+                                return callback();
                             });
                         });
                     });
@@ -1001,86 +969,77 @@ describe('Groups', function() {
          */
         it('verify simple member adding', function(callback) {
             // Create a first user to use inside of test
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, branden, nicolaas) {
                 assert.ok(!err);
-                var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
 
-                // Create a second user to use inside of test
-                var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-                RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
+                // Create a group
+                RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
                     assert.ok(!err);
-                    var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                    // Create a group
-                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
-                        assert.ok(!err);
+                    // Try and add a user as a non-member
+                    var membersToAdd = {};
+                    membersToAdd[nicolaas.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
 
-                        // Try and add a user as a non-member
-                        var membersToAdd = {};
-                        membersToAdd[nicolaas.id] = 'member';
-                        RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 401);
+                        // Verify that the user has not been added
+                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
+                            assert.ok(!err);
+                            assert.equal(groupMemberships.results.length, 0);
 
-                            // Verify that the user has not been added
-                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                            // Add branden as a member, and make sure that he still cannot add a member
+                            membersToAdd = {};
+                            membersToAdd[branden.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                 assert.ok(!err);
-                                assert.equal(groupMemberships.results.length, 0);
 
-                                // Add branden as a member, and make sure that he still cannot add a member
+                                // Try to add nicolaas as a member
                                 membersToAdd = {};
-                                membersToAdd[branden.id] = 'member';
-                                RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
-                                    assert.ok(!err);
+                                membersToAdd[nicolaas.user.id] = 'member';
+                                RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
+                                    assert.ok(err);
+                                    assert.equal(err.code, 401);
 
-                                    // Try to add nicolaas as a member
-                                    membersToAdd = {};
-                                    membersToAdd[nicolaas.id] = 'member';
-                                    RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 401);
+                                    // Verify that the user has not been added
+                                    RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
+                                        assert.ok(!err);
+                                        assert.equal(groupMemberships.results.length, 0);
 
-                                        // Verify that the user has not been added
-                                        RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                                        // Add branden a manager, and make sure that he can add a member
+                                        membersToAdd = {};
+                                        membersToAdd[branden.user.id] = 'manager';
+                                        RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                             assert.ok(!err);
-                                            assert.equal(groupMemberships.results.length, 0);
 
-                                            // Add branden a manager, and make sure that he can add a member
+                                            // Try to add nicolaas as a member
                                             membersToAdd = {};
-                                            membersToAdd[branden.id] = 'manager';
-                                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
+                                            membersToAdd[nicolaas.user.id] = 'member';
+                                            RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
                                                 assert.ok(!err);
 
-                                                // Try to add nicolaas as a member
-                                                membersToAdd = {};
-                                                membersToAdd[nicolaas.id] = 'member';
-                                                RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
+                                                // Verify that the user has not been added
+                                                RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
                                                     assert.ok(!err);
+                                                    assert.equal(groupMemberships.results.length, 1);
+                                                    assert.equal(groupMemberships.results[0].id, groupObj.id);
 
-                                                    // Verify that the user has not been added
-                                                    RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                                                    // Verify that members can be removed
+                                                    membersToAdd = {};
+                                                    membersToAdd[nicolaas.user.id] = false;
+                                                    RestAPI.Group.setGroupMembers(branden.restContext, groupObj.id, membersToAdd, function(err) {
                                                         assert.ok(!err);
-                                                        assert.equal(groupMemberships.results.length, 1);
-                                                        assert.equal(groupMemberships.results[0].id, groupObj.id);
 
-                                                        // Verify that members can be removed
-                                                        membersToAdd = {};
-                                                        membersToAdd[nicolaas.id] = false;
-                                                        RestAPI.Group.setGroupMembers(brandenRestContext, groupObj.id, membersToAdd, function(err) {
+                                                        // Verify that the user has been removed as a member
+                                                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, groupMemberships) {
                                                             assert.ok(!err);
+                                                            assert.equal(groupMemberships.results.length, 0);
 
-                                                            // Verify that the user has been removed as a member
-                                                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, groupMemberships) {
+                                                            // Ensure the lastModified date of the group has been updated as a result of these memberships changes
+                                                            RestAPI.Group.getGroup(johnRestContext, groupObj.id, function(err, updatedGroup) {
                                                                 assert.ok(!err);
-                                                                assert.equal(groupMemberships.results.length, 0);
-
-                                                                // Ensure the lastModified date of the group has been updated as a result of these memberships changes
-                                                                RestAPI.Group.getGroup(johnRestContext, groupObj.id, function(err, updatedGroup) {
-                                                                    assert.ok(!err);
-                                                                    assert.ok(groupObj.lastModified < updatedGroup.lastModified);
-                                                                    return callback();
-                                                                });
+                                                                assert.ok(groupObj.lastModified < updatedGroup.lastModified);
+                                                                return callback();
                                                             });
                                                         });
                                                     });
@@ -1100,77 +1059,61 @@ describe('Groups', function() {
          * Test that verifies that adding/removing multiple members at the same time is possible
          */
         it('verify combination of roles is possible', function(callback) {
-            // Create 3 users.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var janeUserId = TestsUtil.generateTestUserId('jane');
-            var joeUserId = TestsUtil.generateTestUserId('joe');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'John Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, joe) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Create the test group
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [], [], function(err, newGroup) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, joeUserId, 'password', 'Joe Doe', null, function(err, joe) {
+                    // Add 3 members at the same time, using a combination of roles
+                    var membersToAdd = {};
+                    membersToAdd[jack.user.id] = 'member';
+                    membersToAdd[jane.user.id] = 'manager';
+                    membersToAdd[joe.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
                         assert.ok(!err);
-                        var joeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, joeUserId, 'password');
 
-                        // Create the test group
-                        RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [], [], function(err, newGroup) {
+                        // Verify that each member has the correct role
+                        RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
                             assert.ok(!err);
+                            assert.equal(members.results.length, 4);
+                            // Morph results to hash for easy access.
+                            var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
+                            assert.equal(hash[johnRestContext.user.id][0].role, 'manager');
+                            assert.equal(hash[jack.user.id][0].role, 'member');
+                            assert.equal(hash[jane.user.id][0].role, 'manager');
+                            assert.equal(hash[joe.user.id][0].role, 'member');
 
-                            // Add 3 members at the same time, using a combination of roles
-                            var membersToAdd = {};
-                            membersToAdd[jack.id] = 'member';
-                            membersToAdd[jane.id] = 'manager';
-                            membersToAdd[joe.id] = 'member';
-                            RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
+                            // Make sure that the group shows up in Joe's membership list
+                            RestAPI.Group.getMembershipsLibrary(joe.restContext, joe.user.id, null, null, function(err, memberships) {
                                 assert.ok(!err);
+                                assert.equal(memberships.results.length, 1);
+                                assert.equal(memberships.results[0].id, newGroup.id);
 
-                                // Verify that each member has the correct role
-                                RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
+                                // Delete Joe and make Jane a member
+                                membersToAdd = {};
+                                membersToAdd[jane.user.id] = 'member';
+                                membersToAdd[joe.user.id] = false;
+                                RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
                                     assert.ok(!err);
-                                    assert.equal(members.results.length, 4);
-                                    // Morph results to hash for easy access.
-                                    var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
-                                    assert.equal(hash[johnRestContext.id][0].role, 'manager');
-                                    assert.equal(hash[jack.id][0].role, 'member');
-                                    assert.equal(hash[jane.id][0].role, 'manager');
-                                    assert.equal(hash[joe.id][0].role, 'member');
 
-                                    // Make sure that the group shows up in Joe's membership list
-                                    RestAPI.Group.getMembershipsLibrary(joeRestContext, joe.id, null, null, function(err, memberships) {
+                                    // Make sure that the membership changes have happened
+                                    RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
                                         assert.ok(!err);
-                                        assert.equal(memberships.results.length, 1);
-                                        assert.equal(memberships.results[0].id, newGroup.id);
+                                        assert.equal(members.results.length, 3);
+                                        // Morph results to hash for easy access.
+                                        var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
+                                        assert.equal(hash[johnRestContext.user.id][0].role, 'manager');
+                                        assert.equal(hash[jack.user.id][0].role, 'member');
+                                        assert.equal(hash[jane.user.id][0].role, 'member');
+                                        assert.equal(hash[joe.user.id], undefined);
 
-                                        // Delete Joe and make Jane a member
-                                        membersToAdd = {};
-                                        membersToAdd[jane.id] = 'member';
-                                        membersToAdd[joe.id] = false;
-                                        RestAPI.Group.setGroupMembers(johnRestContext, newGroup.id, membersToAdd, function(err) {
+                                        // Make sure that the group does not show up in Joe's membership list
+                                        RestAPI.Group.getMembershipsLibrary(joe.restContext, joe.user.id, null, null, function(err, memberships) {
                                             assert.ok(!err);
-
-                                            // Make sure that the membership changes have happened
-                                            RestAPI.Group.getGroupMembers(johnRestContext, newGroup.id, null, null, function(err, members) {
-                                                assert.ok(!err);
-                                                assert.equal(members.results.length, 3);
-                                                // Morph results to hash for easy access.
-                                                var hash = _.groupBy(members.results, function(member) { return member.profile.id; });
-                                                assert.equal(hash[johnRestContext.id][0].role, 'manager');
-                                                assert.equal(hash[jack.id][0].role, 'member');
-                                                assert.equal(hash[jane.id][0].role, 'member');
-                                                assert.equal(hash[joe.id], undefined);
-
-                                                // Make sure that the group does not show up in Joe's membership list
-                                                RestAPI.Group.getMembershipsLibrary(joeRestContext, joe.id, null, null, function(err, memberships) {
-                                                    assert.ok(!err);
-                                                    assert.equal(memberships.results.length, 0);
-                                                    return callback();
-                                                });
-                                            });
+                                            assert.equal(memberships.results.length, 0);
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1185,65 +1128,57 @@ describe('Groups', function() {
          * Test that verifies that it should not be possible to add members as an unprivileged user
          */
         it('verify add members no access', function(callback) {
-            var simonUserId = TestsUtil.generateTestUserId('simong');
-            RestAPI.User.createUser(camAdminRestContext, simonUserId, 'password', 'Simon Gaeremynck', null, function(err, simon) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, simon, nicolaas) {
                 assert.ok(!err);
-                var simonRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, simonUserId, 'password');
-                // Create a second user to use inside of test
-                var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-                RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
+
+                // Create a test group
+                RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
                     assert.ok(!err);
-                    var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                    // Create a test group
-                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, groupObj) {
-                        assert.ok(!err);
+                    // Try and add nicolaas to the group as an unprivileged user
+                    var membersToAdd = {};
+                    membersToAdd[nicolaas.user.id] = 'member';
+                    RestAPI.Group.setGroupMembers(simon.restContext, groupObj.id, membersToAdd, function(err) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
+                        // Verify that nicolaas has not been added to the group
+                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
+                            assert.ok(!err);
+                            assert.equal(memberships.results.length, 0);
 
-                        // Try and add nicolaas to the group as an unprivileged user
-                        var membersToAdd = {};
-                        membersToAdd[nicolaas.id] = 'member';
-                        RestAPI.Group.setGroupMembers(simonRestContext, groupObj.id, membersToAdd, function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 401);
-                            // Verify that nicolaas has not been added to the group
-                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
+                            // Add simon as a member of the group
+                            membersToAdd = {};
+                            membersToAdd[simon.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                 assert.ok(!err);
-                                assert.equal(memberships.results.length, 0);
 
-                                // Add simon as a member of the group
+                                // Make sure that simon still can't add any members
                                 membersToAdd = {};
-                                membersToAdd[simon.id] = 'member';
-                                RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
-                                    assert.ok(!err);
+                                membersToAdd[nicolaas.user.id] = 'member';
+                                RestAPI.Group.setGroupMembers(simon.restContext, groupObj.id, membersToAdd, function(err) {
+                                    assert.ok(err);
+                                    // Verify that nicolaas has not been added to the group
+                                    RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
+                                        assert.ok(!err);
+                                        assert.equal(memberships.results.length, 0);
 
-                                    // Make sure that simon still can't add any members
-                                    membersToAdd = {};
-                                    membersToAdd[nicolaas.id] = 'member';
-                                    RestAPI.Group.setGroupMembers(simonRestContext, groupObj.id, membersToAdd, function(err) {
-                                        assert.ok(err);
-                                        // Verify that nicolaas has not been added to the group
-                                        RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
+                                        // Add simon as a manager of the group
+                                        membersToAdd = {};
+                                        membersToAdd[simon.user.id] = 'manager';
+                                        RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                                             assert.ok(!err);
-                                            assert.equal(memberships.results.length, 0);
 
-                                            // Add simon as a manager of the group
+                                            // Verify that simon can now add members to the group
                                             membersToAdd = {};
-                                            membersToAdd[simon.id] = 'manager';
-                                            RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
+                                            membersToAdd[nicolaas.user.id] = 'member';
+                                            RestAPI.Group.setGroupMembers(simon.restContext, groupObj.id, membersToAdd, function(err) {
                                                 assert.ok(!err);
-
-                                                // Verify that simon can now add members to the group
-                                                membersToAdd = {};
-                                                membersToAdd[nicolaas.id] = 'member';
-                                                RestAPI.Group.setGroupMembers(simonRestContext, groupObj.id, membersToAdd, function(err) {
+                                                // Verify that nicolaas has been added to the group
+                                                RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
                                                     assert.ok(!err);
-                                                    // Verify that nicolaas has been added to the group
-                                                    RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
-                                                        assert.ok(!err);
-                                                        assert.equal(memberships.results.length, 1);
-                                                        assert.equal(memberships.results[0].id, groupObj.id);
-                                                        return callback();
-                                                    });
+                                                    assert.equal(memberships.results.length, 1);
+                                                    assert.equal(memberships.results[0].id, groupObj.id);
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -1260,55 +1195,46 @@ describe('Groups', function() {
          * Test to verify that it should be possible for an indirect manager to add members
          */
         it('verify add members indirect access', function(callback) {
-            // Create a first user to use inside of test
-            var simonUserId = TestsUtil.generateTestUserId('simong');
-            RestAPI.User.createUser(camAdminRestContext, simonUserId, 'password', 'Simon Gaeremynck', null, function(err, simon) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, simon, nicolaas) {
                 assert.ok(!err);
-                var simonRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, simonUserId, 'password');
-                // Create a second user to use inside of test
-                var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-                RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
-                    assert.ok(!err);
-                    var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                    // Create the base group
-                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, managedByCambridge) {
+                // Create the base group
+                RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, managedByCambridge) {
+                    assert.ok(!err);
+
+                    // Create the "Cambridge" group that will manage the Managed-by-cambridge group
+                    RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, cambridge) {
                         assert.ok(!err);
 
-                        // Create the "Cambridge" group that will manage the Managed-by-cambridge group
-                        RestAPI.Group.createGroup(johnRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, cambridge) {
+                        // Make the "Cambridge" group a manager of the Managed-by-cambridge group
+                        var membersToAdd = {};
+                        membersToAdd[cambridge.id] = 'manager';
+                        RestAPI.Group.setGroupMembers(johnRestContext, managedByCambridge.id, membersToAdd, function(err) {
                             assert.ok(!err);
 
-                            // Make the "Cambridge" group a manager of the Managed-by-cambridge group
-                            var membersToAdd = {};
-                            membersToAdd[cambridge.id] = 'manager';
-                            RestAPI.Group.setGroupMembers(johnRestContext, managedByCambridge.id, membersToAdd, function(err) {
+                            // Make "simon" a member of the "Cambridge" group, then verify he can manage "Managed-by-cambridge"
+                            membersToAdd = {};
+                            membersToAdd[simon.user.id] = 'member';
+                            RestAPI.Group.setGroupMembers(johnRestContext, cambridge.id, membersToAdd, function(err) {
                                 assert.ok(!err);
 
-                                // Make "simon" a member of the "Cambridge" group, then verify he can manage "Managed-by-cambridge"
-                                membersToAdd = {};
-                                membersToAdd[simon.id] = 'member';
-                                RestAPI.Group.setGroupMembers(johnRestContext, cambridge.id, membersToAdd, function(err) {
+                                // Check if "simon" can manage the "Managed-by-cambridge" group through the internal Authz API
+                                AuthzAPI.hasRole(simon.user.id, managedByCambridge.id, 'manager', function(err, isAllowed) {
                                     assert.ok(!err);
+                                    assert.equal(isAllowed, true);
 
-                                    // Check if "simon" can manage the "Managed-by-cambridge" group through the internal Authz API
-                                    AuthzAPI.hasRole(simon.id, managedByCambridge.id, 'manager', function(err, isAllowed) {
+                                    // Verify that "simon" can add someone to the "Managed-by-cambridge" group
+                                    membersToAdd = {};
+                                    membersToAdd[nicolaas.user.id] = 'member';
+                                    RestAPI.Group.setGroupMembers(simon.restContext, managedByCambridge.id, membersToAdd, function(err) {
                                         assert.ok(!err);
-                                        assert.equal(isAllowed, true);
 
-                                        // Verify that "simon" can add someone to the "Managed-by-cambridge" group
-                                        membersToAdd = {};
-                                        membersToAdd[nicolaas.id] = 'member';
-                                        RestAPI.Group.setGroupMembers(simonRestContext, managedByCambridge.id, membersToAdd, function(err) {
+                                        // Verify that the "nicolaas" has been added to the group
+                                        RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
                                             assert.ok(!err);
-
-                                            // Verify that the "nicolaas" has been added to the group
-                                            RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
-                                                assert.ok(!err);
-                                                assert.equal(memberships.results.length, 1);
-                                                assert.equal(memberships.results[0].id, managedByCambridge.id);
-                                                return callback();
-                                            });
+                                            assert.equal(memberships.results.length, 1);
+                                            assert.equal(memberships.results[0].id, managedByCambridge.id);
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1323,8 +1249,7 @@ describe('Groups', function() {
          * Verify that non-existing users and/or groups cannot be added as members to a group
          */
         it('verify that non-existing principals cannot be added to a group', function(callback) {
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, branden) {
                 assert.ok(!err);
 
                 // Create the group
@@ -1333,7 +1258,7 @@ describe('Groups', function() {
 
                     // Try to add an existing and non-existing user
                     var membersToAdd = {};
-                    membersToAdd[branden.id] = 'member';
+                    membersToAdd[branden.user.id] = 'member';
                     membersToAdd['u:camtest:non-existing'] = 'member';
                     RestAPI.Group.setGroupMembers(johnRestContext, groupObj.id, membersToAdd, function(err) {
                         assert.ok(err);
@@ -1343,7 +1268,7 @@ describe('Groups', function() {
                         RestAPI.Group.getGroupMembers(johnRestContext, groupObj.id, null, null, function(err, members) {
                             assert.ok(!err);
                             assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, johnRestContext.id);
+                            assert.equal(members.results[0].profile.id, johnRestContext.user.id);
                             return callback();
                         });
                     });
@@ -1418,43 +1343,28 @@ describe('Groups', function() {
         });
 
         it('verify that a group that is part of a public tenant can add a user member from an external public tenant', function(callback) {
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
-
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, userB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create a "loggedin" group in tenant A, with userA as a member
-                    RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'loggedin', 'no', [], [], function(err, groupA) {
+                    // Create a "loggedin" group in tenant A, with userA1 as a member
+                    var groupNameA = TestsUtil.generateTestUserId();
+                    RestAPI.Group.createGroup(userA1.restContext, groupNameA, groupNameA, 'loggedin', 'no', [], [], function(err, groupA) {
                         assert.ok(!err);
 
                         // Ensure user A2 can see userA in the members list
-                        RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
+                        RestAPI.Group.getGroupMembers(userA2.restContext, groupA.id, null, 10, function(err, members) {
                             assert.ok(!err);
                             assert.ok(members);
                             assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, userA.id);
+                            assert.equal(members.results[0].profile.id, userA1.user.id);
 
-                            var usernameB = TestsUtil.generateTestUserId();
-
-                            // Create user in tenant B
-                            RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
-                                assert.ok(!err);
-                                var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
-
-                                // Verify userB cannot see userA as a member of groupA
-                                RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
-                                    return callback();
-                                });
+                            // Verify userB cannot see userA1 as a member of groupA
+                            RestAPI.Group.getGroupMembers(userB.restContext, groupA.id, null, 10, function(err, members) {
+                                assert.ok(err);
+                                assert.equal(err.code, 401);
+                                return callback();
                             });
                         });
                     });
@@ -1463,59 +1373,48 @@ describe('Groups', function() {
         });
 
         it('verify that a group that is part of a public tenant cannot add a user from an external private tenant', function(callback) {
-            var usernameB = TestsUtil.generateTestUserId();
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameA = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create users in tenant A
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                // Create a "public" group in tenant A, with userA1 as a member
+                var groupNameA = TestsUtil.generateTestUserId();
+                RestAPI.Group.createGroup(userA1.restContext, groupNameA, groupNameA, 'public', 'no', [], [], function(err, groupA) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create a "public" group in tenant A, with userA as a member
-                    RestAPI.Group.createGroup(restCtxA, groupNameA, groupNameA, 'public', 'no', [], [], function(err, groupA) {
+                    // Ensure user A2 can see userA in the members list
+                    RestAPI.Group.getGroupMembers(userA2.restContext, groupA.id, null, 10, function(err, members) {
                         assert.ok(!err);
+                        assert.ok(members);
+                        assert.equal(members.results.length, 1);
+                        assert.equal(members.results[0].profile.id, userA1.user.id);
 
-                        // Ensure user A2 can see userA in the members list
-                        RestAPI.Group.getGroupMembers(restCtxA2, groupA.id, null, 10, function(err, members) {
+                        // Create tenant B
+                        var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
+                        TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
                             assert.ok(!err);
-                            assert.ok(members);
-                            assert.equal(members.results.length, 1);
-                            assert.equal(members.results[0].profile.id, userA.id);
 
-                            // Create tenant B
-                            TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
+                            // Create user in tenant B
+                            TestsUtil.generateTestUsers(adminRestCtxB, 1, function(err, users, userB) {
                                 assert.ok(!err);
 
-                                // Create user in tenant B
-                                RestAPI.User.createUser(adminRestCtxB, usernameB, 'password', 'Private User', null, function(err, userB) {
+                                // Make tenant B private
+                                ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAliasB, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                                     assert.ok(!err);
-                                    var restCtxB = TestsUtil.createTenantRestContext(tenantAliasB, usernameB, 'password');
 
-                                    // Make tenant B private
-                                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAliasB, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
-                                        assert.ok(!err);
+                                    // Verify we can't add userB as a member of groupA.
+                                    var newMemberB = {};
+                                    newMemberB[userB.user.id] = 'member';
+                                    RestAPI.Group.setGroupMembers(userA1.restContext, groupA.id, newMemberB, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
 
-                                        // Verify we can't add userB as a member of groupA.
-                                        var newMemberB = {};
-                                        newMemberB[userB.id] = 'member';
-                                        RestAPI.Group.setGroupMembers(restCtxA, groupA.id, newMemberB, function(err) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 401);
-
-                                            // Verify userB is not added to the group
-                                            RestAPI.Group.getGroupMembers(restCtxB, groupA.id, null, 10, function(err, members) {
-                                                assert.ok(!err);
-                                                assert.equal(members.results.length, 1);
-                                                assert.equal(members.results[0].profile.id, userA.id);
-                                                return callback();
-                                            });
+                                        // Verify userB is not added to the group
+                                        RestAPI.Group.getGroupMembers(userB.restContext, groupA.id, null, 10, function(err, members) {
+                                            assert.ok(!err);
+                                            assert.equal(members.results.length, 1);
+                                            assert.equal(members.results[0].profile.id, userA1.user.id);
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1527,32 +1426,26 @@ describe('Groups', function() {
         });
 
         it('verify that a group that is part of a private tenant cannot add a user from an external public tenant', function(callback) {
-            var usernameB = TestsUtil.generateTestUserId();
-            var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameA2 = TestsUtil.generateTestUserId();
-            var groupNameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', null, function(err, userA) {
+            // Create users in tenant A
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, userA1, userA2) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
-                RestAPI.User.createUser(camAdminRestContext, usernameA2, 'password', 'Public User', null, function(err, userA2) {
+                // Create tenant B
+                var tenantAliasB = TenantsTestUtil.generateTestTenantAlias();
+                TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
                     assert.ok(!err);
-                    var restCtxA2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA2, 'password');
 
-                    // Create tenant B
-                    TestsUtil.createTenantWithAdmin(tenantAliasB, tenantAliasB, function(err, tenantB, adminRestCtxB) {
+                    // Create user in tenant B
+                    TestsUtil.generateTestUsers(adminRestCtxB, 1, function(err, users, userB) {
                         assert.ok(!err);
 
-                        // Create user in tenant B
-                        RestAPI.User.createUser(adminRestCtxB, usernameB, 'password', 'Private User', null, function(err, userB) {
+                        // Make tenant B private
+                        ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAliasB, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                             assert.ok(!err);
-                            var restCtxB = TestsUtil.createTenantRestContext(tenantAliasB, usernameB, 'password');
 
                             // Create a "public" group in tenant B
-                            RestAPI.Group.createGroup(restCtxB, groupNameB, groupNameB, 'public', 'no', [], [], function(err, groupB) {
+                            var groupNameB = TestsUtil.generateTestUserId();
+                            RestAPI.Group.createGroup(userB.restContext, groupNameB, groupNameB, 'public', 'no', [], [], function(err, groupB) {
                                 assert.ok(!err);
 
                                 // Make tenant B private
@@ -1561,16 +1454,16 @@ describe('Groups', function() {
 
                                     // Verify we can't add userA as a member of groupA.
                                     var newMemberA = {};
-                                    newMemberA[userA.id] = 'member';
-                                    RestAPI.Group.setGroupMembers(restCtxB, groupB.id, newMemberA, function(err) {
+                                    newMemberA[userA1.user.id] = 'member';
+                                    RestAPI.Group.setGroupMembers(userB.restContext, groupB.id, newMemberA, function(err) {
                                         assert.ok(err);
                                         assert.equal(err.code, 401);
 
                                         // Verify userB cannot see userA as a member of groupA
-                                        RestAPI.Group.getGroupMembers(restCtxB, groupB.id, null, 10, function(err, members) {
+                                        RestAPI.Group.getGroupMembers(userB.restContext, groupB.id, null, 10, function(err, members) {
                                             assert.ok(!err);
                                             assert.equal(members.results.length, 1);
-                                            assert.equal(members.results[0].profile.id, userB.id);
+                                            assert.equal(members.results[0].profile.id, userB.user.id);
                                             return callback();
                                         });
                                     });
@@ -1586,58 +1479,47 @@ describe('Groups', function() {
          * Test that verifies validation of leaving a group
          */
         it('verify validation and success of leaving a group', function(callback) {
-
-            // Create a first user to setup the test
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, branden) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                // Create a user as our test subject
-                RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+                // Create a group that is joinable
+                RestAPI.Group.createGroup(jack.restContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, group) {
                     assert.ok(!err);
-                    var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
 
-                    // Create a group that is joinable
-                    RestAPI.Group.createGroup(jackRestContext, 'Test Group', 'Group', 'public', 'yes', [], [], function(err, group) {
-                        assert.ok(!err);
+                    // Verify cannot leave group of which I am not a member
+                    PrincipalsTestUtil.assertLeaveGroupFails(branden.restContext, group.id, 400, function() {
 
-                        // Verify cannot leave group of which I am not a member
-                        PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, group.id, 400, function() {
+                        // Now join the group and ensure it was successful
+                        PrincipalsTestUtil.assertJoinGroupSucceeds(jack.restContext, branden.restContext, group.id, function() {
 
-                            // Now join the group and ensure it was successful
-                            PrincipalsTestUtil.assertJoinGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
+                            // Get the group state immediately after join so we can ensure the stability of its lastModified time
+                            RestAPI.Group.getGroup(jack.restContext, group.id, function(err, groupAfterJoin) {
 
-                                // Get the group state immediately after join so we can ensure the stability of its lastModified time
-                                RestAPI.Group.getGroup(jackRestContext, group.id, function(err, groupAfterJoin) {
+                                // Verify not a valid id
+                                PrincipalsTestUtil.assertLeaveGroupFails(branden.restContext, 'not-a-valid-id', 400, function() {
 
-                                    // Verify not a valid id
-                                    PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, 'not-a-valid-id', 400, function() {
+                                    // Verify a non-group id
+                                    PrincipalsTestUtil.assertLeaveGroupFails(branden.restContext, branden.user.id, 400, function() {
 
-                                        // Verify a non-group id
-                                        PrincipalsTestUtil.assertLeaveGroupFails(brandenRestContext, branden.id, 400, function() {
+                                        // Verify anonymous user cannot leave
+                                        PrincipalsTestUtil.assertLeaveGroupFails(anonymousRestContext, group.id, 401, function() {
 
-                                            // Verify anonymous user cannot leave
-                                            PrincipalsTestUtil.assertLeaveGroupFails(anonymousRestContext, group.id, 401, function() {
+                                            // Verify branden is still a member
+                                            RestAPI.Group.getGroupMembers(branden.restContext, group.id, null, 10000, function(err, members) {
+                                                assert.ok(!err);
+                                                assert.equal(members.results.length, 2);
 
-                                                // Verify branden is still a member
-                                                RestAPI.Group.getGroupMembers(brandenRestContext, group.id, null, 10000, function(err, members) {
-                                                    assert.ok(!err);
-                                                    assert.equal(members.results.length, 2);
+                                                // Verify successful leave
+                                                PrincipalsTestUtil.assertLeaveGroupSucceeds(jack.restContext, branden.restContext, group.id, function() {
 
-                                                    // Verify successful leave
-                                                    PrincipalsTestUtil.assertLeaveGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
+                                                    RestAPI.Group.getGroup(jack.restContext, group.id, function(err, groupAfterLeave) {
+                                                        assert.ok(!err);
 
-                                                        RestAPI.Group.getGroup(jackRestContext, group.id, function(err, groupAfterLeave) {
-                                                            assert.ok(!err);
+                                                        // Make sure the lastModified has not changed as a result of a leave
+                                                        assert.equal(groupAfterJoin.lastModified, groupAfterLeave.lastModified);
 
-                                                            // Make sure the lastModified has not changed as a result of a leave
-                                                            assert.equal(groupAfterJoin.lastModified, groupAfterLeave.lastModified);
-
-                                                            // Verify that the last manager can't leave
-                                                            return PrincipalsTestUtil.assertLeaveGroupFails(jackRestContext, group.id, 400, callback);
-                                                        });
+                                                        // Verify that the last manager can't leave
+                                                        return PrincipalsTestUtil.assertLeaveGroupFails(jack.restContext, group.id, 400, callback);
                                                     });
                                                 });
                                             });
@@ -1655,56 +1537,51 @@ describe('Groups', function() {
          * Test that verifies validation of joining a group
          */
         it('verify validation and success of joining a group', function(callback) {
-
-            // Create a first user to setup the test
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, branden) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                // Create a user as our test subject
-                RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
+                // Create a group that is not joinable
+                RestAPI.Group.createGroup(jack.restContext, 'Test Group', 'Group', 'public', 'request', [], [], function(err, group) {
                     assert.ok(!err);
-                    var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
 
-                    // Create a group that is not joinable
-                    RestAPI.Group.createGroup(jackRestContext, 'Test Group', 'Group', 'public', 'request', [], [], function(err, group) {
-                        assert.ok(!err);
+                    // Validate invalid group id
+                    RestAPI.Group.joinGroup(branden.restContext, 'not-a-valid-id', function(err) {
+                        assert.ok(err);
+                        assert.equal(err.code, 400);
 
                         // Validate invalid group id
-                        PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, 'not-a-valid-id', 400, function() {
+                        PrincipalsTestUtil.assertJoinGroupFails(branden.restContext, 'not-a-valid-id', 400, function() {
 
                             // Validate non-group group id
-                            PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, branden.id, 400, function() {
+                            PrincipalsTestUtil.assertJoinGroupFails(branden.restContext, branden.user.id, 400, function() {
 
                                 // Validate non-joinable group
-                                PrincipalsTestUtil.assertJoinGroupFails(brandenRestContext, group.id, 401, function() {
+                                PrincipalsTestUtil.assertJoinGroupFails(branden.restContext, group.id, 401, function() {
 
                                     // Make group joinable
-                                    RestAPI.Group.updateGroup(jackRestContext, group.id, {'joinable': 'yes'}, function(err) {
+                                    RestAPI.Group.updateGroup(jack.restContext, group.id, {'joinable': 'yes'}, function(err) {
                                         assert.ok(!err);
 
                                         // Join as anonymous and verify it still fails
                                         PrincipalsTestUtil.assertJoinGroupFails(anonymousRestContext, group.id, 401, function() {
 
                                             // Verify we still aren't a member
-                                            PrincipalsTestUtil.assertGetAllMembersLibrarySucceeds(jackRestContext, group.id, null, function(members) {
+                                            PrincipalsTestUtil.assertGetAllMembersLibrarySucceeds(jack.restContext, group.id, null, function(members) {
                                                 assert.equal(members.length, 1);
 
                                                 // Join as branden, should finally work
-                                                PrincipalsTestUtil.assertJoinGroupSucceeds(jackRestContext, brandenRestContext, group.id, function() {
+                                                PrincipalsTestUtil.assertJoinGroupSucceeds(jack.restContext, branden.restContext, group.id, function() {
 
                                                     // Verify jack cannot join, he is already manager
-                                                    PrincipalsTestUtil.assertJoinGroupFails(jackRestContext, group.id, 400, function() {
+                                                    PrincipalsTestUtil.assertJoinGroupFails(jack.restContext, group.id, 400, function() {
 
                                                         // Verify he was not demoted to member
-                                                        PrincipalsTestUtil.assertGetAllMembersLibrarySucceeds(jackRestContext, group.id, null, function(members) {
+                                                        PrincipalsTestUtil.assertGetAllMembersLibrarySucceeds(jack.restContext, group.id, null, function(members) {
                                                             assert.equal(members.length, 2);
 
                                                             var hadJack = false;
                                                             _.each(members, function(result) {
-                                                                if (result.profile.id === jack.id) {
+                                                                if (result.profile.id === jack.user.id) {
                                                                     hadJack = true;
                                                                     assert.equal(result.role, 'manager');
                                                                 }
@@ -1733,35 +1610,26 @@ describe('Groups', function() {
          * Test that verifies that the getMembershipsLibrary function returns all of the groups a user is a member of
          */
         it('verify getMembershipsLibrary', function(callback) {
-            // Create the users to test with
-            var nicolaasUserId = TestsUtil.generateTestUserId('nicolaas');
-            RestAPI.User.createUser(camAdminRestContext, nicolaasUserId, 'password', 'Nicolaas Matthijs', null, function(err, nicolaas) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, nicolaas, branden) {
                 assert.ok(!err);
-                var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, nicolaasUserId, 'password');
 
-                var brandenUserId = TestsUtil.generateTestUserId('mrvisser');
-                RestAPI.User.createUser(camAdminRestContext, brandenUserId, 'password', 'Branden Visser', null, function(err, branden) {
-                    assert.ok(!err);
-                    var brandenRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, brandenUserId, 'password');
+                // Create 3 groups
+                TestsUtil.generateTestGroups(nicolaas.restContext, 3, function() {
+                    var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
 
-                    // Create 3 groups
-                    TestsUtil.generateTestGroups(nicolaasRestContext, 3, function() {
-                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+                    // Check that all those groups are part of the memberships
+                    RestAPI.Group.getMembershipsLibrary(nicolaas.restContext, nicolaas.user.id, null, null, function(err, memberships) {
+                        assert.ok(!err);
+                        assert.equal(memberships.results.length, 3);
+                        assert.ok(groupIds.indexOf(memberships.results[0].id) !== -1);
+                        assert.ok(groupIds.indexOf(memberships.results[1].id) !== -1);
+                        assert.ok(groupIds.indexOf(memberships.results[2].id) !== -1);
 
-                        // Check that all those groups are part of the memberships
-                        RestAPI.Group.getMembershipsLibrary(nicolaasRestContext, nicolaas.id, null, null, function(err, memberships) {
+                        // Verify that the groups are not part of branden's membership list
+                        RestAPI.Group.getMembershipsLibrary(branden.restContext, branden.user.id, null, null, function(err, memberships) {
                             assert.ok(!err);
-                            assert.equal(memberships.results.length, 3);
-                            assert.ok(groupIds.indexOf(memberships.results[0].id) !== -1);
-                            assert.ok(groupIds.indexOf(memberships.results[1].id) !== -1);
-                            assert.ok(groupIds.indexOf(memberships.results[2].id) !== -1);
-
-                            // Verify that the groups are not part of branden's membership list
-                            RestAPI.Group.getMembershipsLibrary(brandenRestContext, branden.id, null, null, function(err, memberships) {
-                                assert.ok(!err);
-                                assert.equal(memberships.results.length, 0);
-                                return callback();
-                            });
+                            assert.equal(memberships.results.length, 0);
+                            return callback();
                         });
                     });
                 });
@@ -1960,11 +1828,10 @@ describe('Groups', function() {
                         }
                     });
                 } else {
-                    RestAPI.User.createUser(camAdminRestContext, principalId, 'password', metadata, null, function(err, userObj) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
                         assert.ok(!err);
-                        var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, principalId, 'password');
-                        userRestContext.id = userObj.id;
-                        createdPrincipals[identifier] = userRestContext;
+                        user.restContext.id = user.user.id;
+                        createdPrincipals[identifier] = user.restContext;
                         if (_.keys(createdPrincipals).length === 12) {
                             return callback(createdPrincipals);
                         }

--- a/node_modules/oae-principals/tests/test-members-search.js
+++ b/node_modules/oae-principals/tests/test-members-search.js
@@ -63,11 +63,6 @@ describe('Members Library Search', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
 
-        var publicUserMemberUsername = TestsUtil.generateTestUserId('publicUserMember');
-        var loggedinUserMemberUsername = TestsUtil.generateTestUserId('loggedinUserMember');
-        var privateUserMemberUsername = TestsUtil.generateTestUserId('privateUserMember');
-        var doerUsername = TestsUtil.generateTestUserId('privateUserMember');
-
         /*!
          * Creates the following variable setup for testing members search:
          *
@@ -85,72 +80,66 @@ describe('Members Library Search', function() {
          *  publicGroupMember:      A group with visibility 'public'. Is a member of all the target groups.
          *  privateGroupMember:     A group with visibility 'private'. Is a member of all the target groups.
          */
-        RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, _doerUser) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 4, function(err, users, doer, publicUser, loggedinUser, privateUser) {
             assert.ok(!err);
-            doerUser = _doerUser;
-            doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
 
-            RestAPI.User.createUser(camAdminRestContext, publicUserMemberUsername, 'password', 'Public User Member', null, function(err, _publicUserMember) {
+            doerRestContext = doer.restContext;
+            publicUserMember = publicUser.user;
+
+            var loggedinOpts = {
+                'visibility': 'loggedin',
+                'publicAlias': 'LoggedinHidden'
+            };
+            RestAPI.User.updateUser(loggedinUser.restContext, loggedinUser.user.id, loggedinOpts, function(err, loggedinUser) {
                 assert.ok(!err);
-                publicUserMember = _publicUserMember;
-
-                var loggedinOpts = {
-                    'visibility': 'loggedin',
-                    'publicAlias': 'LoggedinHidden'
-                };
+                loggedinUserMember = loggedinUser;
 
                 var privateOpts = {
                     'visibility': 'private',
                     'publicAlias': 'PrivateHidden'
                 };
-
-                RestAPI.User.createUser(camAdminRestContext, loggedinUserMemberUsername, 'password', 'Loggedin User Member', loggedinOpts, function(err, _loggedinUserMember) {
+                RestAPI.User.updateUser(privateUser.restContext, privateUser.user.id, privateOpts, function(err, privateUser) {
                     assert.ok(!err);
-                    loggedinUserMember = _loggedinUserMember;
+                    privateUserMember = privateUser;
 
-                    RestAPI.User.createUser(camAdminRestContext, privateUserMemberUsername, 'password', 'Private User Member', privateOpts, function(err, _privateUserMember) {
+                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPublicGroup'), TestsUtil.generateTestUserId('targetPublicGroup'), 'public', 'no', [], [], function(err, _targetPublicGroup) {
                         assert.ok(!err);
-                        privateUserMember = _privateUserMember;
+                        targetPublicGroup = _targetPublicGroup;
 
-                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPublicGroup'), TestsUtil.generateTestUserId('targetPublicGroup'), 'public', 'no', [], [], function(err, _targetPublicGroup) {
+                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetLoggedinGroup'), TestsUtil.generateTestUserId('targetLoggedinGroup'), 'loggedin', 'no', [], [], function(err, _targetLoggedinGroup) {
                             assert.ok(!err);
-                            targetPublicGroup = _targetPublicGroup;
+                            targetLoggedinGroup = _targetLoggedinGroup;
 
-                            RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetLoggedinGroup'), TestsUtil.generateTestUserId('targetLoggedinGroup'), 'loggedin', 'no', [], [], function(err, _targetLoggedinGroup) {
+                            RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPrivateGroup'), TestsUtil.generateTestUserId('targetPrivateGroup'), 'private', 'no', [], [], function(err, _targetPrivateGroup) {
                                 assert.ok(!err);
-                                targetLoggedinGroup = _targetLoggedinGroup;
+                                targetPrivateGroup = _targetPrivateGroup;
 
-                                RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('targetPrivateGroup'), TestsUtil.generateTestUserId('targetPrivateGroup'), 'private', 'no', [], [], function(err, _targetPrivateGroup) {
+                                RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('publicGroupMemberAlias'), TestsUtil.generateTestUserId('publicGroupMemberAlias'), 'public', 'no', [], [], function(err, _publicGroupMember) {
                                     assert.ok(!err);
-                                    targetPrivateGroup = _targetPrivateGroup;
+                                    publicGroupMember = _publicGroupMember;
 
-                                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('publicGroupMemberAlias'), TestsUtil.generateTestUserId('publicGroupMemberAlias'), 'public', 'no', [], [], function(err, _publicGroupMember) {
+                                    RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('privateGroupMemberAlias'), TestsUtil.generateTestUserId('privateGroupMemberAlias'), 'private', 'no', [], [], function(err, _privateGroupMember) {
                                         assert.ok(!err);
-                                        publicGroupMember = _publicGroupMember;
+                                        privateGroupMember = _privateGroupMember;
 
-                                        RestAPI.Group.createGroup(doerRestContext, TestsUtil.generateTestUserId('privateGroupMemberAlias'), TestsUtil.generateTestUserId('privateGroupMemberAlias'), 'private', 'no', [], [], function(err, _privateGroupMember) {
+                                        var memberships = {};
+                                        memberships[publicGroupMember.id] = 'member';
+                                        memberships[privateGroupMember.id] = 'member';
+                                        memberships[publicUserMember.id] = 'member';
+                                        memberships[loggedinUserMember.id] = 'member';
+                                        memberships[privateUserMember.id] = 'member';
+
+                                        // Set the members of the groups with the cam admin since they are the only ones with access to make the private
+                                        // user a member
+                                        RestAPI.Group.setGroupMembers(camAdminRestContext, targetPublicGroup.id, memberships, function(err) {
                                             assert.ok(!err);
-                                            privateGroupMember = _privateGroupMember;
 
-                                            var memberships = {};
-                                            memberships[publicGroupMember.id] = 'member';
-                                            memberships[privateGroupMember.id] = 'member';
-                                            memberships[publicUserMember.id] = 'member';
-                                            memberships[loggedinUserMember.id] = 'member';
-                                            memberships[privateUserMember.id] = 'member';
-
-                                            // Set the members of the groups with the cam admin since they are the only ones with access to make the private
-                                            // user a member
-                                            RestAPI.Group.setGroupMembers(camAdminRestContext, targetPublicGroup.id, memberships, function(err) {
+                                            RestAPI.Group.setGroupMembers(camAdminRestContext, targetLoggedinGroup.id, memberships, function(err) {
                                                 assert.ok(!err);
 
-                                                RestAPI.Group.setGroupMembers(camAdminRestContext, targetLoggedinGroup.id, memberships, function(err) {
+                                                RestAPI.Group.setGroupMembers(camAdminRestContext, targetPrivateGroup.id, memberships, function(err) {
                                                     assert.ok(!err);
-
-                                                    RestAPI.Group.setGroupMembers(camAdminRestContext, targetPrivateGroup.id, memberships, function(err) {
-                                                        assert.ok(!err);
-                                                        callback();
-                                                    });
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -183,32 +172,49 @@ describe('Members Library Search', function() {
     });
 
     /**
-     * Test that verifies the member visibility of a group members search.
+     * Test that verifies the member visibility of a group members search
      */
     it('verify public group members visibility', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-        var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-        RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 var changes = {};
-                changes[jack.id] = 'member';
+                changes[jack.user.id] = 'member';
                 RestAPI.Group.setGroupMembers(doerRestContext, targetPublicGroup.id, changes, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                    // Verify results and visibility for anonymous user
+                    SearchTestsUtil.searchAll(anonymousRestContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        var publicUserResult = _getDocById(results, publicUserMember.id);
+                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
+                        var privateUserResult = _getDocById(results, privateUserMember.id);
+                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
+                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                        // Verify results and visibility for anonymous user
-                        SearchTestsUtil.searchAll(anonymousRestContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
+                        // Verify anonymous only sees public members
+                        assert.ok(publicUserResult);
+                        assert.ok(!loggedinUserResult);
+                        assert.ok(!privateUserResult);
+                        assert.ok(!privateGroupResult);
+                        assert.ok(publicGroupResult);
+
+                        // Verify user visibility. Loggedin and private should have their publicAlias swapped into the title
+                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
+                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+
+                        // Verify that the correct resourceTypes are set
+                        assert.equal(publicUserResult.resourceType, 'user');
+                        assert.equal(publicGroupResult.resourceType, 'group');
+
+                        // Verify that the correct profilePaths are set
+                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
+                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+
+                        // Verify results and visibility for cross-tenant user
+                        SearchTestsUtil.searchAll(darthVader.restContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
                             assert.ok(!err);
 
                             var publicUserResult = _getDocById(results, publicUserMember.id);
@@ -217,7 +223,7 @@ describe('Members Library Search', function() {
                             var privateGroupResult = _getDocById(results, privateGroupMember.id);
                             var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                            // Verify anonymous only sees public members
+                            // Verify cross-tenant user only sees public members
                             assert.ok(publicUserResult);
                             assert.ok(!loggedinUserResult);
                             assert.ok(!privateUserResult);
@@ -236,8 +242,8 @@ describe('Members Library Search', function() {
                             assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
                             assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
 
-                            // Verify results and visibility for cross-tenant user
-                            SearchTestsUtil.searchAll(darthVaderRestContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
+                            // Verify results and visibility for loggedin user
+                            SearchTestsUtil.searchAll(jane.restContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
                                 assert.ok(!err);
                                 var publicUserResult = _getDocById(results, publicUserMember.id);
                                 var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
@@ -245,12 +251,24 @@ describe('Members Library Search', function() {
                                 var privateGroupResult = _getDocById(results, privateGroupMember.id);
                                 var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                // Verify cross-tenant user sees only public users
+                                // Verify user doesn't see private users and groups
                                 assert.ok(publicUserResult);
+                                assert.ok(loggedinUserResult);
+                                assert.ok(!privateUserResult);
+                                assert.ok(!privateGroupResult);
                                 assert.ok(publicGroupResult);
 
-                                // Verify user visibility. Loggedin and private should have their publicAlias swapped into the title
+                                // Verify user visibility. Private should have their publicAlias swapped into the title
                                 assert.equal(publicUserResult.displayName, publicUserMember.displayName);
+                                assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
+
+                                // There should be no extra right now because we haven't added extension properties
+                                assert.ok(!loggedinUserResult.extra);
+
+                                assert.equal(loggedinUserResult._extra, undefined);
+                                assert.equal(loggedinUserResult.q_high, undefined);
+                                assert.equal(loggedinUserResult.q_low, undefined);
+                                assert.equal(loggedinUserResult.sort, undefined);
                                 assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
 
                                 // Verify that the correct resourceTypes are set
@@ -259,10 +277,11 @@ describe('Members Library Search', function() {
 
                                 // Verify that the correct profilePaths are set
                                 assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
+                                assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
                                 assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
 
-                                // Verify results and visibility for loggedin user
-                                SearchTestsUtil.searchAll(janeRestContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
+                                // Verify results and visibility for member user
+                                SearchTestsUtil.searchAll(jack.restContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
                                     assert.ok(!err);
                                     var publicUserResult = _getDocById(results, publicUserMember.id);
                                     var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
@@ -270,9 +289,11 @@ describe('Members Library Search', function() {
                                     var privateGroupResult = _getDocById(results, privateGroupMember.id);
                                     var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                    // Verify user sees all members
+                                    // Verify member user sees all members, even private
                                     assert.ok(publicUserResult);
                                     assert.ok(loggedinUserResult);
+                                    assert.ok(privateUserResult);
+                                    assert.ok(privateGroupResult);
                                     assert.ok(publicGroupResult);
 
                                     // Verify user visibility. Private should have their publicAlias swapped into the title
@@ -285,65 +306,25 @@ describe('Members Library Search', function() {
                                     assert.equal(loggedinUserResult.q_high, undefined);
                                     assert.equal(loggedinUserResult.q_low, undefined);
                                     assert.equal(loggedinUserResult.sort, undefined);
+                                    assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
                                     assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+                                    assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
 
                                     // Verify that the correct resourceTypes are set
                                     assert.equal(publicUserResult.resourceType, 'user');
                                     assert.equal(loggedinUserResult.resourceType, 'user');
+                                    assert.equal(privateUserResult.resourceType, 'user');
                                     assert.equal(publicGroupResult.resourceType, 'group');
+                                    assert.equal(privateGroupResult.resourceType, 'group');
 
                                     // Verify that the correct profilePaths are set
                                     assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
                                     assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
+                                    assert.equal(privateUserResult.profilePath, undefined);
                                     assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+                                    assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                                    // Verify results and visibility for member user
-                                    SearchTestsUtil.searchAll(jackRestContext, 'members-library', [targetPublicGroup.id], null, function(err, results) {
-                                        assert.ok(!err);
-                                        var publicUserResult = _getDocById(results, publicUserMember.id);
-                                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
-                                        var privateUserResult = _getDocById(results, privateUserMember.id);
-                                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
-                                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
-
-                                        // Verify user sees all
-                                        assert.ok(publicUserResult);
-                                        assert.ok(loggedinUserResult);
-                                        assert.ok(privateUserResult);
-                                        assert.ok(privateGroupResult);
-                                        assert.ok(publicGroupResult);
-
-                                        // Verify user visibility. Private should have their publicAlias swapped into the title
-                                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
-                                        assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
-
-                                        // There should be no extra right now because we haven't added extension properties
-                                        assert.ok(!loggedinUserResult.extra);
-
-                                        assert.equal(loggedinUserResult._extra, undefined);
-                                        assert.equal(loggedinUserResult.q_high, undefined);
-                                        assert.equal(loggedinUserResult.q_low, undefined);
-                                        assert.equal(loggedinUserResult.sort, undefined);
-                                        assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
-                                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
-                                        assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
-
-                                        // Verify that the correct resourceTypes are set
-                                        assert.equal(publicUserResult.resourceType, 'user');
-                                        assert.equal(loggedinUserResult.resourceType, 'user');
-                                        assert.equal(privateUserResult.resourceType, 'user');
-                                        assert.equal(publicGroupResult.resourceType, 'group');
-                                        assert.equal(privateGroupResult.resourceType, 'group');
-
-                                        // Verify that the correct profilePaths are set
-                                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
-                                        assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
-                                        assert.equal(privateUserResult.profilePath, undefined);
-                                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
-                                        assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });
@@ -357,41 +338,69 @@ describe('Members Library Search', function() {
      * Test that verifies that anonymous and cross-tenant users cannot see the group members of a loggedin group
      */
     it('verify loggedin group members access', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-        var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-        RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 var changes = {};
-                changes[jack.id] = 'member';
+                changes[jack.user.id] = 'member';
                 RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
-                        assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                    // Verify anonymous cannot see loggedin group
+                    SearchTestsUtil.searchAll(anonymousRestContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
+                        assert.ok(!results);
 
-                        // Verify anonymous cannot see loggedin group
-                        SearchTestsUtil.searchAll(anonymousRestContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
+                        // Verify results and visibility for cross-tenant user. Cross-tenant user cannot see memberships of 'loggedin' groups from other tenants
+                        SearchTestsUtil.searchAll(darthVader.restContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
                             assert.ok(!results);
 
-                            // Verify results and visibility for cross-tenant user. Cross-tenant user cannot see memberships of 'loggedin' groups from other tenants
-                            SearchTestsUtil.searchAll(darthVaderRestContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
-                                assert.ok(err);
-                                assert.equal(err.code, 401);
-                                assert.ok(!results);
+                            // Verify results and visibility for loggedin user
+                            SearchTestsUtil.searchAll(jane.restContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
+                                assert.ok(!err);
+                                var publicUserResult = _getDocById(results, publicUserMember.id);
+                                var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
+                                var privateUserResult = _getDocById(results, privateUserMember.id);
+                                var privateGroupResult = _getDocById(results, privateGroupMember.id);
+                                var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                // Verify results and visibility for loggedin user
-                                SearchTestsUtil.searchAll(janeRestContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
+                                // Verify only public and loggedin members are returned
+                                assert.ok(publicUserResult);
+                                assert.ok(loggedinUserResult);
+                                assert.ok(!privateUserResult);
+                                assert.ok(!privateGroupResult);
+                                assert.ok(publicGroupResult);
+
+                                // Verify user visibility. Private should have their publicAlias swapped into the title
+                                assert.equal(publicUserResult.displayName, publicUserMember.displayName);
+                                assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
+
+                                // There should be no extra right now because we haven't added extension properties
+                                assert.ok(!loggedinUserResult.extra);
+
+                                assert.equal(loggedinUserResult._extra, undefined);
+                                assert.equal(loggedinUserResult.q_high, undefined);
+                                assert.equal(loggedinUserResult.q_low, undefined);
+                                assert.equal(loggedinUserResult.sort, undefined);
+                                assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+
+                                // Verify that the correct resourceTypes are set
+                                assert.equal(publicUserResult.resourceType, 'user');
+                                assert.equal(loggedinUserResult.resourceType, 'user');
+                                assert.equal(publicGroupResult.resourceType, 'group');
+
+                                // Verify that the correct profilePaths are set
+                                assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
+                                assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
+                                assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+
+                                // Verify results and visibility for member user
+                                SearchTestsUtil.searchAll(jack.restContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
                                     assert.ok(!err);
                                     var publicUserResult = _getDocById(results, publicUserMember.id);
                                     var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
@@ -399,11 +408,11 @@ describe('Members Library Search', function() {
                                     var privateGroupResult = _getDocById(results, privateGroupMember.id);
                                     var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                    // Verify only public and loggedin members are found
+                                    // Verify member sees all
                                     assert.ok(publicUserResult);
                                     assert.ok(loggedinUserResult);
-                                    assert.ok(!privateUserResult);
-                                    assert.ok(!privateGroupResult);
+                                    assert.ok(privateUserResult);
+                                    assert.ok(privateGroupResult);
                                     assert.ok(publicGroupResult);
 
                                     // Verify user visibility. Private should have their publicAlias swapped into the title
@@ -417,65 +426,25 @@ describe('Members Library Search', function() {
                                     assert.equal(loggedinUserResult.q_high, undefined);
                                     assert.equal(loggedinUserResult.q_low, undefined);
                                     assert.equal(loggedinUserResult.sort, undefined);
+                                    assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
                                     assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+                                    assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
 
                                     // Verify that the correct resourceTypes are set
                                     assert.equal(publicUserResult.resourceType, 'user');
                                     assert.equal(loggedinUserResult.resourceType, 'user');
+                                    assert.equal(privateUserResult.resourceType, 'user');
                                     assert.equal(publicGroupResult.resourceType, 'group');
+                                    assert.equal(privateGroupResult.resourceType, 'group');
 
                                     // Verify that the correct profilePaths are set
                                     assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
                                     assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
+                                    assert.equal(privateUserResult.profilePath, undefined);
                                     assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+                                    assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                                    // Verify results and visibility for member user
-                                    SearchTestsUtil.searchAll(jackRestContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
-                                        assert.ok(!err);
-                                        var publicUserResult = _getDocById(results, publicUserMember.id);
-                                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
-                                        var privateUserResult = _getDocById(results, privateUserMember.id);
-                                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
-                                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
-
-                                        // Verify member sees all
-                                        assert.ok(publicUserResult);
-                                        assert.ok(loggedinUserResult);
-                                        assert.ok(privateUserResult);
-                                        assert.ok(privateGroupResult);
-                                        assert.ok(publicGroupResult);
-
-                                        // Verify user visibility. Private should have their publicAlias swapped into the title
-                                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
-                                        assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
-
-                                        // There should be no extra right now because we haven't added extension properties
-                                        assert.ok(!loggedinUserResult.extra);
-
-                                        assert.equal(loggedinUserResult._extra, undefined);
-                                        assert.equal(loggedinUserResult.q_high, undefined);
-                                        assert.equal(loggedinUserResult.q_low, undefined);
-                                        assert.equal(loggedinUserResult.sort, undefined);
-                                        assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
-                                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
-                                        assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
-
-                                        // Verify that the correct resourceTypes are set
-                                        assert.equal(publicUserResult.resourceType, 'user');
-                                        assert.equal(loggedinUserResult.resourceType, 'user');
-                                        assert.equal(privateUserResult.resourceType, 'user');
-                                        assert.equal(publicGroupResult.resourceType, 'group');
-                                        assert.equal(privateGroupResult.resourceType, 'group');
-
-                                        // Verify that the correct profilePaths are set
-                                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
-                                        assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
-                                        assert.equal(privateUserResult.profilePath, undefined);
-                                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
-                                        assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });
@@ -489,92 +458,80 @@ describe('Members Library Search', function() {
      * Test that verifies only members can search the group members of a private group.
      */
     it('verify private group members access', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-        var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-
-        RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
                 var changes = {};
-                changes[jack.id] = 'member';
+                changes[jack.user.id] = 'member';
                 RestAPI.Group.setGroupMembers(doerRestContext, targetPrivateGroup.id, changes, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
-                        assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                    // Verify anonymous cannot see members of private group
+                    SearchTestsUtil.searchAll(anonymousRestContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
+                        assert.ok(err);
+                        assert.equal(err.code, 401);
+                        assert.ok(!results);
 
-                        // Verify anonymous cannot see members of private group
-                        SearchTestsUtil.searchAll(anonymousRestContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
+                        // Verify cross-tenant user cannot see members of private group
+                        SearchTestsUtil.searchAll(darthVader.restContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
                             assert.ok(!results);
 
-                            // Verify cross-tenant user cannot see members of private group
-                            SearchTestsUtil.searchAll(darthVaderRestContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
+                            // Verify loggedin user cannot see members of private group
+                            SearchTestsUtil.searchAll(jane.restContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
                                 assert.ok(err);
                                 assert.equal(err.code, 401);
                                 assert.ok(!results);
 
-                                // Verify loggedin user cannot see members of private group
-                                SearchTestsUtil.searchAll(janeRestContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
-                                    assert.ok(!results);
+                                // Verify results and visibility for member user
+                                SearchTestsUtil.searchAll(jack.restContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
+                                    assert.ok(!err);
+                                    var publicUserResult = _getDocById(results, publicUserMember.id);
+                                    var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
+                                    var privateUserResult = _getDocById(results, privateUserMember.id);
+                                    var privateGroupResult = _getDocById(results, privateGroupMember.id);
+                                    var publicGroupResult = _getDocById(results, publicGroupMember.id);
 
-                                    // Verify results and visibility for member user
-                                    SearchTestsUtil.searchAll(jackRestContext, 'members-library', [targetPrivateGroup.id], null, function(err, results) {
-                                        assert.ok(!err);
-                                        var publicUserResult = _getDocById(results, publicUserMember.id);
-                                        var loggedinUserResult = _getDocById(results, loggedinUserMember.id);
-                                        var privateUserResult = _getDocById(results, privateUserMember.id);
-                                        var privateGroupResult = _getDocById(results, privateGroupMember.id);
-                                        var publicGroupResult = _getDocById(results, publicGroupMember.id);
+                                    // Verify member sees all
+                                    assert.ok(publicUserResult);
+                                    assert.ok(loggedinUserResult);
+                                    assert.ok(privateUserResult);
+                                    assert.ok(privateGroupResult);
+                                    assert.ok(publicGroupResult);
 
-                                        // Verify member sees all.
-                                        assert.ok(publicUserResult);
-                                        assert.ok(loggedinUserResult);
-                                        assert.ok(privateUserResult);
-                                        assert.ok(privateGroupResult);
-                                        assert.ok(publicGroupResult);
+                                    // Verify user visibility. Private should have their publicAlias swapped into the title
+                                    assert.equal(publicUserResult.displayName, publicUserMember.displayName);
+                                    assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
 
-                                        // Verify user visibility. Private should have their publicAlias swapped into the title
-                                        assert.equal(publicUserResult.displayName, publicUserMember.displayName);
-                                        assert.equal(loggedinUserResult.displayName, loggedinUserMember.displayName);
+                                    // There should be no extra right now because we haven't added extension properties
+                                    assert.ok(!loggedinUserResult.extra);
 
-                                        // There should be no extra right now because we haven't added extension properties
-                                        assert.ok(!loggedinUserResult.extra);
+                                    assert.equal(loggedinUserResult._extra, undefined);
+                                    assert.equal(loggedinUserResult.q_high, undefined);
+                                    assert.equal(loggedinUserResult.q_low, undefined);
+                                    assert.equal(loggedinUserResult.sort, undefined);
+                                    assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
+                                    assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
+                                    assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
 
-                                        assert.equal(loggedinUserResult._extra, undefined);
-                                        assert.equal(loggedinUserResult.q_high, undefined);
-                                        assert.equal(loggedinUserResult.q_low, undefined);
-                                        assert.equal(loggedinUserResult.sort, undefined);
-                                        assert.equal(privateUserResult.displayName, privateUserMember.publicAlias);
-                                        assert.equal(publicGroupResult.displayName, publicGroupMember.displayName);
-                                        assert.equal(privateGroupResult.displayName, privateGroupMember.displayName);
+                                    // Verify that the correct resourceTypes are set
+                                    assert.equal(publicUserResult.resourceType, 'user');
+                                    assert.equal(loggedinUserResult.resourceType, 'user');
+                                    assert.equal(privateUserResult.resourceType, 'user');
+                                    assert.equal(publicGroupResult.resourceType, 'group');
+                                    assert.equal(privateGroupResult.resourceType, 'group');
 
-                                        // Verify that the correct resourceTypes are set
-                                        assert.equal(publicUserResult.resourceType, 'user');
-                                        assert.equal(loggedinUserResult.resourceType, 'user');
-                                        assert.equal(privateUserResult.resourceType, 'user');
-                                        assert.equal(publicGroupResult.resourceType, 'group');
-                                        assert.equal(privateGroupResult.resourceType, 'group');
+                                    // Verify that the correct profilePaths are set
+                                    assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
+                                    assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
+                                    assert.equal(privateUserResult.profilePath, undefined);
+                                    assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
+                                    assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
 
-                                        // Verify that the correct profilePaths are set
-                                        assert.equal(publicUserResult.profilePath, '/user/' + publicUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicUserResult.id).resourceId);
-                                        assert.equal(loggedinUserResult.profilePath, '/user/' + loggedinUserResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(loggedinUserResult.id).resourceId);
-                                        assert.equal(privateUserResult.profilePath, undefined);
-                                        assert.equal(publicGroupResult.profilePath, '/group/' + publicGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(publicGroupResult.id).resourceId);
-                                        assert.equal(privateGroupResult.profilePath, '/group/' + privateGroupResult.tenant.alias + '/' + AuthzUtil.getResourceFromId(privateGroupResult.id).resourceId);
-
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });
@@ -588,39 +545,30 @@ describe('Members Library Search', function() {
      * Test that verifies when a member is removed from a group, that principal no longer turns up in the members search.
      */
     it('verify remove from group reflects in members', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-
-        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
-            var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
             var changes = {};
-            changes[jack.id] = 'member';
+            changes[jack.user.id] = 'member';
             RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                 assert.ok(!err);
 
-                RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+                // Verify jack exists for jane
+                SearchTestsUtil.searchAll(jane.restContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
                     assert.ok(!err);
-                    var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                    var jackDoc = _getDocById(results, jack.user.id);
+                    assert.ok(jackDoc);
 
-                    // Verify jack exists for jane
-                    SearchTestsUtil.searchAll(janeRestContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
+                    // Remove jack and verify he no longer returns in searches
+                    changes[jack.user.id] = false;
+                    RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                         assert.ok(!err);
-                        var jackDoc = _getDocById(results, jack.id);
-                        assert.ok(jackDoc);
 
-                        // Remove jack and verify he no longer returns in searches
-                        changes[jack.id] = false;
-                        RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
+                        SearchTestsUtil.searchAll(jane.restContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
                             assert.ok(!err);
-
-                            SearchTestsUtil.searchAll(janeRestContext, 'members-library', [targetLoggedinGroup.id], null, function(err, results) {
-                                assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
-                                assert.ok(!jackDoc);
-                                callback();
-                            });
+                            var jackDoc = _getDocById(results, jack.user.id);
+                            assert.ok(!jackDoc);
+                            return callback();
                         });
                     });
                 });
@@ -632,50 +580,42 @@ describe('Members Library Search', function() {
      * Test that verifies paging in the members search feed
      */
     it('verify paging works correcly in the members search', function(callback) {
-        var jackUsername = TestsUtil.generateTestUserId('jack');
-        var janeUsername = TestsUtil.generateTestUserId('jane');
-
-        // Create 2 users and add them as members to the group to test
-        RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
             assert.ok(!err);
 
-            RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Jane McJaneFace', null, function(err, jane) {
+            var changes = {};
+            changes[jack.user.id] = 'member';
+            changes[jane.user.id] = 'member';
+            RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
                 assert.ok(!err);
 
-                var changes = {};
-                changes[jack.id] = 'member';
-                changes[jane.id] = 'member';
-                RestAPI.Group.setGroupMembers(doerRestContext, targetLoggedinGroup.id, changes, function(err) {
+                // Grab the first 2 members of the group, we will page these 2
+                SearchTestsUtil.searchRefreshed(doerRestContext, 'members-library', [targetLoggedinGroup.id], {'limit': 2, 'start': 0}, function(err, results) {
                     assert.ok(!err);
+                    assert.ok(results.results);
+                    assert.equal(results.results.length, 2);
 
-                    // Grab the first 2 members of the group, we will page these 2
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'members-library', [targetLoggedinGroup.id], {'limit': 2, 'start': 0}, function(err, results) {
+                    // Get the ids of the first 2 expected results.
+                    var firstId = results.results[0].id;
+                    var secondId = results.results[1].id;
+
+                    assert.ok(firstId);
+                    assert.ok(secondId);
+
+                    // Get the first page, ensure it is the first document. We don't need refreshing because we haven't updated anything since the previous refresh
+                    RestAPI.Search.search(doerRestContext, 'members-library', [targetLoggedinGroup.id], {'limit': 1, 'start': 0}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(results.results);
-                        assert.equal(results.results.length, 2);
+                        assert.equal(results.results.length, 1);
+                        assert.equal(results.results[0].id, firstId);
 
-                        // Get the ids of the first 2 expected results.
-                        var firstId = results.results[0].id;
-                        var secondId = results.results[1].id;
-
-                        assert.ok(firstId);
-                        assert.ok(secondId);
-
-                        // Get the first page, ensure it is the first document. We don't need refreshing because we haven't updated anything since the previous refresh.
-                        RestAPI.Search.search(doerRestContext, 'members-library', [targetLoggedinGroup.id], {'limit': 1, 'start': 0}, function(err, results) {
+                        // Get the second page, ensure it is the second document
+                        RestAPI.Search.search(doerRestContext, 'members-library', [targetLoggedinGroup.id], {'limit': 1, 'start': 1}, function(err, results) {
                             assert.ok(!err);
                             assert.ok(results.results);
                             assert.equal(results.results.length, 1);
-                            assert.equal(results.results[0].id, firstId);
-
-                            // Get the second page, ensure it is the second document
-                            RestAPI.Search.search(doerRestContext, 'members-library', [targetLoggedinGroup.id], {'limit': 1, 'start': 1}, function(err, results) {
-                                assert.ok(!err);
-                                assert.ok(results.results);
-                                assert.equal(results.results.length, 1);
-                                assert.equal(results.results[0].id, secondId);
-                                callback();
-                            });
+                            assert.equal(results.results[0].id, secondId);
+                            return callback();
                         });
                     });
                 });

--- a/node_modules/oae-principals/tests/test-memberships-library.js
+++ b/node_modules/oae-principals/tests/test-memberships-library.js
@@ -431,61 +431,53 @@ describe('Memberships Library', function() {
          * returning in searches.
          */
         it('verify removing member from group removes it from private and non-private library', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
             var groupParentAlias = TestsUtil.generateTestUserId('groupParent');
             var groupChildAlias = TestsUtil.generateTestUserId('groupChild');
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
+                assert.ok(!err);
 
-                TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, jack) {
+                // Create a group hierarchy to ensure they all show up in 'jack's group membership search
+                RestAPI.Group.createGroup(doer.restContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [], function(err, groupParent) {
                     assert.ok(!err);
 
-                    jack = _.values(jack)[0];
-
-                    // Create a group hierarchy to ensure they all show up in 'jack's group membership search
-                    RestAPI.Group.createGroup(doerRestContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [], function(err, groupParent) {
+                    RestAPI.Group.createGroup(doer.restContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [], function(err, groupChild) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(doerRestContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [], function(err, groupChild) {
+                        TestsUtil.generateGroupHierarchy(doer.restContext, [groupParent.id, groupChild.id, jack.user.id], 'member', function(err) {
                             assert.ok(!err);
 
-                            TestsUtil.generateGroupHierarchy(doerRestContext, [groupParent.id, groupChild.id, jack.user.id], 'member', function(err) {
+                            // Search all and ensure the private feed search contains both groups
+                            SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                 assert.ok(!err);
+                                assert.ok(_getDocById(results, groupChild.id));
+                                assert.ok(_getDocById(results, groupParent.id));
 
-                                // Search all and ensure the private feed search contains both groups
-                                SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
+                                // Ensure loggedin feed has just the direct group
+                                SearchTestsUtil.searchAll(doer.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(_getDocById(results, groupChild.id));
-                                    assert.ok(_getDocById(results, groupParent.id));
+                                    assert.ok(!_getDocById(results, groupParent.id));
 
-                                    // Ensure loggedin feed has just the direct group
-                                    SearchTestsUtil.searchAll(doerRestContext, 'memberships-library', [jack.user.id], null, function(err, results) {
+                                    // Unlink the hierarchy by removing jack from the 'bottom' group
+                                    var changes = {};
+                                    changes[jack.user.id] = false;
+                                    RestAPI.Group.setGroupMembers(doer.restContext, groupChild.id, changes, function(err) {
                                         assert.ok(!err);
-                                        assert.ok(_getDocById(results, groupChild.id));
-                                        assert.ok(!_getDocById(results, groupParent.id));
 
-                                        // Unlink the hierarchy by removing jack from the 'bottom' group
-                                        var changes = {};
-                                        changes[jack.user.id] = false;
-                                        RestAPI.Group.setGroupMembers(doerRestContext, groupChild.id, changes, function(err) {
+                                        // Verify the private memberships search is now empty
+                                        SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                             assert.ok(!err);
+                                            assert.equal(results.total, 0);
+                                            assert.equal(results.results.length, 0);
 
-                                            // Verify the private memberships search is now empty
-                                            SearchTestsUtil.searchAll(jack.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
+                                            // Verify the loggedin memberships search is now empty
+                                            SearchTestsUtil.searchAll(doer.restContext, 'memberships-library', [jack.user.id], null, function(err, results) {
                                                 assert.ok(!err);
                                                 assert.equal(results.total, 0);
                                                 assert.equal(results.results.length, 0);
 
-                                                // Verify the loggedin memberships search is now empty
-                                                SearchTestsUtil.searchAll(doerRestContext, 'memberships-library', [jack.user.id], null, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.equal(results.total, 0);
-                                                    assert.equal(results.results.length, 0);
-
-                                                    return callback();
-                                                });
+                                                return callback();
                                             });
                                         });
                                     });
@@ -501,58 +493,49 @@ describe('Memberships Library', function() {
          * Test that verifies paging works correctly in memberships search.
          */
         it('verify paging works correctly in memberships library search', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
             var groupParentAlias = TestsUtil.generateTestUserId('groupParent');
             var groupChildAlias = TestsUtil.generateTestUserId('groupChild');
 
-            // Create the user with which we'll set up the data
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, doer) {
 
-                // Create the user whose memberships to check
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                // Create a group hierarchy to ensure we have memberships
+                RestAPI.Group.createGroup(doer.restContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [jack.user.id], function(err, groupParent) {
                     assert.ok(!err);
 
-                    // Create a group hierarchy to ensure we have memberships
-                    RestAPI.Group.createGroup(doerRestContext, groupParentAlias, groupParentAlias, 'public', 'no', [], [jack.id], function(err, groupParent) {
+                    RestAPI.Group.createGroup(doer.restContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [jack.user.id], function(err, groupChild) {
                         assert.ok(!err);
 
-                        RestAPI.Group.createGroup(doerRestContext, groupChildAlias, groupChildAlias, 'public', 'no', [], [jack.id], function(err, groupChild) {
+                        // Search only 2 documents to get the expected ids for paging afterward
+                        SearchTestsUtil.searchRefreshed(doer.restContext, 'memberships-library', [jack.user.id], {'limit': 2, 'start': 0}, function(err, results) {
                             assert.ok(!err);
+                            assert.ok(results.results);
+                            assert.ok(results.results.length, 2);
 
-                            // Search only 2 documents to get the expected ids for paging afterward
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'memberships-library', [jack.id], {'limit': 2, 'start': 0}, function(err, results) {
+                            // Get the ids of the first 2 expected results.
+                            var firstId = results.results[0].id;
+                            var secondId = results.results[1].id;
+
+                            assert.ok(firstId);
+                            assert.ok(secondId);
+
+                            // Verify page 1 gives the first id. We don't need to refresh since we haven't updated anything since the first refresh.
+                            RestAPI.Search.search(doer.restContext, 'memberships-library', [jack.user.id], {'limit': 1, 'start': 0}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(results.results);
-                                assert.ok(results.results.length, 2);
+                                assert.ok(results.results.length, 1);
+                                assert.equal(results.results[0].id, firstId);
+                                assert.equal(results.results[0].resourceType, 'group');
+                                assert.equal(results.results[0].profilePath, '/group/' + results.results[0].tenant.alias + '/' + AuthzUtil.getResourceFromId(results.results[0].id).resourceId);
 
-                                // Get the ids of the first 2 expected results.
-                                var firstId = results.results[0].id;
-                                var secondId = results.results[1].id;
-
-                                assert.ok(firstId);
-                                assert.ok(secondId);
-
-                                // Verify page 1 gives the first id. We don't need to refresh since we haven't updated anything since the first refresh.
-                                RestAPI.Search.search(doerRestContext, 'memberships-library', [jack.id], {'limit': 1, 'start': 0}, function(err, results) {
+                                // Verify page 2 gives the second id
+                                RestAPI.Search.search(doer.restContext, 'memberships-library', [jack.user.id], {'limit': 1, 'start': 1}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(results.results);
                                     assert.ok(results.results.length, 1);
-                                    assert.equal(results.results[0].id, firstId);
+                                    assert.equal(results.results[0].id, secondId);
                                     assert.equal(results.results[0].resourceType, 'group');
                                     assert.equal(results.results[0].profilePath, '/group/' + results.results[0].tenant.alias + '/' + AuthzUtil.getResourceFromId(results.results[0].id).resourceId);
-
-                                    // Verify page 2 gives the second id
-                                    RestAPI.Search.search(doerRestContext, 'memberships-library', [jack.id], {'limit': 1, 'start': 1}, function(err, results) {
-                                        assert.ok(!err);
-                                        assert.ok(results.results);
-                                        assert.ok(results.results.length, 1);
-                                        assert.equal(results.results[0].id, secondId);
-                                        assert.equal(results.results[0].resourceType, 'group');
-                                        assert.equal(results.results[0].profilePath, '/group/' + results.results[0].tenant.alias + '/' + AuthzUtil.getResourceFromId(results.results[0].id).resourceId);
-                                        callback();
-                                    });
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-principals/tests/test-search.js
+++ b/node_modules/oae-principals/tests/test-search.js
@@ -65,47 +65,39 @@ describe('Search', function() {
          * item.
          */
         it('verify indexing without full user item', function(callback) {
-            var username = TestsUtil.generateTestUserId('user');
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, doer, jack) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create the user we will test with
-                RestAPI.User.createUser(camAdminRestContext, username, username, username, null, function(err, user) {
+                // Verify the content item exists
+                SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                     assert.ok(!err);
+                    var userDoc = _getDocById(results, jack.user.id);
+                    assert.ok(userDoc);
 
-                    // Verify the content item exists
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'user', 'q': username}, function(err, results) {
+                    // Delete the content item from the index under the hood, this is to avoid the automatic index events invalidating the test
+                    ElasticSearch.del('resource', jack.user.id, function(err) {
                         assert.ok(!err);
-                        var userDoc = _getDocById(results, user.id);
-                        assert.ok(userDoc);
 
-                        // Delete the content item from the index under the hood, this is to avoid the automatic index events invalidating the test
-                        ElasticSearch.del('resource', user.id, function(err) {
+                        // Verify the content item no longer exists
+                        SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
+                            var userDoc = _getDocById(results, jack.user.id);
+                            assert.ok(!userDoc);
 
-                            // Verify the content item no longer exists
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'user', 'q': username}, function(err, results) {
+                            // Fire off an indexing task using just the user id
+                            SearchAPI.postIndexTask('user', [{'id': jack.user.id}], {'resource': true}, function(err) {
                                 assert.ok(!err);
-                                var userDoc = _getDocById(results, user.id);
-                                assert.ok(!userDoc);
 
-                                // Fire off an indexing task using just the user id
-                                SearchAPI.postIndexTask('user', [{'id': user.id}], {'resource': true}, function(err) {
+                                // Ensure that the full content item is now back in the search index
+                                SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-
-                                    // Ensure that the full content item is now back in the search index
-                                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'user', 'q': username}, function(err, results) {
-                                        assert.ok(!err);
-                                        var userDoc = _getDocById(results, user.id);
-                                        assert.ok(userDoc);
-                                        assert.ok(_.isObject(userDoc.tenant));
-                                        assert.equal(_.keys(userDoc.tenant).length, 2);
-                                        assert.equal(userDoc.tenant.displayName, global.oaeTests.tenants.cam.displayName);
-                                        assert.equal(userDoc.tenant.alias, global.oaeTests.tenants.cam.alias);
-                                        callback();
-                                    });
+                                    var userDoc = _getDocById(results, jack.user.id);
+                                    assert.ok(userDoc);
+                                    assert.ok(_.isObject(userDoc.tenant));
+                                    assert.equal(_.keys(userDoc.tenant).length, 2);
+                                    assert.equal(userDoc.tenant.displayName, global.oaeTests.tenants.cam.displayName);
+                                    assert.equal(userDoc.tenant.alias, global.oaeTests.tenants.cam.alias);
+                                    return callback();
                                 });
                             });
                         });
@@ -120,17 +112,16 @@ describe('Search', function() {
          * item.
          */
         it('verify indexing without full group item', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
                 // Create the group we will test with
                 var groupText = TestsUtil.generateTestUserId('group');
-                RestAPI.Group.createGroup(doerRestContext, groupText, groupText, 'public', 'no', [], [], function(err, group) {
+                RestAPI.Group.createGroup(doer.restContext, groupText, groupText, 'public', 'no', [], [], function(err, group) {
                     assert.ok(!err);
 
                     // Verify the content item exists
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
                         assert.ok(!err);
                         var groupDoc = _getDocById(results, group.id);
                         assert.ok(groupDoc);
@@ -140,7 +131,7 @@ describe('Search', function() {
                             assert.ok(!err);
 
                             // Verify the content item no longer exists
-                            SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
+                            SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
                                 assert.ok(!err);
                                 var groupDoc = _getDocById(results, group.id);
                                 assert.ok(!groupDoc);
@@ -149,7 +140,7 @@ describe('Search', function() {
                                 SearchAPI.postIndexTask('group', [{'id': group.id}], {'resource': true}, function(err) {
 
                                     // Ensure that the full content item is now back in the search index
-                                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
+                                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': groupText}, function(err, results) {
                                         assert.ok(!err);
                                         var groupDoc = _getDocById(results, group.id);
                                         assert.ok(groupDoc);

--- a/node_modules/oae-principals/tests/test-terms-and-conditions.js
+++ b/node_modules/oae-principals/tests/test-terms-and-conditions.js
@@ -93,14 +93,15 @@ describe('Terms and Conditions', function() {
 
                 // Not passing in acceptedTC: true should result in a 400
                 var username = TestsUtil.generateRandomText(5);
-                RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', null, function(err, userObj) {
+                var email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {}, function(err, userObj) {
                     assert.equal(err.code, 400);
-                    RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', {'acceptedTC': false}, function(err, userObj) {
+                    RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {'acceptedTC': false}, function(err, userObj) {
                         assert.equal(err.code, 400);
-                        RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', {'acceptedTC': 'wrong'}, function(err, userObj) {
+                        RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {'acceptedTC': 'wrong'}, function(err, userObj) {
                             assert.equal(err.code, 400);
 
-                            RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', {'acceptedTC': true}, function(err, userObj) {
+                            RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {'acceptedTC': true}, function(err, userObj) {
                                 assert.ok(!err);
                                 assert.equal(typeof userObj.acceptedTC, 'number');
                                 assert.ok(userObj.acceptedTC <= Date.now());

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -31,7 +31,6 @@ var TZ = require('oae-util/lib/tz');
 
 var PrincipalsAPI = require('oae-principals');
 var PrincipalsTestUtil = require('oae-principals/lib/test/util');
-var User = require('oae-principals/lib/model.user').User;
 
 
 describe('Users', function() {
@@ -53,7 +52,7 @@ describe('Users', function() {
     };
 
     /**
-     * Function that will fill up the anonymous and the tenant admin context
+     * Function that will fill up the REST and admin contexts
      */
     before(function(callback) {
         // Fill up the request contexts
@@ -61,14 +60,9 @@ describe('Users', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
-
-        var globalTenant = new Tenant('admin', 'Global tenant', 'localhost:2000');
-        var mockUserId = 'u:' + globalTenant.alias + ':admin';
-        globalAdminContext = new Context(globalTenant, new User(globalTenant.alias, mockUserId, 'The global admin user', { isGlobalAdmin: true }));
-
+        globalAdminContext = TestsUtil.createGlobalAdminContext();
         anonymousGlobalRestContext = TestsUtil.createGlobalRestContext();
-
-        callback();
+        return callback();
     });
 
     describe('Full User Profile Decorators', function() {
@@ -180,29 +174,32 @@ describe('Users', function() {
                 ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, recaptchaTenantAlias, {'oae-principals/recaptcha/enabled': true}, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(recaptchaAnonymousRestContext, username, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                    var email = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(recaptchaAnonymousRestContext, username, 'password', 'Test User', email, {'visibility': 'public'}, function(err, userObj) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
                         assert.ok(!userObj);
 
-                        RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public'}, function(err, createdUser) {
+                        RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {'visibility': 'public'}, function(err, createdUser) {
                             assert.ok(!err);
                             assert.ok(createdUser);
                             assert.equal(createdUser.displayName, 'Test User');
                             assert.equal(createdUser.publicAlias, 'Test User');
                             assert.equal(createdUser.visibility, 'public');
                             assert.equal(createdUser.resourceType, 'user');
+                            assert.equal(createdUser.email, email.toLowerCase());
                             assert.equal(createdUser.profilePath, '/user/' + createdUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(createdUser.id).resourceId);
                             var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                             // Try creating a user with the same username, which should fail
-                            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, userObj) {
+                            var email2 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email2, {}, function(err, userObj) {
                                 assert.ok(err);
                                 assert.ok(!userObj);
 
                                 // Try creating a new user as the created user
                                 var newUsername = TestsUtil.generateTestUserId();
-                                RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', email2, {}, function(err, userObj) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
 
@@ -211,13 +208,14 @@ describe('Users', function() {
                                         assert.ok(!err);
 
                                         // Try creating the user again
-                                        RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                        RestAPI.User.createUser(userRestContext, newUsername, 'password', 'Test User', email2, {}, function(err, userObj) {
                                             assert.ok(!err);
                                             assert.ok(userObj);
 
                                             // Create a user on a tenant as the global administrator
                                             newUsername = TestsUtil.generateTestUserId();
-                                            RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                                            var email3 = TestsUtil.generateTestEmailAddress();
+                                            RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email3, {'visibility': 'public'}, function(err, userObj) {
                                                 assert.ok(!err);
                                                 assert.ok(userObj);
                                                 assert.equal(userObj.displayName, 'Test User');
@@ -228,25 +226,27 @@ describe('Users', function() {
 
                                                 // Create a user on the global tenant as the global administrator
                                                 newUsername = TestsUtil.generateTestUserId();
-                                                RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                                                var email4 = TestsUtil.generateTestEmailAddress();
+                                                RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email4, {'visibility': 'public'}, function(err, userObj) {
                                                     assert.ok(!err);
                                                     assert.ok(userObj);
 
                                                     // Verify we cannot create a user on the global admin tenant as an anonymous user
                                                     newUsername = TestsUtil.generateTestUserId();
-                                                    RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, 'admin', newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                                    var email5 = TestsUtil.generateTestEmailAddress();
+                                                    RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, 'admin', newUsername, 'password', 'Test User', email5, {}, function(err, userObj) {
                                                         assert.ok(err);
                                                         assert.equal(err.code, 401);
 
                                                         // Verify we cannot create a user on another tenant as global admin anonymous user
-                                                        RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', null, function(err, userObj) {
+                                                        RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email5, {}, function(err, userObj) {
                                                             assert.ok(err);
                                                             assert.equal(err.code, 401);
 
                                                             // Verify we cannot create a user on another tenant as a tenant admin. We check for a 404 because at the moment there is no
                                                             // such endpoint bound to the user tenant
                                                             newUsername = TestsUtil.generateTestUserId();
-                                                            RestAPI.User.createUserOnTenant(camAdminRestContext, global.oaeTests.tenants.gt.alias, newUsername, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+                                                            RestAPI.User.createUserOnTenant(camAdminRestContext, global.oaeTests.tenants.gt.alias, newUsername, 'password', 'Test User', email5, {'visibility': 'public'}, function(err, userObj) {
                                                                 assert.ok(err);
                                                                 assert.strictEqual(err.code, 404);
                                                                 return callback();
@@ -272,7 +272,8 @@ describe('Users', function() {
             var camTenantAlias = global.oaeTests.tenants.cam.alias;
 
             // Create a user to ensure the default user visibility of the tenant starts as public
-            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bart', null, function(err, createdUser) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bart', email1, {}, function(err, createdUser) {
                 assert.ok(!err);
                 assert.equal(createdUser.visibility, 'public');
 
@@ -281,7 +282,8 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create a user to ensure its visibility defaults to loggedin
-                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', null, function(err, createdUser) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', email2, {}, function(err, createdUser) {
                         assert.ok(!err);
                         assert.equal(createdUser.visibility, 'loggedin');
 
@@ -290,7 +292,8 @@ describe('Users', function() {
                             assert.ok(!err);
 
                             // Ensure a user's visibility can be overridden when they are created
-                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', {'visibility': 'private'}, function(err, createdUser) {
+                            var email3 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', email3, {'visibility': 'private'}, function(err, createdUser) {
                                 assert.ok(!err);
                                 assert.equal(createdUser.visibility, 'private');
                                 return callback();
@@ -308,7 +311,8 @@ describe('Users', function() {
             var camTenantAlias = global.oaeTests.tenants.cam.alias;
 
             // Create a user to ensure the default user email preference of the tenant starts as immediate
-            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bert', null, function(err, createdUser) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bert', email1, {}, function(err, createdUser) {
                 assert.ok(!err);
                 assert.equal(createdUser.emailPreference, 'immediate');
 
@@ -317,7 +321,8 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create a user to ensure its email preference defaults to weekly
-                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', null, function(err, createdUser) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', email2, {}, function(err, createdUser) {
                         assert.ok(!err);
                         assert.equal(createdUser.emailPreference, 'weekly');
 
@@ -326,7 +331,8 @@ describe('Users', function() {
                             assert.ok(!err);
 
                             // Ensure a user's email preference can be overridden when they are created
-                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', {'emailPreference': 'daily'}, function(err, createdUser) {
+                            var email3 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', email3, {'emailPreference': 'daily'}, function(err, createdUser) {
                                 assert.ok(!err);
                                 assert.equal(createdUser.emailPreference, 'daily');
                                 return callback();
@@ -346,13 +352,15 @@ describe('Users', function() {
             var lowerCasedUsername = username.toLowerCase();
             var upperCasedUsername = username.toUpperCase();
 
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', null, function(err, createdUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                 assert.ok(!err);
 
                 // Verify we cannot create another user account where the username only differs in the casing
-                RestAPI.User.createUser(camAdminRestContext, lowerCasedUsername, 'password', 'Test User', null, function(err) {
+                var email2 = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(camAdminRestContext, lowerCasedUsername, 'password', 'Test User', email2, {}, function(err) {
                     assert.equal(err.code, 400);
-                    RestAPI.User.createUser(camAdminRestContext, upperCasedUsername, 'password', 'Test User', null, function(err) {
+                    RestAPI.User.createUser(camAdminRestContext, upperCasedUsername, 'password', 'Test User', email2, {}, function(err) {
                         assert.equal(err.code, 400);
 
                         // When logging in with the same username but in lower case we should succesfully log in
@@ -389,7 +397,8 @@ describe('Users', function() {
             var userId3 = TestsUtil.generateTestUserId();
 
             // Create user without locale
-            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User 1', null, function(err, createdUser1) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User 1', email1, {}, function(err, createdUser1) {
                 assert.ok(!err);
                 assert.ok(createdUser1);
                 // Check that the user has been given the default locale
@@ -400,7 +409,8 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create user without locale
-                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Test User 2', null, function(err, createdUser2) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Test User 2', email2, {}, function(err, createdUser2) {
                         assert.ok(!err);
                         assert.ok(createdUser2);
                         // Check that the user has been given the new default locale
@@ -412,7 +422,10 @@ describe('Users', function() {
                             'additionalHeaders': { 'Accept-Language': 'en-us' }
                         });
                         ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-principals/recaptcha/enabled': false}, function(err) {
-                            RestAPI.User.createUser(acceptLanguageRestContext, userId3, 'password', 'Test User 3', null, function(err, createdUser3) {
+                            assert.ok(!err);
+
+                            var email3 = TestsUtil.generateTestEmailAddress();
+                            RestAPI.User.createUser(acceptLanguageRestContext, userId3, 'password', 'Test User 3', email3, {}, function(err, createdUser3) {
                                 assert.ok(!err);
                                 assert.ok(createdUser3);
                                 assert.equal(createdUser3.locale, 'en_US');
@@ -527,39 +540,51 @@ describe('Users', function() {
          */
         it('verify validation', function(callback) {
             var userId = TestsUtil.generateTestUserId();
+            var email = TestsUtil.generateTestEmailAddress();
 
             // Create user with no user id
-            RestAPI.User.createUser(camAdminRestContext, null, 'password', 'Test User', null, function(err, userObj) {
+            RestAPI.User.createUser(camAdminRestContext, null, 'password', 'Test User', email, {}, function(err, userObj) {
                 assert.ok(err);
                 assert.ok(!userObj);
 
                 // Create user with empty password
-                RestAPI.User.createUser(camAdminRestContext, userId, null, 'Test User', null, function(err, userObj) {
+                RestAPI.User.createUser(camAdminRestContext, userId, null, 'Test User', email, {}, function(err, userObj) {
                     assert.ok(err);
                     assert.ok(!userObj);
 
                     // Create user with short password
-                    RestAPI.User.createUser(camAdminRestContext, userId, 'short', 'Test User', null, function(err, userObj) {
+                    RestAPI.User.createUser(camAdminRestContext, userId, 'short', 'Test User', email, {}, function(err, userObj) {
                         assert.ok(err);
                         assert.ok(!userObj);
 
                         // Create user with no display name
-                        RestAPI.User.createUser(camAdminRestContext, userId, 'password', null, null, function(err, userObj) {
+                        RestAPI.User.createUser(camAdminRestContext, userId, 'password', null, email, {}, function(err, userObj) {
                             assert.ok(err);
                             assert.ok(!userObj);
 
                             // Create user with unkown visibility setting
-                            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', {'visibility': 'unknown'}, function(err, userObj) {
+                            RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', email, {'visibility': 'unknown'}, function(err, userObj) {
                                 assert.ok(err);
                                 assert.ok(!userObj);
 
                                 // Create user with displayName that is longer than the maximum allowed size
                                 var longDisplayName = TestsUtil.generateRandomText(100);
-                                RestAPI.User.createUser(camAdminRestContext, userId, 'password', longDisplayName, {}, function(err, userObj) {
+                                RestAPI.User.createUser(camAdminRestContext, userId, 'password', longDisplayName, email, {}, function(err, userObj) {
                                     assert.ok(err);
                                     assert.equal(err.code, 400);
-                                    assert.ok(!userObj);
-                                    return callback();
+
+                                    // Create a user with no email address
+                                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test user', null, {}, function(err, userObj) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 400);
+
+                                        // Create a user with an invalid email address
+                                        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test user', 'not an email address', {}, function(err, userObj) {
+                                            assert.ok(err);
+                                            assert.equal(err.code, 400);
+                                            return callback();
+                                        });
+                                    });
                                 });
                             });
                         });
@@ -613,29 +638,29 @@ describe('Users', function() {
                 assert.ok(!err);
 
                 // Import users as a global admin using a local authentication strategy
-                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password-displayname.csv'), 'local', null, function(err) {
                     assert.ok(!err);
 
                     // Verify that all imported users have been created
                     // First user in the csv
                     var nicolaasRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-zfdHliPLa', 'password1');
                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                         // User with missing first name
                         var simonRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-HlKKreaDP', 'password4');
                         RestAPI.User.getMe(simonRestContext, function(err, simonMeObj) {
-                            _verifyUser(err, simonMeObj, 'Gaeremynck', 'Gaeremynck', 'simon@test.com');
+                            _verifyUser(err, simonMeObj, 'Gaeremynck', 'Gaeremynck', 'simon@displayname.test.com');
 
                             // User with more complex display name
                             var stuartRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-IrewPDSAw', 'password5');
                             RestAPI.User.getMe(stuartRestContext, function(err, stuartMeObj) {
-                                _verifyUser(err, stuartMeObj, 'Stuart D. Freeman', 'Stuart D. Freeman', 'stuart@test.com');
+                                _verifyUser(err, stuartMeObj, 'Stuart D. Freeman', 'Stuart D. Freeman', 'stuart@displayname.test.com');
 
                                 // Last user in the csv
                                 var stephenRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-bbLwAWxpd', 'password26');
                                 RestAPI.User.getMe(stephenRestContext, function(err, stephenMeObj) {
-                                    _verifyUser(err, stephenMeObj, 'Stephen Thomas', 'Stephen Thomas', 'stephen@test.com');
+                                    _verifyUser(err, stephenMeObj, 'Stephen Thomas', 'Stephen Thomas', 'stephen@displayname.test.com');
 
                                     // Update a user's display name to be the same as its external id
                                     RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'displayName': 'user-zfdHliPLa'}, function (err, user) {
@@ -646,16 +671,16 @@ describe('Users', function() {
 
                                         // Verify that the update is reflected in the me feed
                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                            _verifyUser(err, nicolaasMeObj, 'user-zfdHliPLa', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                            _verifyUser(err, nicolaasMeObj, 'user-zfdHliPLa', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                             // Re-import the users to verify that the displayName is reverted back to the display name
                                             // provided in the CSV file. This time, the import is attempted as a tenant admin
-                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', null, function(err) {
                                                 assert.ok(!err);
 
                                                 // Verify that the display name is correctly reverted
                                                 RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                    _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                    _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                     // Update the user's display name to a different real display name
                                                     RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'displayName': 'N. Matthijs'}, function (err, user) {
@@ -666,25 +691,25 @@ describe('Users', function() {
 
                                                         // Verify that the update is reflected in the me feed
                                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                            _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                            _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                             // Re-import the users as a tenant admin to verify that the displayName is not reverted
                                                             // back to the display name provided in the CSV file
-                                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', null, function(err) {
                                                                 assert.ok(!err);
 
                                                                 // Verify that the display name has not been reverted
                                                                 RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                    _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                    _verifyUser(err, nicolaasMeObj, 'N. Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                                     // Re-import the users using the `forceProfileUpdate` flag to verify that the displayName is reverted to
                                                                     // the display name provided in the CSV file
-                                                                    PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                                    PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', true, function(err) {
                                                                         assert.ok(!err);
 
                                                                         // Verify that the display name is correctly reverted
                                                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
 
                                                                             // Update the user's display name to be the same as its external id
                                                                             RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'displayName': 'user-zfdHliPLa'}, function (err, user) {
@@ -695,12 +720,12 @@ describe('Users', function() {
 
                                                                                 // Re-import the users using the `forceProfileUpdate` flag to verify that the displayName is correctly reverted to
                                                                                 // the display name provided in the CSV file when providing the flag
-                                                                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-displayname.csv'), 'local', true, function(err) {
                                                                                     assert.ok(!err);
 
                                                                                     // Verify that the display name is correctly reverted
                                                                                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@displayname.test.com');
                                                                                         return callback();
                                                                                     });
                                                                                 });
@@ -734,84 +759,42 @@ describe('Users', function() {
                 assert.ok(!err);
 
                 // Import users as a global admin using a local authentication strategy
-                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                PrincipalsTestUtil.importUsers(globalAdminRestContext, tenant.alias, getDataFileStream('users-with-password-email.csv'), 'local', null, function(err) {
                     assert.ok(!err);
 
                     var nicolaasRestContext = TestsUtil.createTenantRestContext(tenant.host, 'user-zfdHliPLa', 'password1');
                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@email.test.com');
 
-                        // Empty a user's email address
-                        RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'email': ''}, function (err, user) {
+                        // Update the user's email address to a different real one
+                        var email = 'nicolaas@my.other.mail.address.com';
+                        PrincipalsTestUtil.assertUpdateUserSucceeds(nicolaasRestContext, nicolaasMeObj.id, {'email': email}, function(user, token) {
                             assert.ok(!err);
-                            assert.ok(user);
-                            assert.equal(user.id, nicolaasMeObj.id);
-                            assert.equal(user.email, '');
+                            // Verify the email address
+                            PrincipalsTestUtil.assertVerifyEmailSucceeds(nicolaasRestContext, nicolaasMeObj.id, token, function() {
 
-                            // Verify that the update is reflected in the me feed
-                            RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', '');
+                                // Verify that the update is reflected in the me feed
+                                RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
+                                    _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
 
-                                // Re-import the users to verify that the email address is reverted back to the one
-                                // provided in the CSV file. This time, the import is attempted as a tenant admin
-                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
-                                    assert.ok(!err);
+                                    // Re-import the users as a tenant admin to verify that the email adress is not reverted
+                                    // back to the email address provided in the CSV file
+                                    PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-email.csv'), 'local', null, function(err) {
+                                        assert.ok(!err);
 
-                                    // Verify that the email address is correctly reverted
-                                    RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                        // Verify that the email address has not been reverted
+                                        RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
+                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
 
-                                        // Update the user's email address to a different real one
-                                        RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'email': 'nicolaas@my.other.mail.address.com'}, function (err, user) {
-                                            assert.ok(!err);
-                                            assert.ok(user);
-                                            assert.equal(user.id, nicolaasMeObj.id);
-                                            assert.equal(user.email, 'nicolaas@my.other.mail.address.com');
+                                            // Re-import the users using the `forceProfileUpdate` flag to verify that the email address is reverted to
+                                            // the email address provided in the CSV file
+                                            PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password-email.csv'), 'local', true, function(err) {
+                                                assert.ok(!err);
 
-                                            // Verify that the update is reflected in the me feed
-                                            RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
-
-                                                // Re-import the users as a tenant admin to verify that the email adress is not reverted
-                                                // back to the email address provided in the CSV file
-                                                PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
-                                                    assert.ok(!err);
-
-                                                    // Verify that the email address has not been reverted
-                                                    RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@my.other.mail.address.com');
-
-                                                        // Re-import the users using the `forceProfileUpdate` flag to verify that the email address is reverted to
-                                                        // the email address provided in the CSV file
-                                                        PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
-                                                            assert.ok(!err);
-
-                                                            // Verify that the email address is correctly reverted
-                                                            RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
-
-                                                                // Empty the user's email address
-                                                                RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'email': ''}, function (err, user) {
-                                                                    assert.ok(!err);
-                                                                    assert.ok(user);
-                                                                    assert.equal(user.id, nicolaasMeObj.id);
-                                                                    assert.equal(user.email, '');
-
-                                                                    // Re-import the users using the `forceProfileUpdate` flag to verify that the email address is correctly reverted to
-                                                                    // the email address provided in the CSV file when providing the flag
-                                                                    PrincipalsTestUtil.importUsers(tenantAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
-                                                                        assert.ok(!err);
-
-                                                                        // Verify that the email address is correctly reverted
-                                                                        RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
-                                                                            return callback();
-                                                                        });
-                                                                    });
-                                                                });
-                                                            });
-                                                        });
-                                                    });
+                                                // Verify that the email address is correctly reverted
+                                                RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
+                                                    _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@email.test.com');
+                                                    return callback();
                                                 });
                                             });
                                         });
@@ -835,12 +818,12 @@ describe('Users', function() {
                 assert.ok(!err);
 
                 // Import users as a global admin using a local authentication strategy
-                PrincipalsTestUtil.importUsers(globalAdminRestContext, global.oaeTests.tenants.cam.alias, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                PrincipalsTestUtil.importUsers(globalAdminRestContext, global.oaeTests.tenants.cam.alias, getDataFileStream('users-with-password-alias.csv'), 'local', null, function(err) {
                     assert.ok(!err);
 
                     var nicolaasRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, 'user-zfdHliPLa', 'password1');
                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
 
                         // Empty a user's public alias
                         RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'publicAlias': ''}, function (err, user) {
@@ -851,16 +834,16 @@ describe('Users', function() {
 
                             // Verify that the update is reflected in the me feed
                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', '', 'nicolaas@test.com');
+                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', '', 'nicolaas@alias.test.com');
 
                                 // Re-import the users to verify that the public alias is reverted back to the display name
                                 // provided in the CSV file. This time, the import is attempted as a tenant admin
-                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', null, function(err) {
                                     assert.ok(!err);
 
                                     // Verify that the public alias is correctly reverted
                                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
 
                                         // Update the user's public alias to a different real one
                                         RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'publicAlias': 'Nico'}, function (err, user) {
@@ -871,25 +854,25 @@ describe('Users', function() {
 
                                             // Verify that the update is reflected in the me feed
                                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@test.com');
+                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@alias.test.com');
 
                                                 // Re-import the users as a tenant admin to verify that the public alias is not reverted
                                                 // back to the display name provided in the CSV file
-                                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', null, function(err) {
+                                                PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', null, function(err) {
                                                     assert.ok(!err);
 
                                                     // Verify that the public alias has not been reverted
                                                     RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@test.com');
+                                                        _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nico', 'nicolaas@alias.test.com');
 
                                                         // Re-import the users using the `forceProfileUpdate` flag to verify that the public alias is reverted to
                                                         // the display name provided in the CSV file
-                                                        PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                        PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', true, function(err) {
                                                             assert.ok(!err);
 
                                                             // Verify that the public alias is correctly reverted
                                                             RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
 
                                                                 // Empty the user's public alias
                                                                 RestAPI.User.updateUser(nicolaasRestContext, nicolaasMeObj.id, {'publicAlias': ''}, function (err, user) {
@@ -900,12 +883,12 @@ describe('Users', function() {
 
                                                                     // Re-import the users using the `forceProfileUpdate` flag to verify that the public alias is correctly reverted to
                                                                     // the display name provided in the CSV file when providing the flag
-                                                                    PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password.csv'), 'local', true, function(err) {
+                                                                    PrincipalsTestUtil.importUsers(camAdminRestContext, null, getDataFileStream('users-with-password-alias.csv'), 'local', true, function(err) {
                                                                         assert.ok(!err);
 
                                                                         // Verify that the public alias is correctly reverted
                                                                         RestAPI.User.getMe(nicolaasRestContext, function(err, nicolaasMeObj) {
-                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@test.com');
+                                                                            _verifyUser(err, nicolaasMeObj, 'Nicolaas Matthijs', 'Nicolaas Matthijs', 'nicolaas@alias.test.com');
                                                                             return callback();
                                                                         });
                                                                     });
@@ -1184,15 +1167,11 @@ describe('Users', function() {
                     assert.ok(err.code, 401);
 
                     // Create a non-admin user on a user tenant
-                    var userId = TestsUtil.generateTestUserId();
-                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', {'visibility': 'public'}, function(err, createdUser) {
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                         assert.ok(!err);
-                        assert.ok(createdUser);
-                        assert.equal(createdUser.displayName, 'Test User');
-                        var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
 
                         // Verify that an authenticated non-admin user on a user tenant cannot import users
-                        PrincipalsTestUtil.importUsers(userRestContext, null, getDataFileStream('users-without-password.csv'), 'cas', null, function(err) {
+                        PrincipalsTestUtil.importUsers(jack.restContext, null, getDataFileStream('users-without-password.csv'), 'cas', null, function(err) {
                             assert.ok(err);
                             assert.ok(err.code, 401);
                             callback();
@@ -1210,22 +1189,15 @@ describe('Users', function() {
          */
         it('verify get user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            var opts = {'visibility': 'public'};
-
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', opts, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                assert.equal(userObj.displayName, 'Test User');
-                assert.equal(userObj.resourceType, 'user');
-                assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
 
                 // Get the user on the global admin tenant
-                RestAPI.User.getUser(globalAdminRestContext, userObj.id, function(err, retrievedUser) {
+                RestAPI.User.getUser(globalAdminRestContext, jack.user.id, function(err, retrievedUser) {
                     assert.ok(!err);
                     assert.ok(retrievedUser);
-                    assert.equal(retrievedUser.visibility, 'public');
-                    assert.equal(retrievedUser.displayName, 'Test User');
+                    assert.equal(retrievedUser.visibility, jack.user.visibility);
+                    assert.equal(retrievedUser.displayName, jack.user.displayName);
                     assert.equal(retrievedUser.resourceType, 'user');
                     assert.equal(retrievedUser.profilePath, '/user/' + retrievedUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser.id).resourceId);
                     assert.ok(_.isObject(retrievedUser.tenant));
@@ -1234,11 +1206,11 @@ describe('Users', function() {
                     assert.equal(retrievedUser.tenant.alias, global.oaeTests.tenants.cam.alias);
 
                     // Get the user
-                    RestAPI.User.getUser(anonymousRestContext, userObj.id, function(err, retrievedUser) {
+                    RestAPI.User.getUser(anonymousRestContext, jack.user.id, function(err, retrievedUser) {
                         assert.ok(!err);
                         assert.ok(retrievedUser);
-                        assert.equal(retrievedUser.visibility, 'public');
-                        assert.equal(retrievedUser.displayName, 'Test User');
+                        assert.equal(retrievedUser.visibility, jack.user.visibility);
+                        assert.equal(retrievedUser.displayName, jack.user.displayName);
                         assert.equal(retrievedUser.resourceType, 'user');
                         assert.equal(retrievedUser.profilePath, '/user/' + retrievedUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser.id).resourceId);
                         assert.ok(_.isObject(retrievedUser.tenant));
@@ -1247,10 +1219,9 @@ describe('Users', function() {
                         assert.equal(retrievedUser.tenant.alias, global.oaeTests.tenants.cam.alias);
 
                         // Upload a profile picture for the user so we can verify its data on the user profile model
-                        var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
-                        PrincipalsTestUtil.uploadAndCropPicture(userRestContext, userObj.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
+                        PrincipalsTestUtil.uploadAndCropPicture(jack.restContext, jack.user.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
                             // Get the user
-                            RestAPI.User.getUser(anonymousRestContext, userObj.id, function(err, retrievedUser) {
+                            RestAPI.User.getUser(anonymousRestContext, jack.user.id, function(err, retrievedUser) {
                                 assert.ok(!err);
 
                                 // Ensure the profile picture URL is signed, and back-end URIs are not returned
@@ -1262,11 +1233,11 @@ describe('Users', function() {
                                 assert.ok(!retrievedUser.picture.largeUri);
 
                                 // Ensure we can get the user from the global admin tenant
-                                RestAPI.User.getUser(globalAdminRestContext, userObj.id, function(err, retrievedUser) {
+                                RestAPI.User.getUser(globalAdminRestContext, jack.user.id, function(err, retrievedUser) {
                                     assert.ok(!err);
                                     assert.ok(retrievedUser);
-                                    assert.equal(retrievedUser.visibility, 'public');
-                                    assert.equal(retrievedUser.displayName, 'Test User');
+                                    assert.equal(retrievedUser.visibility, jack.user.visibility);
+                                    assert.equal(retrievedUser.displayName, jack.user.displayName);
                                     assert.equal(retrievedUser.resourceType, 'user');
                                     assert.equal(retrievedUser.profilePath, '/user/' + retrievedUser.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser.id).resourceId);
                                     assert.ok(_.isObject(retrievedUser.tenant));
@@ -1336,7 +1307,7 @@ describe('Users', function() {
                                 assert.strictEqual(meData.tenant.displayName, privateTenant1.tenant.displayName);
                                 assert.strictEqual(meData.tenant.alias, privateTenant1.tenant.alias);
                                 assert.strictEqual(meData.tenant.isPrivate, true);
-                        
+
                                 return callback();
                             });
                         });
@@ -1576,7 +1547,8 @@ describe('Users', function() {
         it('verify get user by ugly username', function(callback) {
             // Create a test user with an ugly user name
             var userId1 = TestsUtil.generateTestUserId('some.weird@`user\\name');
-            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User', {'visibility': 'public'},  function(err, userObj1) {
+            var email1 = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User', email1, {'visibility': 'public'},  function(err, userObj1) {
                 assert.ok(!err);
                 assert.ok(userObj1);
 
@@ -1591,7 +1563,8 @@ describe('Users', function() {
 
                     // Create a test user with a UTF-8 username
                     var userId2 = TestsUtil.generateTestUserId('стремился');
-                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Кругом шумел', {'visibility': 'public'}, function(err, userObj2) {
+                    var email2 = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Кругом шумел', email2, {'visibility': 'public'}, function(err, userObj2) {
                         assert.ok(!err);
                         assert.ok(userObj2);
 
@@ -1603,7 +1576,7 @@ describe('Users', function() {
                             assert.equal(retrievedUser2.displayName, 'Кругом шумел');
                             assert.equal(retrievedUser2.resourceType, 'user');
                             assert.equal(retrievedUser2.profilePath, '/user/' + retrievedUser2.tenant.alias + '/' + AuthzUtil.getResourceFromId(retrievedUser2.id).resourceId);
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1646,19 +1619,11 @@ describe('Users', function() {
          */
         it('verify update user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public', 'locale': 'en_GB', 'timezone': 'Europe/London'}, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(user);
-                assert.equal(user.visibility, 'public');
-                assert.equal(user.displayName, 'Test User');
-                assert.equal(user.locale, 'en_GB');
-                assert.equal(user.resourceType, 'user');
-                assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                 // Set a profile picture
-                PrincipalsTestUtil.uploadAndCropPicture(testUserRestContext, user.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
+                PrincipalsTestUtil.uploadAndCropPicture(jack.restContext, jack.user.id, _getPictureStream, {'x': 10, 'y': 10, 'width': 200}, function() {
                     var timeBeforeUpdate = Date.now();
 
                     // Update the user
@@ -1668,15 +1633,9 @@ describe('Users', function() {
                         'visibility': 'private',
                         'locale': 'nl_NL'
                     };
-                    RestAPI.User.updateUser(testUserRestContext, user.id, updateValues, function (err, user) {
-                        assert.ok(!err);
-                        assert.ok(user);
+                    PrincipalsTestUtil.assertUpdateUserSucceeds(jack.restContext, jack.user.id, updateValues, function(user) {
                         assert.ok(user.lastModified <= Date.now());
                         assert.ok(user.lastModified >= timeBeforeUpdate);
-                        assert.equal(user.visibility, 'private');
-                        assert.equal(user.displayName, 'displayname');
-                        assert.equal(user.publicAlias, 'publicalias');
-                        assert.equal(user.locale, 'nl_NL');
                         assert.equal(user.resourceType, 'user');
                         assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
                         assert.ok(!user.picture.largeUri);
@@ -1687,7 +1646,7 @@ describe('Users', function() {
                         assert.ok(user.picture.small);
 
                         // Get the user's me feed
-                        RestAPI.User.getMe(testUserRestContext, function(err, me) {
+                        RestAPI.User.getMe(jack.restContext, function(err, me) {
                             assert.ok(!err);
                             assert.ok(me);
                             assert.equal(me.visibility, 'private');
@@ -1704,23 +1663,7 @@ describe('Users', function() {
                             assert.ok(!me.picture.smallUri);
                             assert.ok(me.picture.small);
 
-                            // Get the user's basic profile
-                            RestAPI.User.getUser(testUserRestContext, user.id, function(err, user) {
-                                assert.ok(!err);
-                                assert.ok(user);
-                                assert.equal(user.visibility, 'private');
-                                assert.equal(user.displayName, 'displayname');
-                                assert.equal(user.publicAlias, 'publicalias');
-                                assert.equal(user.resourceType, 'user');
-                                assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
-                                assert.ok(!user.picture.largeUri);
-                                assert.ok(user.picture.large);
-                                assert.ok(!user.picture.mediumUri);
-                                assert.ok(user.picture.medium);
-                                assert.ok(!user.picture.smallUri);
-                                assert.ok(user.picture.small);
-                                return callback();
-                            });
+                            return callback();
                         });
                     });
                 });
@@ -1732,18 +1675,8 @@ describe('Users', function() {
          */
         it('verify admin update other user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public', 'locale': 'en_GB', 'emailPreference': 'never'}, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                assert.equal(userObj.visibility, 'public');
-                assert.equal(userObj.displayName, 'Test User');
-                assert.equal(userObj.locale, 'en_GB');
-                assert.equal(userObj.emailPreference, 'never');
-                assert.equal(userObj.resourceType, 'user');
-                assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
-
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
                 var timeBeforeUpdate = Date.now();
 
                 // Update the user as a global admin
@@ -1754,21 +1687,14 @@ describe('Users', function() {
                     'locale': 'nl_NL',
                     'emailPreference': 'weekly'
                 };
-                RestAPI.User.updateUser(globalAdminRestContext, userObj.id, updateValues, function (err, user) {
-                    assert.ok(!err);
-                    assert.ok(user);
+                PrincipalsTestUtil.assertUpdateUserSucceeds(globalAdminRestContext, jack.user.id, updateValues, function(user) {
                     assert.ok(user.lastModified <= Date.now());
                     assert.ok(user.lastModified >= timeBeforeUpdate);
-                    assert.equal(user.visibility, 'private');
-                    assert.equal(user.displayName, 'displayname');
-                    assert.equal(user.publicAlias, 'publicalias');
-                    assert.equal(user.locale, 'nl_NL');
-                    assert.equal(user.emailPreference, 'weekly');
                     assert.equal(user.resourceType, 'user');
                     assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
 
                     // Ensure the user's `me` feed contains the updated information
-                    RestAPI.User.getMe(testUserRestContext, function(err, meObj) {
+                    RestAPI.User.getMe(jack.restContext, function(err, meObj) {
                         assert.ok(!err);
                         assert.ok(meObj);
                         assert.equal(meObj.visibility, 'private');
@@ -1780,65 +1706,34 @@ describe('Users', function() {
                         assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
                         assert.equal(meObj.lastModified, user.lastModified);
 
-                        // Ensure the user's basic profile contains the updated information
-                        RestAPI.User.getUser(testUserRestContext, userObj.id, function(err, userObj) {
-                            assert.ok(!err);
-                            assert.ok(userObj);
-                            assert.equal(userObj.visibility, 'private');
-                            assert.equal(userObj.displayName, 'displayname');
-                            assert.equal(userObj.publicAlias, 'publicalias');
-                            assert.equal(userObj.resourceType, 'user');
-                            assert.equal(userObj.emailPreference, 'weekly');
-                            assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
+                        // Verify that a tenant admin can also update a user's basic profile
+                        updateValues = {
+                            'displayName': 'Test User',
+                            'publicAlias': 'updatedalias',
+                            'visibility': 'public',
+                            'locale': 'en_GB',
+                            'emailPreference': 'daily'
+                        };
+                        PrincipalsTestUtil.assertUpdateUserSucceeds(camAdminRestContext, jack.user.id, updateValues, function(user) {
+                            assert.ok(user.lastModified <= Date.now());
+                            assert.ok(user.lastModified >= timeBeforeUpdate);
+                            assert.equal(user.resourceType, 'user');
+                            assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
 
-                            // Verify that a tenant admin can also update a user's basic profile
-                            updateValues = {
-                                'displayName': 'Test User',
-                                'publicAlias': 'updatedalias',
-                                'visibility': 'public',
-                                'locale': 'en_GB',
-                                'emailPreference': 'daily'
-                            };
-                            RestAPI.User.updateUser(camAdminRestContext, userObj.id, updateValues, function (err, user) {
+                            // Ensure the user's `me` feed contains the updated information
+                            RestAPI.User.getMe(jack.restContext, function(err, meObj) {
                                 assert.ok(!err);
-                                assert.ok(user);
-                                assert.ok(user.lastModified <= Date.now());
-                                assert.ok(user.lastModified >= timeBeforeUpdate);
-                                assert.equal(user.visibility, 'public');
-                                assert.equal(user.displayName, 'Test User');
-                                assert.equal(user.publicAlias, 'updatedalias');
-                                assert.equal(user.locale, 'en_GB');
-                                assert.equal(user.emailPreference, 'daily');
-                                assert.equal(user.resourceType, 'user');
-                                assert.equal(user.profilePath, '/user/' + user.tenant.alias + '/' + AuthzUtil.getResourceFromId(user.id).resourceId);
+                                assert.ok(meObj);
+                                assert.equal(meObj.visibility, 'public');
+                                assert.equal(meObj.displayName, 'Test User');
+                                assert.equal(meObj.publicAlias, 'updatedalias');
+                                assert.equal(meObj.locale, 'en_GB');
+                                assert.equal(meObj.emailPreference, 'daily');
+                                assert.equal(meObj.resourceType, 'user');
+                                assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
+                                assert.equal(meObj.lastModified, user.lastModified);
 
-                                // Ensure the user's `me` feed contains the updated information
-                                RestAPI.User.getMe(testUserRestContext, function(err, meObj) {
-                                    assert.ok(!err);
-                                    assert.ok(meObj);
-                                    assert.equal(meObj.visibility, 'public');
-                                    assert.equal(meObj.displayName, 'Test User');
-                                    assert.equal(meObj.publicAlias, 'updatedalias');
-                                    assert.equal(meObj.locale, 'en_GB');
-                                    assert.equal(meObj.emailPreference, 'daily');
-                                    assert.equal(meObj.resourceType, 'user');
-                                    assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
-                                    assert.equal(meObj.lastModified, user.lastModified);
-
-                                    // Ensure the user's basic profile contains the updated information
-                                    RestAPI.User.getUser(testUserRestContext, userObj.id, function(err, userObj) {
-                                        assert.ok(!err);
-                                        assert.ok(userObj);
-                                        assert.equal(userObj.visibility, 'public');
-                                        assert.equal(userObj.displayName, 'Test User');
-                                        assert.equal(userObj.publicAlias, 'updatedalias');
-                                        assert.equal(userObj.resourceType, 'user');
-                                        assert.equal(userObj.emailPreference, 'daily');
-                                        assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
-
-                                        return callback();
-                                    });
-                                });
+                                return callback();
                             });
                         });
                     });
@@ -1850,39 +1745,21 @@ describe('Users', function() {
          * Test that verifies that it is not possible for a user to be updated with restricted fields being set
          */
         it('verify cannot update user to tenant admin', function(callback) {
-            // Create a test user
-
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public', 'locale': 'en_GB'}, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                assert.equal(userObj.visibility, 'public');
-                assert.equal(userObj.displayName, 'Test User');
-                assert.equal(userObj.locale, 'en_GB');
-                assert.equal(userObj.resourceType, 'user');
-                assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
-                var testUserRestContext =  TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
-                // Update the user
-                var updateValues = {
-                    'admin:tenant': 'true'
-                };
+                // Verify a user cannot promote themselves to a tenant administrator
+                PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'admin:tenant': 'true'}, 400, function() {
 
-                RestAPI.User.updateUser(testUserRestContext, userObj.id, updateValues, function (err) {
-                    assert.ok(err);
+                    // Verify a user cannot promote themselves to a global administrator
+                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'admin:global': 'true'}, 400, function() {
 
-                    updateValues = {
-                        'admin:global': 'true'
-                    };
-
-                    RestAPI.User.updateUser(testUserRestContext, userObj.id, updateValues, function (err) {
-                        assert.ok(err);
-
-                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), userObj.id, function(err, userObj) {
+                        // Sanity check the user has not been promoted
+                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, userObj) {
                             assert.ok(!err);
                             assert.ok(userObj);
                             assert.ok(!userObj.isTenantAdmin(global.oaeTests.tenants.cam.alias), 'Expected user to not be update-able to tenant or global admin');
-                            callback();
+                            return callback();
                         });
                     });
                 });
@@ -1899,80 +1776,100 @@ describe('Users', function() {
          */
         it('verify validation of updating a user', function(callback) {
             // Create a test user
-            var username = TestsUtil.generateTestUserId();
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', {'visibility': 'public'}, function(err, userObj) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                assert.ok(userObj);
-                var testUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');
 
                 // Ensure the user id must be a valid principal id
-                RestAPI.User.updateUser(camAdminRestContext, 'notavalidid', {'displayName': 'Casper, the friendly horse'}, function(err) {
-                    assert.ok(err);
-                    assert.equal(err.code, 400);
+                PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, 'notavalidid',  {'displayName': 'Casper, the friendly horse'}, 400, function() {
 
                     // Update a non-existing variation of a valid user id (so we know it is a valid id)
-                    RestAPI.User.updateUser(camAdminRestContext, userObj.id+'nonexisting', {'displayName': 'Casper, the friendly horse'}, function(err) {
-                        assert.ok(err);
-                        assert.equal(err.code, 404);
+                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id + 'nonexisting',  {'displayName': 'Casper, the friendly horse'}, 401, function() {
 
                         // Try to update the user's profile without parameters
-                        var updateValues = {};
-                        RestAPI.User.updateUser(testUserRestContext, userObj.id, updateValues, function(err) {
-                            assert.ok(err);
-                            assert.equal(err.code, 400);
+                        PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {}, 400, function() {
 
-                            // Try to update the user's profile as a different user. Create this user first
-                            var updaterUserId = TestsUtil.generateTestUserId();
-                            RestAPI.User.createUser(camAdminRestContext, updaterUserId, 'password', 'Test User', null, function(err, updaterUserObj) {
-                                assert.ok(!err);
-                                assert.ok(updaterUserObj);
-                                var updateUserRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, updaterUserId, 'password');
-                                updateValues = {
-                                    'displayName': 'Stinky John LOL'
-                                };
-                                RestAPI.User.updateUser(updateUserRestContext, userObj.id, updateValues, function(err) {
-                                    assert.ok(err);
-                                    assert.equal(err.code, 401);
+                            // Try to update the user's profile as a different user
+                            PrincipalsTestUtil.assertUpdateUserFails(jane.restContext, jack.user.id,  {'displayName': 'Stinky Jack LOL'}, 401, function() {
 
-                                    // Try to update the user's profile as the anonymous user
-                                    RestAPI.User.updateUser(anonymousRestContext, userObj.id, updateValues, function(err) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 401);
+                                // Try to update the user's profile as the anonymous user
+                                PrincipalsTestUtil.assertUpdateUserFails(anonymousRestContext, jack.user.id,  {'displayName': 'Stinky Jack LOL'}, 401, function() {
 
-                                         // Create user with displayName that is longer than the maximum allowed size
-                                        var longDisplayName = TestsUtil.generateRandomText(100);
-                                        RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'displayName': longDisplayName}, function(err) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 400);
-                                            assert.ok(err.msg.indexOf('1000') > 0);
+                                     // Create user with displayName that is longer than the maximum allowed size
+                                    var longDisplayName = TestsUtil.generateRandomText(100);
+                                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'displayName': longDisplayName}, 400, function() {
 
-                                            // Create user with an empty displayName
-                                            RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'displayName': '\n'}, function(err) {
-                                                assert.ok(err);
-                                                assert.equal(err.code, 400);
+                                        // Create user with an empty displayName
+                                        PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'displayName': '\n'}, 400, function() {
 
-                                                // Verify an incorrect visibility is invalid
-                                                RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'visibility': 'so incorrect'}, function(err) {
-                                                    assert.equal(err.code, 400);
+                                            // Verify an incorrect visibility is invalid
+                                            PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'visibility': 'so incorrect'}, 400, function() {
 
-                                                    // Verify an incorrect email preference is invalid
-                                                    RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'emailPreference': 'so incorrect'}, function(err) {
-                                                        assert.equal(err.code, 400);
+                                                // Verify an incorrect email preference is invalid
+                                                PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id,  {'emailPreference': 'so incorrect'}, 400, function() {
 
-                                                        // Make sure that the user's basic profile is unchanged
-                                                        RestAPI.User.getUser(testUserRestContext, userObj.id, function(err, userObj) {
-                                                            assert.ok(!err);
-                                                            assert.ok(userObj);
-                                                            assert.equal(userObj.visibility, 'public');
-                                                            assert.equal(userObj.displayName, 'Test User');
-                                                            assert.equal(userObj.resourceType, 'user');
-                                                            assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
-                                                            return callback();
+                                                    // Verify an incorrect email is invalid
+                                                    PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id, {'email': 'so incorrect'}, 400, function() {
+
+                                                        // Verify unknown fields aren't allowed
+                                                        PrincipalsTestUtil.assertUpdateUserFails(jack.restContext, jack.user.id, {'wumptiedumpty': true}, 400, function() {
+
+                                                            // Make sure that the user's basic profile is unchanged
+                                                            RestAPI.User.getUser(jack.restContext, jack.user.id, function(err, userObj) {
+                                                                assert.ok(!err);
+                                                                assert.ok(userObj);
+                                                                assert.equal(userObj.visibility, jack.user.visibility);
+                                                                assert.equal(userObj.displayName, jack.user.displayName);
+                                                                assert.equal(userObj.resourceType, 'user');
+                                                                assert.equal(userObj.profilePath, '/user/' + userObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(userObj.id).resourceId);
+                                                                assert.equal(userObj.email, jack.user.email);
+                                                                return callback();
+                                                            });
                                                         });
                                                     });
                                                 });
                                             });
                                         });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that users can update their email address
+         */
+        it('verify updating a user their email address', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
+                assert.ok(!err);
+
+                // Jack should be able to use a new email address
+                var email = 'Aa' + TestsUtil.generateTestEmailAddress();
+                PrincipalsTestUtil.assertUpdateUserSucceeds(jack.restContext, jack.user.id, {'email': email}, function(user, token) {
+                    // Verify the new email address
+                    PrincipalsTestUtil.assertVerifyEmailSucceeds(jack.restContext, jack.user.id, token, function() {
+
+                        // "Updating" the email address by changing its case
+                        // should have no effect as the API will lower-case it
+                        PrincipalsTestUtil.assertUpdateUserSucceeds(jack.restContext, jack.user.id, {'email': email.toUpperCase()}, function(user, token) {
+                            assert.strictEqual(user.email, email.toLowerCase());
+
+                            // Assert there's no need to verify the email address (as it hasn't changed)
+                            RestAPI.User.getMe(jack.restContext, function(err, me) {
+                                assert.ok(!err);
+                                assert.strictEqual(me.email, email.toLowerCase());
+
+                                PrincipalsTestUtil.assertUpdateUserSucceeds(jack.restContext, jack.user.id, {'email': email.toLowerCase()}, function(user, token) {
+                                    assert.strictEqual(user.email, email.toLowerCase());
+
+                                    // Assert there's no need to verify the email address (as it hasn't changed)
+                                    RestAPI.User.getMe(jack.restContext, function(err, me) {
+                                        assert.ok(!err);
+                                        assert.strictEqual(me.email, email.toLowerCase());
+
+                                        return callback();
                                     });
                                 });
                             });
@@ -2017,25 +1914,27 @@ describe('Users', function() {
         };
 
         /**
-         * Test that verifies that user visibility settings work as expected. Public users should be visibile to everyone. Loggedin users should be
-         * visible to all users, other than the anonymous user. Private user should only be visibile to the user himself. When a user is not visible,
+         * Test that verifies that user visibility settings work as expected. Public users should be visible to everyone. Loggedin users should be
+         * visible to all users, other than the anonymous user. Private user should only be visible to the user himself. When a user is not visible,
          * only the display name should be visible
          */
         it('verify user permissions', function(callback) {
             // Create 2 public test users
             var jackUserId = TestsUtil.generateTestUserId();
+            var jackEmail = TestsUtil.generateTestEmailAddress();
             var jackOpts = {
                 'visibility': 'public',
                 'publicAlias': 'Jack'
             };
 
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', jackOpts, function(err, jack) {
+            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', jackEmail, jackOpts, function(err, jack) {
                 assert.ok(!err);
                 assert.ok(jack);
                 var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
                 var janeUserId = TestsUtil.generateTestUserId();
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', {'visibility': 'public'}, function(err, jane) {
+                var janeEmail = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', janeEmail, {'visibility': 'public'}, function(err, jane) {
                     assert.ok(!err);
                     assert.ok(jane);
                     var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUserId, 'password');
@@ -2095,20 +1994,12 @@ describe('Users', function() {
          * Test that verifies that a public user's profile is fully visible beyond the tenant scope.
          */
         it('verify public user is visible beyond tenant scope', function(callback) {
-            var usernameA = TestsUtil.generateTestUserId();
-            var usernameB = TestsUtil.generateTestUserId();
-
-            // Create user in tenant A
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'Public User', {'visibility': 'public'}, function(err, userA) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
-
-                // Create user B in GT tenant
-                RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, jane) {
                     assert.ok(!err);
-                    var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
-                    verifyProfilePermissions(restCtxB, userA.id, true, userA.displayName, undefined, 'public', callback);
+                    verifyProfilePermissions(jane.restContext, jack.user.id, true, jack.user.displayName, undefined, 'public', callback);
                 });
             });
         });
@@ -2126,13 +2017,15 @@ describe('Users', function() {
                 'visibility': 'loggedin',
                 'publicAlias': 'A user.'
             };
+            var email = TestsUtil.generateTestEmailAddress();
 
-            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'LoggedIn User', loggedInUserOpts, function(err, userA) {
+            RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'LoggedIn User', email, loggedInUserOpts, function(err, userA) {
                 assert.ok(!err);
                 var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
                 // Create user B in GT tenant
-                RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', null, function(err, userB) {
+                email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', email, {}, function(err, userB) {
                     assert.ok(!err);
                     var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');
 
@@ -2150,89 +2043,79 @@ describe('Users', function() {
          */
         it('verify making someone an admin', function(callback) {
             // Create 2 test users
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                assert.ok(jack);
-                var jackContext = new Context(global.oaeTests.tenants.cam, jack);
+                jack.context = new Context(global.oaeTests.tenants.cam, jack.user);
 
-                var janeUserId = TestsUtil.generateTestUserId('jane');
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
-                    assert.ok(!err);
-                    assert.ok(jane);
-                    var janeContext = new Context(global.oaeTests.tenants.cam, jane);
+                // Verify an anonymous user cannot promote someone to global admin
+                PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), jack.user.id, true, function(err) {
+                    assert.ok(err);
+                    assert.equal(err.code, 401);
 
-                    // Verify an anonymous user cannot promote someone to global admin
-                    PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), jack.id, true, function(err) {
+                    // Verify an anonymous user-tenant user cannot promote someone to tenant admin
+                    RestAPI.User.setTenantAdmin(anonymousRestContext, jack.user.id, true, function(err) {
                         assert.ok(err);
                         assert.equal(err.code, 401);
 
-                        // Verify an anonymous user-tenant user cannot promote someone to tenant admin
-                        RestAPI.User.setTenantAdmin(anonymousRestContext, jack.id, true, function(err) {
+                        // Verify that anonymous admin-tenant users cannot make users tenant-admin
+                        RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jack.user.id, true, function(err) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
 
-                            // Verify that anonymous admin-tenant users cannot make users tenant-admin
-                            RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jack.id, true, function(err) {
+                            // Jack will try to make himself and Jane an admin. Both should fail.
+                            PrincipalsAPI.setGlobalAdmin(jack.context, jack.user.id, true, function(err) {
                                 assert.ok(err);
                                 assert.equal(err.code, 401);
-
-                                // Jack will try to make himself and Jane an admin. Both should fail.
-                                PrincipalsAPI.setGlobalAdmin(jackContext, jack.id, true, function(err) {
+                                PrincipalsAPI.setGlobalAdmin(jack.context, jane.user.id, true, function(err) {
                                     assert.ok(err);
                                     assert.equal(err.code, 401);
-                                    PrincipalsAPI.setGlobalAdmin(jackContext, jane.id, true, function(err) {
-                                        assert.ok(err);
-                                        assert.equal(err.code, 401);
 
-                                        // We make Jack a global admin
-                                        PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.id, true, function(err) {
+                                    // We make Jack a global admin
+                                    PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.user.id, true, function(err) {
+                                        assert.ok(!err);
+                                        // Verify that Jack is a global admin
+                                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                             assert.ok(!err);
-                                            // Verify that Jack is a global admin
-                                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                                            assert.equal(user.isGlobalAdmin(), true);
+                                            assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                                            assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                            jack.context = new Context(global.oaeTests.tenants.cam, user);
+
+                                            // Jack will make Jane a global admin
+                                            PrincipalsAPI.setGlobalAdmin(jack.context, jane.user.id, true, function(err) {
                                                 assert.ok(!err);
-                                                assert.equal(user.isGlobalAdmin(), true);
-                                                assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                                assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                var jackContext = new Context(global.oaeTests.tenants.cam, user);
 
-                                                // Jack will make Jane a global admin
-                                                PrincipalsAPI.setGlobalAdmin(jackContext, jane.id, true, function(err) {
+                                                // Check that Jane is a global admin
+                                                PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.user.id, function(err, user) {
                                                     assert.ok(!err);
+                                                    assert.equal(user.isGlobalAdmin(), true);
+                                                    assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                                                    assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
 
-                                                    // Check that Jane is a global admin
-                                                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.id, function(err, user) {
+                                                    // Revoke Jack's global admin rights
+                                                    PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.user.id, false, function(err) {
                                                         assert.ok(!err);
-                                                        assert.equal(user.isGlobalAdmin(), true);
-                                                        assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                                        assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                        janeContext = new Context(global.oaeTests.tenants.cam, user);
 
-                                                        // Revoke Jack's global admin rights
-                                                        PrincipalsAPI.setGlobalAdmin(globalAdminContext, jack.id, false, function(err) {
+                                                        // Check that Jack is no longer an admin
+                                                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                                             assert.ok(!err);
+                                                            assert.equal(user.isGlobalAdmin(), false);
+                                                            assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                            assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                            jack.context = new Context(global.oaeTests.tenants.cam, user);
 
-                                                            // Check that Jack is no longer an admin
-                                                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
-                                                                assert.ok(!err);
-                                                                assert.equal(user.isGlobalAdmin(), false);
-                                                                assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                                assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                                jackContext = new Context(global.oaeTests.tenants.cam, user);
+                                                            // Make sure that Jack can no longer revoke the admin rights of Jane
+                                                            PrincipalsAPI.setGlobalAdmin(jack.context, jane.user.id, false, function(err) {
+                                                                assert.ok(err);
+                                                                assert.equal(err.code, 401);
 
-                                                                // Make sure that Jack can no longer revoke the admin rights of Jane
-                                                                PrincipalsAPI.setGlobalAdmin(jackContext, jane.id, false, function(err) {
-                                                                    assert.ok(err);
-                                                                    assert.equal(err.code, 401);
-
-                                                                    // Make sure that Jane is still an admin
-                                                                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.id, function(err, user) {
-                                                                        assert.ok(!err);
-                                                                        assert.equal(user.isGlobalAdmin(), true);
-                                                                        assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                                                        assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                                        callback();
-                                                                    });
+                                                                // Make sure that Jane is still an admin
+                                                                PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jane.user.id, function(err, user) {
+                                                                    assert.ok(!err);
+                                                                    assert.equal(user.isGlobalAdmin(), true);
+                                                                    assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                                                                    assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                                    return callback();
                                                                 });
                                                             });
                                                         });
@@ -2254,77 +2137,65 @@ describe('Users', function() {
          */
         it('verify revoking admin rights access restrictions', function(callback) {
             // Create 3 test users
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, jack, jane, sam) {
                 assert.ok(!err);
 
-                var janeUserId = TestsUtil.generateTestUserId('jane');
-                RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                // Make jane a tenant admin and verify it worked
+                RestAPI.User.setTenantAdmin(globalAdminRestContext, jane.user.id, true, function(err) {
                     assert.ok(!err);
 
-                    var samUserId = TestsUtil.generateTestUserId('sam');
-                    RestAPI.User.createUser(camAdminRestContext, samUserId, 'password', 'Jane Doe', null, function(err, sam) {
+                    PrincipalsAPI.getUser(globalAdminContext, jane.user.id, function(err, user) {
                         assert.ok(!err);
+                        assert.ok(user.isTenantAdmin(global.oaeTests.tenants.cam.alias));
 
-                        // Make jane a tenant admin and verify it worked
-                        RestAPI.User.setTenantAdmin(globalAdminRestContext, jane.id, true, function(err) {
+                        // Make sam a global admin and verify it worked
+                        PrincipalsAPI.setGlobalAdmin(globalAdminContext, sam.user.id, true, function(err) {
                             assert.ok(!err);
 
-                            PrincipalsAPI.getUser(globalAdminContext, jane.id, function(err, jane) {
+                            PrincipalsAPI.getUser(globalAdminContext, sam.user.id, function(err, user) {
                                 assert.ok(!err);
-                                assert.ok(jane.isTenantAdmin(global.oaeTests.tenants.cam.alias));
+                                assert.ok(user.isGlobalAdmin());
 
-                                // Make sam a global admin and verify it worked
-                                PrincipalsAPI.setGlobalAdmin(globalAdminContext, sam.id, true, function(err) {
+                                // Get jack's API user so we can build an API context later
+                                PrincipalsAPI.getUser(globalAdminContext, jack.user.id, function(err, user) {
                                     assert.ok(!err);
+                                    jack.context = new Context(global.oaeTests.tenants.cam, user);
 
-                                    PrincipalsAPI.getUser(globalAdminContext, sam.id, function(err, sam) {
-                                        assert.ok(!err);
-                                        assert.ok(sam.isGlobalAdmin());
+                                    // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke jane's tenant-admin rights
+                                    RestAPI.User.setTenantAdmin(anonymousRestContext, jane.user.id, false, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
 
-                                        // Get jack's API user so we can build an API context later
-                                        PrincipalsAPI.getUser(globalAdminContext, jack.id, function(err, jack) {
-                                            assert.ok(!err);
-                                            var jackCtx = new Context(global.oaeTests.tenants.cam, jack);
-                                            var jackRestCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
+                                        RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jane.user.id, false, function(err) {
+                                            assert.ok(err);
+                                            assert.equal(err.code, 401);
 
-                                            // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke jane's tenant-admin rights
-                                            RestAPI.User.setTenantAdmin(anonymousRestContext, jane.id, false, function(err) {
+                                            RestAPI.User.setTenantAdmin(jack.restContext, jane.user.id, false, function(err) {
                                                 assert.ok(err);
                                                 assert.equal(err.code, 401);
 
-                                                RestAPI.User.setTenantAdmin(anonymousGlobalRestContext, jane.id, false, function(err) {
+                                                // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke sam's global-admin rights
+                                                PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), sam.user.id, false, function(err) {
                                                     assert.ok(err);
                                                     assert.equal(err.code, 401);
 
-                                                    RestAPI.User.setTenantAdmin(jackRestCtx, jane.id, false, function(err) {
+                                                    PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.global), sam.user.id, false, function(err) {
                                                         assert.ok(err);
                                                         assert.equal(err.code, 401);
 
-                                                        // Verify an anonymous user (user-tenant or admin-tenant) or auth user cannot revoke sam's global-admin rights
-                                                        PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.cam), sam.id, false, function(err) {
+                                                        PrincipalsAPI.setGlobalAdmin(jack.context, sam.user.id, false, function(err) {
                                                             assert.ok(err);
                                                             assert.equal(err.code, 401);
 
-                                                            PrincipalsAPI.setGlobalAdmin(new Context(global.oaeTests.tenants.global), sam.id, false, function(err) {
-                                                                assert.ok(err);
-                                                                assert.equal(err.code, 401);
+                                                            // Ensure jane and sam have their admin rights
+                                                            PrincipalsAPI.getUser(globalAdminContext, jane.user.id, function(err, user) {
+                                                                assert.ok(!err);
+                                                                assert.ok(user.isTenantAdmin(global.oaeTests.tenants.cam.alias));
 
-                                                                PrincipalsAPI.setGlobalAdmin(jackCtx, sam.id, false, function(err) {
-                                                                    assert.ok(err);
-                                                                    assert.equal(err.code, 401);
-
-                                                                    // Ensure jane and sam have their admin rights
-                                                                    PrincipalsAPI.getUser(globalAdminContext, jane.id, function(err, jane) {
-                                                                        assert.ok(!err);
-                                                                        assert.ok(jane.isTenantAdmin(global.oaeTests.tenants.cam.alias));
-
-                                                                        PrincipalsAPI.getUser(globalAdminContext, sam.id, function(err, sam) {
-                                                                            assert.ok(!err);
-                                                                            assert.ok(sam.isGlobalAdmin());
-                                                                            return callback();
-                                                                        });
-                                                                    });
+                                                                PrincipalsAPI.getUser(globalAdminContext, sam.user.id, function(err, user) {
+                                                                    assert.ok(!err);
+                                                                    assert.ok(user.isGlobalAdmin());
+                                                                    return callback();
                                                                 });
                                                             });
                                                         });
@@ -2346,34 +2217,31 @@ describe('Users', function() {
          */
         it('verify tenant admin restrictions', function(callback) {
             // Create a test user
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                assert.ok(jack);
-                var jackContext = new Context(global.oaeTests.tenants.cam, jack);
 
                 // We make Jack a tenant admin
-                RestAPI.User.setTenantAdmin(globalAdminRestContext, jack.id, true, function(err) {
+                RestAPI.User.setTenantAdmin(globalAdminRestContext, jack.user.id, true, function(err) {
                     assert.ok(!err);
                     // Verify that Jack is a tenant admin
-                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                         assert.ok(!err);
                         assert.equal(user.isGlobalAdmin(), false);
                         assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
                         assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
-                        jackContext = new Context(global.oaeTests.tenants.cam, user);
+                        jack.context = new Context(global.oaeTests.tenants.cam, user);
 
                         // Jack will try to make herself a global admin. This should fail
-                        PrincipalsAPI.setGlobalAdmin(jackContext, jack.id, true, function(err) {
+                        PrincipalsAPI.setGlobalAdmin(jack.context, jack.user.id, true, function(err) {
                             assert.ok(err);
                             assert.equal(err.code, 401);
                             // Verify that Jack is not a global admin
-                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                 assert.ok(!err);
                                 assert.equal(user.isGlobalAdmin(), false);
                                 assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
                                 assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -2412,75 +2280,64 @@ describe('Users', function() {
             // We create 3 users: jack, jane and joe. Jack and Joe are in tenant A, Jane is in tenant B.
             // We promote John to a tenant admin (for A) and try to update the profile info for Jack and Jane.
             // It should only work for Jack.
-            var jackUserId = TestsUtil.generateTestUserId('jack');
-            RestAPI.User.createUser(camAdminRestContext, jackUserId, 'password', 'Jack Doe', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, joe) {
                 assert.ok(!err);
-                assert.ok(jack);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
-                var joeUserId = TestsUtil.generateTestUserId('joe');
-                RestAPI.User.createUser(camAdminRestContext, joeUserId, 'password', 'Joe Doe', null, function(err, joe) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, jane) {
                     assert.ok(!err);
-                    assert.ok(joe);
-                    var joeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, joeUserId, 'password');
 
-                    var janeUserId = TestsUtil.generateTestUserId('jane');
-                    RestAPI.User.createUser(gtAdminRestContext, janeUserId, 'password', 'Jane Doe', null, function(err, jane) {
+                    // Make Jack a tenant admin
+                    RestAPI.User.setTenantAdmin(camAdminRestContext, jack.user.id, true, function(err) {
                         assert.ok(!err);
-                        assert.ok(jane);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, janeUserId, 'password');
 
-                        // Make Jack a tenant admin
-                        RestAPI.User.setTenantAdmin(camAdminRestContext, jack.id, true, function(err) {
+                        // Verify that Jack is a tenant admin
+                        PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                             assert.ok(!err);
-                            // Verify that Jack is a tenant admin
-                            PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
+                            assert.equal(user.isGlobalAdmin(), false);
+                            assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
+                            assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
+
+                            // Update Joe
+                            var updateData = {
+                                'locale': 'en_CA',
+                                'displayName': 'Foo Bar'
+                            };
+                            RestAPI.User.updateUser(jack.restContext, joe.user.id, updateData, function(err) {
                                 assert.ok(!err);
-                                assert.equal(user.isGlobalAdmin(), false);
-                                assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), true);
-                                assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), true);
-                                var jackContext = new Context(global.oaeTests.tenants.cam, user);
-
-                                // Update Joe
-                                var updateData = {
-                                    'locale': 'en_CA',
-                                    'displayName': 'Foo Bar'
-                                };
-                                RestAPI.User.updateUser(jackRestContext, joe.id, updateData, function(err) {
+                                // Verify that the update has worked
+                                RestAPI.User.getMe(joe.restContext, function(err, meObj) {
                                     assert.ok(!err);
-                                    // Verify that the update has worked
-                                    RestAPI.User.getMe(joeRestContext, function(err, meObj) {
-                                        assert.ok(!err);
-                                        assert.ok(meObj);
-                                        assert.equal(meObj.displayName, 'Foo Bar');
-                                        assert.equal(meObj.locale, 'en_CA');
-                                        assert.equal(meObj.resourceType, 'user');
-                                        assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
+                                    assert.ok(meObj);
+                                    assert.equal(meObj.displayName, 'Foo Bar');
+                                    assert.equal(meObj.locale, 'en_CA');
+                                    assert.equal(meObj.resourceType, 'user');
+                                    assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
 
-                                        // Try to update Jane
-                                        RestAPI.User.updateUser(jackRestContext, jane.id, updateData, function(err) {
-                                            assert.ok(err);
-                                            // Verify that the update has not happened
-                                            RestAPI.User.getMe(janeRestContext, function(err, meObj) {
+                                    // Try to update Jane
+                                    RestAPI.User.updateUser(jack.restContext, jane.user.id, updateData, function(err) {
+                                        assert.ok(err);
+                                        assert.equal(err.code, 401);
+
+                                        // Verify that the update has not happened
+                                        RestAPI.User.getMe(jane.restContext, function(err, meObj) {
+                                            assert.ok(!err);
+                                            assert.ok(meObj);
+                                            assert.equal(meObj.displayName, jane.user.displayName);
+                                            assert.equal(meObj.locale, jane.user.locale);
+                                            assert.equal(meObj.resourceType, 'user');
+                                            assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
+
+                                            // Disable Jack's admin status
+                                            RestAPI.User.setTenantAdmin(camAdminRestContext, jack.user.id, false, function(err) {
                                                 assert.ok(!err);
-                                                assert.ok(meObj);
-                                                assert.equal(meObj.displayName, 'Jane Doe');
-                                                assert.equal(meObj.locale, 'en_GB');
-                                                assert.equal(meObj.resourceType, 'user');
-                                                assert.equal(meObj.profilePath, '/user/' + meObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(meObj.id).resourceId);
 
-                                                // Disable Jack's admin status
-                                                RestAPI.User.setTenantAdmin(camAdminRestContext, jack.id, false, function(err) {
+                                                // Verify he is no longer an admin
+                                                PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.user.id, function(err, user) {
                                                     assert.ok(!err);
-
-                                                    // Verify he is no longer an admin
-                                                    PrincipalsAPI.getUser(new Context(global.oaeTests.tenants.cam), jack.id, function(err, user) {
-                                                        assert.ok(!err);
-                                                        assert.equal(user.isGlobalAdmin(), false);
-                                                        assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                        assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
-                                                        callback();
-                                                    });
+                                                    assert.equal(user.isGlobalAdmin(), false);
+                                                    assert.equal(user.isAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                    assert.equal(user.isTenantAdmin(global.oaeTests.tenants.cam.alias), false);
+                                                    return callback();
                                                 });
                                             });
                                         });

--- a/node_modules/oae-principals/tests/test-util.js
+++ b/node_modules/oae-principals/tests/test-util.js
@@ -37,15 +37,14 @@ describe('Principals', function() {
     before(function(callback) {
         // Fill up global admin rest context
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+
         // Fill up the rest context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            // Add the full user id onto the REST context for use inside of this test
-            johnRestContext.id = createdUser.id;
-            // We get John's me feed so he is logged in for creating users and groups
-            RestAPI.User.getMe(johnRestContext, function() {
-                callback();
+        TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+            assert.ok(!err);
+            johnRestContext = john.restContext;
+            RestAPI.User.getMe(johnRestContext, function(err) {
+                assert.ok(!err);
+                return callback();
             });
         });
     });
@@ -74,7 +73,8 @@ describe('Principals', function() {
                         }
                     });
                 } else {
-                    RestAPI.User.createUser(camAdminRestContext, principalId, 'password', metadata, null, function(err, userObj) {
+                    var email = TestsUtil.generateTestEmailAddress();
+                    RestAPI.User.createUser(camAdminRestContext, principalId, 'password', metadata, email, {}, function(err, userObj) {
                         assert.ok(!err);
                         var userContext = new Context(global.oaeTests.tenants.cam, userObj);
                         createdPrincipals[identifier] = userContext;
@@ -213,8 +213,11 @@ describe('Principals', function() {
             assert.ok(!PrincipalsUtil.isUser(id));
         });
 
+        /**
+         * Test that verifies the createUpdatedUser function
+         */
         it('verify createUpdatedUser', function() {
-            var source = new User('camtest', 'u:camtest:sourceId', 'sourceDisplayName', {
+            var source = new User('camtest', 'u:camtest:sourceId', 'sourceDisplayName', 'sourceEmail', {
                 'visibility': 'sourceVisibility',
                 'locale': 'sourceLocale',
                 'publicAlias': 'sourcePublicAlias'

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -184,14 +184,13 @@ describe('General Search', function() {
          * Test that verifies the search index is updated when a group is updated.
          */
         it('verify index updated group', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                TestsUtil.generateTestGroups(doerRestContext, 1, function(xyzTeam) {
+                TestsUtil.generateTestGroups(doer.restContext, 1, function(xyzTeam) {
 
                     // Verify that the group does not match on the term 'testverifyindexupdatedgroup', this is to sanity check the search before searching for a valid post-update hit later
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': xyzTeam.group.displayName}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': xyzTeam.group.displayName}, function(err, results) {
                         assert.ok(!err);
 
                         var doc = _getDocById(results, xyzTeam.group.id);
@@ -202,11 +201,11 @@ describe('General Search', function() {
 
                         // Update name match the term
                         var displayName = 'Team testverifyindexupdatedgroup' + xyzTeam.group.id;
-                        RestAPI.Group.updateGroup(doerRestContext, xyzTeam.group.id, {'displayName': displayName}, function(err) {
+                        RestAPI.Group.updateGroup(doer.restContext, xyzTeam.group.id, {'displayName': displayName}, function(err) {
                             assert.ok(!err);
 
                             // Verify that the group now appears with the search term 'testverifyindexupdatedgroup'
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'group', 'q': displayName}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'group', 'q': displayName}, function(err, results) {
                                 assert.ok(!err);
 
                                 var doc = _getDocById(results, xyzTeam.group.id);
@@ -229,15 +228,14 @@ describe('General Search', function() {
          * Test that verifies that a content item can be searched after it has been created.
          */
         it('verify index created content', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Verify search term Apereo matches the document
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'Apereo'}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'Apereo'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
                         callback();
@@ -250,24 +248,23 @@ describe('General Search', function() {
          * Test that verifies the search index is updated after a content item is updated.
          */
         it('verify index updated content', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Verify search term OAE does not match the content
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(!_getDocById(results, content.id));
 
                         // Update the content
-                        RestAPI.Content.updateContent(doerRestContext, content.id, {'displayName': 'OAE Project'}, function(err) {
+                        RestAPI.Content.updateContent(doer.restContext, content.id, {'displayName': 'OAE Project'}, function(err) {
                             assert.ok(!err);
 
                             // Verify OAE now matches the updated content item
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': 'OAE'}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(_getDocById(results, content.id));
                                 callback();
@@ -588,65 +585,63 @@ describe('General Search', function() {
             };
 
             // Ensure at least one user, group and content item exists
-            var uniqueString = TestsUtil.generateTestUserId('resourcetype-test');
-            RestAPI.User.createUser(camAdminRestContext, uniqueString, 'password', uniqueString, null, function(err, user) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, uniqueString, 'password');
 
-                RestAPI.Group.createGroup(jackRestContext, uniqueString, uniqueString, 'public', 'no', [], [], function(err, group) {
+                RestAPI.Group.createGroup(jack.restContext, jack.user.displayName, jack.user.displayName, 'public', 'no', [], [], function(err, group) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(jackRestContext, uniqueString, uniqueString, 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                    RestAPI.Content.createLink(jack.restContext, jack.user.displayName, jack.user.displayName, 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                         assert.ok(!err);
 
                         // Verify unspecified resourceTypes searches all
-                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
                             _verifyHasResourceTypes(results, true, true, true);
 
                             // Verify empty resourceTypes searches all
-                            RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': '', 'q': uniqueString}, function(err, results) {
+                            RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': '', 'q': jack.user.displayName}, function(err, results) {
                                 assert.ok(!err);
                                 _verifyHasResourceTypes(results, true, true, true);
 
                                 // Verify non-matching single resource type returns nothing
-                                RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'not-matching-anything', 'q': uniqueString}, function(err, results) {
+                                RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'not-matching-anything', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
                                     assert.equal(results.results.length, 0);
 
                                     // Verify each single resourceType searches just that one
-                                    RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
                                         _verifyHasResourceTypes(results, true, false, false);
 
-                                        RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
+                                        RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
                                             _verifyHasResourceTypes(results, false, true, false);
 
-                                            RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': 'content'}, function(err, results) {
+                                            RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': 'content'}, function(err, results) {
                                                 assert.ok(!err);
                                                 _verifyHasResourceTypes(results, false, false, true);
 
                                                 // Verify searching 2 returns just the 2 types
-                                                RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['group', 'content'], 'q': uniqueString}, function(err, results) {
+                                                RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['group', 'content'], 'q': jack.user.displayName}, function(err, results) {
                                                     assert.ok(!err);
                                                     _verifyHasResourceTypes(results, false, true, true);
 
                                                     // Verify searching one with garbage commas returns just the one
-                                                    RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['', '', 'content', ''], 'q': uniqueString}, function(err, results) {
+                                                    RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['', '', 'content', ''], 'q': jack.user.displayName}, function(err, results) {
                                                         assert.ok(!err);
                                                         _verifyHasResourceTypes(results, false, false, true);
 
                                                         // Verify searching two with garbage commas returns just the two
-                                                        RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['', '', 'user', 'content', '', ''], 'q': uniqueString}, function(err, results) {
+                                                        RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['', '', 'user', 'content', '', ''], 'q': jack.user.displayName}, function(err, results) {
                                                             assert.ok(!err);
                                                             _verifyHasResourceTypes(results, true, false, true);
 
                                                             // Verify searching with garbage commas and non-matching values still returns by the valid resources types
-                                                            RestAPI.Search.search(jackRestContext, 'general', null, {'resourceTypes': ['', '', 'non-matching', '', 'group', 'user'], 'q': uniqueString}, function(err, results) {
+                                                            RestAPI.Search.search(jack.restContext, 'general', null, {'resourceTypes': ['', '', 'non-matching', '', 'group', 'user'], 'q': jack.user.displayName}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 _verifyHasResourceTypes(results, true, true, false);
-                                                                callback();
+                                                                return callback();
                                                             });
                                                         });
                                                     });
@@ -669,19 +664,18 @@ describe('General Search', function() {
          * Test that verifies that the 'start' property properly pages search results
          */
         it('verify search paging', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
                 // Make sure we have at least 2 content items to page with, their actual information is not important for this test
-                RestAPI.Content.createLink(doerRestContext, 'OAE Project', 'Link to OAE Project Website', 'public', 'http://www.oaeproject.org', [], [], [], function(err, link) {
+                RestAPI.Content.createLink(doer.restContext, 'OAE Project', 'Link to OAE Project Website', 'public', 'http://www.oaeproject.org', [], [], [], function(err, link) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(doerRestContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, link) {
+                    RestAPI.Content.createLink(doer.restContext, 'Apereo Foundation', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, link) {
                         assert.ok(!err);
 
                         // Search once and grab the first document id
-                        SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'limit': 1}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'limit': 1}, function(err, results) {
                             assert.ok(!err);
                             assert.ok(results);
                             assert.ok(results.results);
@@ -691,7 +685,7 @@ describe('General Search', function() {
                             assert.ok(firstDocId);
 
                             // Perform the same search, but with start=0, and make sure the first document is still the same. Verifies default paging
-                            RestAPI.Search.search(doerRestContext, 'general', null, {'limit': 1, 'start': 0}, function(err, results) {
+                            RestAPI.Search.search(doer.restContext, 'general', null, {'limit': 1, 'start': 0}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(results);
                                 assert.ok(results.results);
@@ -699,7 +693,7 @@ describe('General Search', function() {
                                 assert.equal(results.results[0].id, firstDocId);
 
                                 // Search again with start=1 and verify the first document id of the previous search is not the same as the first document id of this search
-                                RestAPI.Search.search(doerRestContext, 'general', null, {'limit': 1, 'start': 1}, function(err, results) {
+                                RestAPI.Search.search(doer.restContext, 'general', null, {'limit': 1, 'start': 1}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(results);
                                     assert.ok(results.results);
@@ -709,7 +703,7 @@ describe('General Search', function() {
                                     assert.ok(secondDocId);
 
                                     assert.notEqual(firstDocId, secondDocId);
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });
@@ -1041,26 +1035,25 @@ describe('General Search', function() {
          * Test that verifies deleted content is removed from the search index.
          */
         it('verify deleted content is unsearchable', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            var uniqueString = TestsUtil.generateTestUserId('unsearchable-content');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, uniqueString, uniqueString, 'public', 'http://www.oaeproject.org', [], [], [], function(err, content) {
+                var uniqueString = TestsUtil.generateTestUserId('unsearchable-content');
+                RestAPI.Content.createLink(doer.restContext, uniqueString, uniqueString, 'public', 'http://www.oaeproject.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Verify search term Apereo does not match the content
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
 
-                        RestAPI.Content.deleteContent(doerRestContext, content.id, function(err) {
+                        RestAPI.Content.deleteContent(doer.restContext, content.id, function(err) {
                             assert.ok(!err);
 
-                            SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'resourceTypes': 'content', 'q': uniqueString}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(!_getDocById(results, content.id));
-                                callback();
+                                return callback();
                             });
                         });
                     });
@@ -1072,50 +1065,73 @@ describe('General Search', function() {
          * Test that verifies that public content is searchable by all users.
          */
         it('verify public content searchable by everyone', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('public-searchable-content');
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                        assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
+                    TestsUtil.generateTestGroups(doer.restContext, 5, function() {
+                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                        // Give jack access via group
+                        TestsUtil.generateGroupHierarchy(doer.restContext, groupIds, 'member', function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            TestsUtil.generateTestGroups(doerRestContext, 5, function() {
-                                var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+                            TestsUtil.generateGroupHierarchy(doer.restContext, [groupIds[4], jack.user.id], 'member', function(err) {
+                                assert.ok(!err);
 
-                                // Give jack access via group
-                                TestsUtil.generateGroupHierarchy(doerRestContext, groupIds, 'member', function(err) {
+                                var uniqueString = TestsUtil.generateTestUserId('public-searchable-content');
+                                RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
                                     assert.ok(!err);
 
-                                    TestsUtil.generateGroupHierarchy(doerRestContext, [groupIds[4], jack.id], 'member', function(err) {
+                                    // Verify anonymous can see it
+                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                         assert.ok(!err);
 
-                                        RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 1', 'public', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
+                                        var contentDoc = _getDocById(results, contentObj.id);
+                                        assert.ok(contentDoc);
+                                        assert.equal(contentDoc.resourceSubType, 'link');
+                                        assert.equal(contentDoc.displayName, contentObj.displayName);
+                                        assert.equal(contentDoc.tenantAlias, 'camtest');
+                                        assert.equal(contentDoc.visibility, contentObj.visibility);
+                                        assert.equal(contentDoc.resourceType, 'content');
+                                        assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                        assert.equal(contentDoc.id, contentObj.id);
+                                        assert.equal(contentDoc._extra, undefined);
+                                        assert.equal(contentDoc._type, undefined);
+                                        assert.equal(contentDoc.q_high, undefined);
+                                        assert.equal(contentDoc.q_low, undefined);
+                                        assert.equal(contentDoc.sort, undefined);
+
+                                        // Verify tenant admin can see it
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                             assert.ok(!err);
 
-                                            // Verify anonymous can see it
-                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                            var contentDoc = _getDocById(results, contentObj.id);
+                                            assert.ok(contentDoc);
+                                            assert.equal(contentDoc.resourceSubType, 'link');
+                                            assert.equal(contentDoc.displayName, contentObj.displayName);
+                                            assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                            assert.equal(contentDoc.visibility, contentObj.visibility);
+                                            assert.equal(contentDoc.resourceType, 'content');
+                                            assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                            assert.equal(contentDoc.id, contentObj.id);
+                                            assert.equal(contentDoc._extra, undefined);
+                                            assert.equal(contentDoc._type, undefined);
+                                            assert.equal(contentDoc.q_high, undefined);
+                                            assert.equal(contentDoc.q_low, undefined);
+                                            assert.equal(contentDoc.sort, undefined);
+
+                                            // Verify same-tenant loggedin user can see it
+                                            SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                 assert.ok(!err);
 
                                                 var contentDoc = _getDocById(results, contentObj.id);
                                                 assert.ok(contentDoc);
                                                 assert.equal(contentDoc.resourceSubType, 'link');
                                                 assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                assert.equal(contentDoc.tenantAlias, 'camtest');
+                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
                                                 assert.equal(contentDoc.visibility, contentObj.visibility);
                                                 assert.equal(contentDoc.resourceType, 'content');
                                                 assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
@@ -1126,8 +1142,8 @@ describe('General Search', function() {
                                                 assert.equal(contentDoc.q_low, undefined);
                                                 assert.equal(contentDoc.sort, undefined);
 
-                                                // Verify tenant admin can see it
-                                                SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                // Verify same-tenant loggedin user can see it
+                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                     assert.ok(!err);
 
                                                     var contentDoc = _getDocById(results, contentObj.id);
@@ -1145,8 +1161,8 @@ describe('General Search', function() {
                                                     assert.equal(contentDoc.q_low, undefined);
                                                     assert.equal(contentDoc.sort, undefined);
 
-                                                    // Verify same-tenant loggedin user can see it
-                                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                    // Verify permitted user can see it
+                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                         assert.ok(!err);
 
                                                         var contentDoc = _getDocById(results, contentObj.id);
@@ -1164,47 +1180,7 @@ describe('General Search', function() {
                                                         assert.equal(contentDoc.q_low, undefined);
                                                         assert.equal(contentDoc.sort, undefined);
 
-                                                        // Verify same-tenant loggedin user can see it
-                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                            assert.ok(!err);
-
-                                                            var contentDoc = _getDocById(results, contentObj.id);
-                                                            assert.ok(contentDoc);
-                                                            assert.equal(contentDoc.resourceSubType, 'link');
-                                                            assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                            assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                            assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                            assert.equal(contentDoc.resourceType, 'content');
-                                                            assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                            assert.equal(contentDoc.id, contentObj.id);
-                                                            assert.equal(contentDoc._extra, undefined);
-                                                            assert.equal(contentDoc._type, undefined);
-                                                            assert.equal(contentDoc.q_high, undefined);
-                                                            assert.equal(contentDoc.q_low, undefined);
-                                                            assert.equal(contentDoc.sort, undefined);
-
-                                                            // Verify permitted user can see it
-                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                assert.ok(!err);
-
-                                                                var contentDoc = _getDocById(results, contentObj.id);
-                                                                assert.ok(contentDoc);
-                                                                assert.equal(contentDoc.resourceSubType, 'link');
-                                                                assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                assert.equal(contentDoc.resourceType, 'content');
-                                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                assert.equal(contentDoc.id, contentObj.id);
-                                                                assert.equal(contentDoc._extra, undefined);
-                                                                assert.equal(contentDoc._type, undefined);
-                                                                assert.equal(contentDoc.q_high, undefined);
-                                                                assert.equal(contentDoc.q_low, undefined);
-                                                                assert.equal(contentDoc.sort, undefined);
-
-                                                                callback();
-                                                            });
-                                                        });
+                                                        return callback();
                                                     });
                                                 });
                                             });
@@ -1222,53 +1198,172 @@ describe('General Search', function() {
          * Test that verifies loggedin content items are only search by users authenticated to the content item's parent tenant.
          */
         it('verify loggedin content search not searchable by anonymous or cross-tenant', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('loggedin-searchable-content');
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
 
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                        assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
+                    TestsUtil.generateTestGroups(doer.restContext, 5, function() {
+                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                        // Give jack access via group
+                        TestsUtil.generateGroupHierarchy(doer.restContext, groupIds, 'member', function(err) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                            TestsUtil.generateTestGroups(doerRestContext, 5, function() {
-                                var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+                            TestsUtil.generateGroupHierarchy(doer.restContext, [groupIds[4], jack.user.id], 'member', function(err) {
+                                assert.ok(!err);
 
-                                // Give jack access via group
-                                TestsUtil.generateGroupHierarchy(doerRestContext, groupIds, 'member', function(err) {
+                                var uniqueString = TestsUtil.generateTestUserId('loggedin-searchable-content');
+                                RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 1', 'loggedin', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
                                     assert.ok(!err);
 
-                                    TestsUtil.generateGroupHierarchy(doerRestContext, [groupIds[4], jack.id], 'member', function(err) {
+                                    // Verify anonymous cannot see it
+                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                         assert.ok(!err);
+                                        assert.ok(!_getDocById(results, contentObj.id));
 
-                                        RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 1', 'loggedin', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
+                                        // Verify cross-tenant user cannot see it
+                                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
                                             assert.ok(!err);
+                                            assert.ok(!_getDocById(results, contentObj.id));
 
-                                            // Verify anonymous cannot see it
-                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                            // Verify tenant admin can see it
+                                            SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                 assert.ok(!err);
-                                                assert.ok(!_getDocById(results, contentObj.id));
 
-                                                // Verify cross-tenant user cannot see it
-                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                                var contentDoc = _getDocById(results, contentObj.id);
+                                                assert.ok(contentDoc);
+                                                assert.equal(contentDoc.resourceSubType, 'link');
+                                                assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                assert.equal(contentDoc.resourceType, 'content');
+                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                assert.equal(contentDoc.id, contentObj.id);
+                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                assert.equal(contentDoc._extra, undefined);
+                                                assert.equal(contentDoc._type, undefined);
+                                                assert.equal(contentDoc.q_high, undefined);
+                                                assert.equal(contentDoc.q_low, undefined);
+                                                assert.equal(contentDoc.sort, undefined);
+
+                                                // Verify same-tenant loggedin user can see it
+                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                    assert.ok(!err);
+
+                                                    var contentDoc = _getDocById(results, contentObj.id);
+                                                    assert.ok(contentDoc);
+                                                    assert.equal(contentDoc.resourceSubType, 'link');
+                                                    assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                    assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                    assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                    assert.equal(contentDoc.resourceType, 'content');
+                                                    assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                    assert.equal(contentDoc.id, contentObj.id);
+                                                    assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                    assert.equal(contentDoc._extra, undefined);
+                                                    assert.equal(contentDoc._type, undefined);
+                                                    assert.equal(contentDoc.q_high, undefined);
+                                                    assert.equal(contentDoc.q_low, undefined);
+                                                    assert.equal(contentDoc.sort, undefined);
+
+                                                    // Verify permitted user can see it
+                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                        assert.ok(!err);
+                                                        assert.ok(_getDocById(results, contentObj.id));
+
+                                                        var contentDoc = _getDocById(results, contentObj.id);
+                                                        assert.ok(contentDoc);
+                                                        assert.equal(contentDoc.resourceSubType, 'link');
+                                                        assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                        assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                        assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                        assert.equal(contentDoc.resourceType, 'content');
+                                                        assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                        assert.equal(contentDoc.id, contentObj.id);
+                                                        assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                        assert.equal(contentDoc._extra, undefined);
+                                                        assert.equal(contentDoc._type, undefined);
+                                                        assert.equal(contentDoc.q_high, undefined);
+                                                        assert.equal(contentDoc.q_low, undefined);
+                                                        assert.equal(contentDoc.sort, undefined);
+
+                                                        return callback();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that private content is not searchable by anyone but admins and members.
+         */
+        it('verify private content search not searchable by anyone but admin and privileged users', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, doer, jack, jane) {
+                assert.ok(!err);
+
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
+                    assert.ok(!err);
+
+                    TestsUtil.generateTestGroups(doer.restContext, 5, function() {
+                        var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
+
+                        // Give jack access via group
+                        TestsUtil.generateGroupHierarchy(doer.restContext, groupIds, 'member', function(err) {
+                            assert.ok(!err);
+
+                            TestsUtil.generateGroupHierarchy(doer.restContext, [groupIds[4], jack.user.id], 'member', function(err) {
+                                assert.ok(!err);
+
+                                var uniqueString = TestsUtil.generateTestUserId('private-searchable-content');
+                                RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 1', 'private', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
+                                    assert.ok(!err);
+
+                                    // Verify anonymous cannot see it
+                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                        assert.ok(!err);
+                                        assert.ok(!_getDocById(results, contentObj.id));
+
+                                        // Verify cross-tenant user cannot see it
+                                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                            assert.ok(!err);
+                                            assert.ok(!_getDocById(results, contentObj.id));
+
+                                            // Verify tenant admin can see it
+                                            SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                assert.ok(!err);
+
+                                                var contentDoc = _getDocById(results, contentObj.id);
+                                                assert.ok(contentDoc);
+                                                assert.equal(contentDoc.resourceSubType, 'link');
+                                                assert.equal(contentDoc.displayName, contentObj.displayName);
+                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
+                                                assert.equal(contentDoc.visibility, contentObj.visibility);
+                                                assert.equal(contentDoc.resourceType, 'content');
+                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
+                                                assert.equal(contentDoc.id, contentObj.id);
+                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
+                                                assert.equal(contentDoc._extra, undefined);
+                                                assert.equal(contentDoc._type, undefined);
+                                                assert.equal(contentDoc.q_high, undefined);
+                                                assert.equal(contentDoc.q_low, undefined);
+                                                assert.equal(contentDoc.sort, undefined);
+
+                                                // Verify same-tenant loggedin user cannot see it
+                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                     assert.ok(!err);
                                                     assert.ok(!_getDocById(results, contentObj.id));
 
-                                                    // Verify tenant admin can see it
-                                                    SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                    // Verify permitted user can see it
+                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                         assert.ok(!err);
 
                                                         var contentDoc = _getDocById(results, contentObj.id);
@@ -1287,8 +1382,8 @@ describe('General Search', function() {
                                                         assert.equal(contentDoc.q_low, undefined);
                                                         assert.equal(contentDoc.sort, undefined);
 
-                                                        // Verify same-tenant loggedin user can see it
-                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
+                                                        // Verify global admin on a different tenant can see it
+                                                        SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
                                                             assert.ok(!err);
 
                                                             var contentDoc = _getDocById(results, contentObj.id);
@@ -1307,178 +1402,25 @@ describe('General Search', function() {
                                                             assert.equal(contentDoc.q_low, undefined);
                                                             assert.equal(contentDoc.sort, undefined);
 
-                                                            // Verify permitted user can see it
-                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                assert.ok(!err);
-                                                                assert.ok(_getDocById(results, contentObj.id));
+                                                            // Generate a new group, make Jack a member of it, create a piece of content and
+                                                            // share it with the group. All of this is done so we can check the direct membership
+                                                            // filter is NOT cached
+                                                            TestsUtil.generateTestGroups(doer.restContext, 1, function(anotherGroup) {
 
-                                                                var contentDoc = _getDocById(results, contentObj.id);
-                                                                assert.ok(contentDoc);
-                                                                assert.equal(contentDoc.resourceSubType, 'link');
-                                                                assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                assert.equal(contentDoc.resourceType, 'content');
-                                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                assert.equal(contentDoc.id, contentObj.id);
-                                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                                assert.equal(contentDoc._extra, undefined);
-                                                                assert.equal(contentDoc._type, undefined);
-                                                                assert.equal(contentDoc.q_high, undefined);
-                                                                assert.equal(contentDoc.q_low, undefined);
-                                                                assert.equal(contentDoc.sort, undefined);
-
-                                                                callback();
-                                                            });
-                                                        });
-                                                    });
-                                                });
-                                            });
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-
-        /**
-         * Test that verifies that private content is not searchable by anyone but admins and members.
-         */
-        it('verify private content search not searchable by anyone but admin and privileged users', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('private-searchable-content');
-
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
-
-                // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
-                    assert.ok(!err);
-                    var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
-
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
-                        assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
-
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
-                            assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
-
-                            TestsUtil.generateTestGroups(doerRestContext, 5, function() {
-                                var groupIds = _.chain(arguments).pluck('group').pluck('id').value();
-
-                                // Give jack access via group
-                                TestsUtil.generateGroupHierarchy(doerRestContext, groupIds, 'member', function(err) {
-                                    assert.ok(!err);
-
-                                    TestsUtil.generateGroupHierarchy(doerRestContext, [groupIds[4], jack.id], 'member', function(err) {
-                                        assert.ok(!err);
-
-                                        RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 1', 'private', 'http://www.oaeproject.org/',  [], [groupIds[0]], [], function(err, contentObj) {
-                                            assert.ok(!err);
-
-                                            // Verify anonymous cannot see it
-                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                assert.ok(!err);
-                                                assert.ok(!_getDocById(results, contentObj.id));
-
-                                                // Verify cross-tenant user cannot see it
-                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
-                                                    assert.ok(!err);
-                                                    assert.ok(!_getDocById(results, contentObj.id));
-
-                                                    // Verify tenant admin can see it
-                                                    SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                        assert.ok(!err);
-
-                                                        var contentDoc = _getDocById(results, contentObj.id);
-                                                        assert.ok(contentDoc);
-                                                        assert.equal(contentDoc.resourceSubType, 'link');
-                                                        assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                        assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                        assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                        assert.equal(contentDoc.resourceType, 'content');
-                                                        assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                        assert.equal(contentDoc.id, contentObj.id);
-                                                        assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                        assert.equal(contentDoc._extra, undefined);
-                                                        assert.equal(contentDoc._type, undefined);
-                                                        assert.equal(contentDoc.q_high, undefined);
-                                                        assert.equal(contentDoc.q_low, undefined);
-                                                        assert.equal(contentDoc.sort, undefined);
-
-                                                        // Verify same-tenant loggedin user cannot see it
-                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                            assert.ok(!err);
-                                                            assert.ok(!_getDocById(results, contentObj.id));
-
-                                                            // Verify permitted user can see it
-                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                assert.ok(!err);
-
-                                                                var contentDoc = _getDocById(results, contentObj.id);
-                                                                assert.ok(contentDoc);
-                                                                assert.equal(contentDoc.resourceSubType, 'link');
-                                                                assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                assert.equal(contentDoc.resourceType, 'content');
-                                                                assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                assert.equal(contentDoc.id, contentObj.id);
-                                                                assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                                assert.equal(contentDoc._extra, undefined);
-                                                                assert.equal(contentDoc._type, undefined);
-                                                                assert.equal(contentDoc.q_high, undefined);
-                                                                assert.equal(contentDoc.q_low, undefined);
-                                                                assert.equal(contentDoc.sort, undefined);
-
-                                                                // Verify global admin on a different tenant can see it
-                                                                SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                                                var permissions = {};
+                                                                permissions[jack.user.id] = 'member';
+                                                                RestAPI.Group.setGroupMembers(doer.restContext, anotherGroup.group.id, permissions, function(err) {
                                                                     assert.ok(!err);
 
-                                                                    var contentDoc = _getDocById(results, contentObj.id);
-                                                                    assert.ok(contentDoc);
-                                                                    assert.equal(contentDoc.resourceSubType, 'link');
-                                                                    assert.equal(contentDoc.displayName, contentObj.displayName);
-                                                                    assert.equal(contentDoc.tenantAlias, contentObj.tenant.alias);
-                                                                    assert.equal(contentDoc.visibility, contentObj.visibility);
-                                                                    assert.equal(contentDoc.resourceType, 'content');
-                                                                    assert.equal(contentDoc.profilePath, '/content/' + contentObj.tenant.alias + '/' + AuthzUtil.getResourceFromId(contentObj.id).resourceId);
-                                                                    assert.equal(contentDoc.id, contentObj.id);
-                                                                    assert.equal(contentDoc.lastModified, contentObj.lastModified);
-                                                                    assert.equal(contentDoc._extra, undefined);
-                                                                    assert.equal(contentDoc._type, undefined);
-                                                                    assert.equal(contentDoc.q_high, undefined);
-                                                                    assert.equal(contentDoc.q_low, undefined);
-                                                                    assert.equal(contentDoc.sort, undefined);
+                                                                    RestAPI.Content.createLink(doer.restContext, uniqueString, 'Test content description 2', 'private', 'http://www.oaeproject.org/',  [], [anotherGroup.group.id], [], function(err, link2) {
+                                                                        assert.ok(!err);
 
-                                                                    // Generate a new group, make Jack a member of it, create a piece of content and
-                                                                    // share it with the group. All of this is done so we can check the direct membership
-                                                                    // filter is NOT cached
-                                                                    TestsUtil.generateTestGroups(doerRestContext, 1, function(anotherGroup) {
-
-                                                                        var permissions = {};
-                                                                        permissions[jack.id] = 'member';
-                                                                        RestAPI.Group.setGroupMembers(doerRestContext, anotherGroup.group.id, permissions, function(err) {
+                                                                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'q': uniqueString}, function(err, results) {
                                                                             assert.ok(!err);
 
-                                                                            RestAPI.Content.createLink(doerRestContext, uniqueString, 'Test content description 2', 'private', 'http://www.oaeproject.org/',  [], [anotherGroup.group.id], [], function(err, link2) {
-                                                                                assert.ok(!err);
-
-                                                                                SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'q': uniqueString}, function(err, results) {
-                                                                                    assert.ok(!err);
-
-                                                                                    var contentDoc = _getDocById(results, link2.id);
-                                                                                    assert.ok(contentDoc);
-                                                                                    return callback();
-                                                                                });
-                                                                            });
+                                                                            var contentDoc = _getDocById(results, link2.id);
+                                                                            assert.ok(contentDoc);
+                                                                            return callback();
                                                                         });
                                                                     });
                                                                 });
@@ -1538,46 +1480,37 @@ describe('General Search', function() {
          * Test that verifies public user search results are not hidden from anyone.
          */
         it('verify public user profile visible to everyone', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('user-public-profile');
-
-            // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                var jackOpts = {
-                    'visibility': 'public',
-                    'publicAlias': 'I was hidden'
-                };
-
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', uniqueString, jackOpts, function(err, jack) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                    var jackOpts = {
+                        'visibility': 'public',
+                        'publicAlias': 'I was hidden'
+                    };
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, jackOpts, function(err, jackUser) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        jack.user = jackUser;
 
                         // Verify hidden for cross-tenant user on internal search
-                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            var jackDoc = _getDocById(results, jack.id);
+                            var jackDoc = _getDocById(results, jack.user.id);
                             assert.ok(!jackDoc);
 
                             // Verify visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
+                                var jackDoc = _getDocById(results, jack.user.id);
                                 assert.ok(jackDoc);
-                                assert.equal(jackDoc.id, jack.id);
+                                assert.equal(jackDoc.id, jack.user.id);
                                 assert.equal(jackDoc.resourceType, 'user');
                                 assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                assert.equal(jackDoc.displayName, jack.displayName);
-                                assert.equal(jackDoc.visibility, jack.visibility);
+                                assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                assert.equal(jackDoc.displayName, jack.user.displayName);
+                                assert.equal(jackDoc.visibility, jack.user.visibility);
                                 assert.equal(jackDoc._extra, undefined);
                                 assert.equal(jackDoc.extra, undefined);
                                 assert.equal(jackDoc.q_high, undefined);
@@ -1586,16 +1519,16 @@ describe('General Search', function() {
                                 assert.equal(jackDoc._type, undefined);
 
                                 // Verify not hidden for anonymous
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-                                    var jackDoc = _getDocById(results, jack.id);
+                                    var jackDoc = _getDocById(results, jack.user.id);
                                     assert.ok(jackDoc);
-                                    assert.equal(jackDoc.id, jack.id);
+                                    assert.equal(jackDoc.id, jack.user.id);
                                     assert.equal(jackDoc.resourceType, 'user');
                                     assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                    assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                    assert.equal(jackDoc.displayName, jack.displayName);
-                                    assert.equal(jackDoc.visibility, jack.visibility);
+                                    assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                    assert.equal(jackDoc.displayName, jack.user.displayName);
+                                    assert.equal(jackDoc.visibility, jack.user.visibility);
                                     assert.equal(jackDoc._extra, undefined);
                                     assert.equal(jackDoc.extra, undefined);
                                     assert.equal(jackDoc.q_high, undefined);
@@ -1604,16 +1537,16 @@ describe('General Search', function() {
                                     assert.equal(jackDoc._type, undefined);
 
                                     // Verify not hidden for other in-tenant loggedin user
-                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
-                                        var jackDoc = _getDocById(results, jack.id);
+                                        var jackDoc = _getDocById(results, jack.user.id);
                                         assert.ok(jackDoc);
-                                        assert.equal(jackDoc.id, jack.id);
+                                        assert.equal(jackDoc.id, jack.user.id);
                                         assert.equal(jackDoc.resourceType, 'user');
                                         assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                        assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                        assert.equal(jackDoc.displayName, jack.displayName);
-                                        assert.equal(jackDoc.visibility, jack.visibility);
+                                        assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                        assert.equal(jackDoc.displayName, jack.user.displayName);
+                                        assert.equal(jackDoc.visibility, jack.user.visibility);
                                         assert.equal(jackDoc._extra, undefined);
                                         assert.equal(jackDoc.extra, undefined);
                                         assert.equal(jackDoc.q_high, undefined);
@@ -1622,16 +1555,16 @@ describe('General Search', function() {
                                         assert.equal(jackDoc._type, undefined);
 
                                         // Verify not hidden for admin
-                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
-                                            var jackDoc = _getDocById(results, jack.id);
+                                            var jackDoc = _getDocById(results, jack.user.id);
                                             assert.ok(jackDoc);
-                                            assert.equal(jackDoc.id, jack.id);
+                                            assert.equal(jackDoc.id, jack.user.id);
                                             assert.equal(jackDoc.resourceType, 'user');
                                             assert.equal(jackDoc.profilePath, '/user/'  + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                            assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                            assert.equal(jackDoc.displayName, jack.displayName);
-                                            assert.equal(jackDoc.visibility, jack.visibility);
+                                            assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                            assert.equal(jackDoc.displayName, jack.user.displayName);
+                                            assert.equal(jackDoc.visibility, jack.user.visibility);
                                             assert.equal(jackDoc._extra, undefined);
                                             assert.equal(jackDoc.extra, undefined);
                                             assert.equal(jackDoc.q_high, undefined);
@@ -1639,7 +1572,7 @@ describe('General Search', function() {
                                             assert.equal(jackDoc.sort, undefined);
                                             assert.equal(jackDoc._type, undefined);
 
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1654,58 +1587,49 @@ describe('General Search', function() {
          * Test that verifies loggedin user search results are hidden to users who are not authenticated to the user's tenant
          */
         it('verify loggedin user profile not visibile cross-tenant or to anonymous', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('user-loggedin-profile');
-
-            // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                var jackOpts = {
-                    'visibility': 'loggedin',
-                    'publicAlias': 'I was hidden'
-                };
-
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', uniqueString, jackOpts, function(err, jack) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                    var jackOpts = {
+                        'visibility': 'loggedin',
+                        'publicAlias': 'I was hidden'
+                    };
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, jackOpts, function(err, jackUser) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        jack.user = jackUser;
 
                         // Verify hidden for cross-tenant user on internal search
-                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            var jackDoc = _getDocById(results, jack.id);
+                            var jackDoc = _getDocById(results, jack.user.id);
                             assert.ok(!jackDoc);
 
                             // Verify not visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
+                                var jackDoc = _getDocById(results, jack.user.id);
                                 assert.ok(!jackDoc);
 
                                 // Verify not visible for anonymous
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-                                    var jackDoc = _getDocById(results, jack.id);
+                                    var jackDoc = _getDocById(results, jack.user.id);
                                     assert.ok(!jackDoc);
 
                                     // Verify visible for other in-tenant loggedin user
-                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
-                                        var jackDoc = _getDocById(results, jack.id);
+                                        var jackDoc = _getDocById(results, jack.user.id);
                                         assert.ok(jackDoc);
-                                        assert.equal(jackDoc.id, jack.id);
+                                        assert.equal(jackDoc.id, jack.user.id);
                                         assert.equal(jackDoc.resourceType, 'user');
                                         assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                        assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                        assert.equal(jackDoc.displayName, jack.displayName);
-                                        assert.equal(jackDoc.visibility, jack.visibility);
+                                        assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                        assert.equal(jackDoc.displayName, jack.user.displayName);
+                                        assert.equal(jackDoc.visibility, jack.user.visibility);
                                         assert.equal(jackDoc._extra, undefined);
                                         assert.equal(jackDoc.extra, undefined);
                                         assert.equal(jackDoc.q_high, undefined);
@@ -1714,16 +1638,16 @@ describe('General Search', function() {
                                         assert.equal(jackDoc._type, undefined);
 
                                         // Verify not hidden for admin
-                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
-                                            var jackDoc = _getDocById(results, jack.id);
+                                            var jackDoc = _getDocById(results, jack.user.id);
                                             assert.ok(jackDoc);
-                                            assert.equal(jackDoc.id, jack.id);
+                                            assert.equal(jackDoc.id, jack.user.id);
                                             assert.equal(jackDoc.resourceType, 'user');
                                             assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                            assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                            assert.equal(jackDoc.displayName, jack.displayName);
-                                            assert.equal(jackDoc.visibility, jack.visibility);
+                                            assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                            assert.equal(jackDoc.displayName, jack.user.displayName);
+                                            assert.equal(jackDoc.visibility, jack.user.visibility);
                                             assert.equal(jackDoc._extra, undefined);
                                             assert.equal(jackDoc.extra, undefined);
                                             assert.equal(jackDoc.q_high, undefined);
@@ -1731,7 +1655,7 @@ describe('General Search', function() {
                                             assert.equal(jackDoc.sort, undefined);
                                             assert.equal(jackDoc._type, undefined);
 
-                                            callback();
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1746,65 +1670,56 @@ describe('General Search', function() {
          * Test that verifies that private user profiles are hidden from everyone.
          */
         it('verify private user profile not visibile to anyone but admin users and the user themself', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var uniqueString = TestsUtil.generateTestUserId('user-private-profile');
-
-            // Create a user from another tenant, a private user from the same tenant, and a user from the same tenant that has access
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                var jackOpts = {
-                    'visibility': 'private',
-                    'publicAlias': 'I was hidden'
-                };
-
-                RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', uniqueString, jackOpts, function(err, jack) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 1, function(err, users, darthVader) {
                     assert.ok(!err);
-                    var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                    RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                    var jackOpts = {
+                        'visibility': 'private',
+                        'publicAlias': 'I was hidden'
+                    };
+                    RestAPI.User.updateUser(jack.restContext, jack.user.id, jackOpts, function(err, jackUser) {
                         assert.ok(!err);
-                        var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                        jack.user = jackUser;
 
                         // Verify hidden for cross-tenant user on internal search
-                        SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            var jackDoc = _getDocById(results, jack.id);
+                            var jackDoc = _getDocById(results, jack.user.id);
                             assert.ok(!jackDoc);
 
                             // Verify not visible for cross-tenant user on external search
-                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
-                                var jackDoc = _getDocById(results, jack.id);
+                                var jackDoc = _getDocById(results, jack.user.id);
                                 assert.ok(!jackDoc);
 
                                 // Verify not visible for anonymous
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
-                                    var jackDoc = _getDocById(results, jack.id);
+                                    var jackDoc = _getDocById(results, jack.user.id);
                                     assert.ok(!jackDoc);
 
                                     // Verify not visible for other in-tenant loggedin user
-                                    SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                         assert.ok(!err);
-                                        var jackDoc = _getDocById(results, jack.id);
+                                        var jackDoc = _getDocById(results, jack.user.id);
                                         assert.ok(!jackDoc);
 
                                         // Verify not hidden for tenant admin
-                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString}, function(err, results) {
+                                        SearchTestsUtil.searchRefreshed(camAdminRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                                             assert.ok(!err);
 
-                                            var jackDoc = _getDocById(results, jack.id);
+                                            var jackDoc = _getDocById(results, jack.user.id);
                                             assert.ok(jackDoc);
-                                            assert.equal(jackDoc.id, jack.id);
+                                            assert.equal(jackDoc.id, jack.user.id);
                                             assert.equal(jackDoc.resourceType, 'user');
                                             assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                            assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                            assert.equal(jackDoc.displayName, jack.displayName);
-                                            assert.equal(jackDoc.visibility, jack.visibility);
+                                            assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                            assert.equal(jackDoc.displayName, jack.user.displayName);
+                                            assert.equal(jackDoc.visibility, jack.user.visibility);
                                             assert.equal(jackDoc._extra, undefined);
                                             assert.equal(jackDoc.extra, undefined);
                                             assert.equal(jackDoc.q_high, undefined);
@@ -1814,17 +1729,17 @@ describe('General Search', function() {
 
 
                                             // Verify not hidden for global admin authenticated to a different tenant
-                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'user', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                            SearchTestsUtil.searchRefreshed(globalAdminOnTenantRestContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName, 'scope': '_network'}, function(err, results) {
                                                 assert.ok(!err);
 
-                                                var jackDoc = _getDocById(results, jack.id);
+                                                var jackDoc = _getDocById(results, jack.user.id);
                                                 assert.ok(jackDoc);
-                                                assert.equal(jackDoc.id, jack.id);
+                                                assert.equal(jackDoc.id, jack.user.id);
                                                 assert.equal(jackDoc.resourceType, 'user');
                                                 assert.equal(jackDoc.profilePath, '/user/' + jackDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(jackDoc.id).resourceId);
-                                                assert.equal(jackDoc.tenantAlias, jack.tenant.alias);
-                                                assert.equal(jackDoc.displayName, jack.displayName);
-                                                assert.equal(jackDoc.visibility, jack.visibility);
+                                                assert.equal(jackDoc.tenantAlias, jack.user.tenant.alias);
+                                                assert.equal(jackDoc.displayName, jack.user.displayName);
+                                                assert.equal(jackDoc.visibility, jack.user.visibility);
                                                 assert.equal(jackDoc._extra, undefined);
                                                 assert.equal(jackDoc.extra, undefined);
                                                 assert.equal(jackDoc.q_high, undefined);
@@ -1851,36 +1766,53 @@ describe('General Search', function() {
          * Test that verifies public groups are searchable by everyone
          */
         it('verify public group is searchable by everyone', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-            var uniqueString = TestsUtil.generateTestUserId('public-group-visibility');
-
-            // Create 2 users from a different tenant than the group, one of which is a member of the group
-            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
                 assert.ok(!err);
-                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy Sitherson', null, function(err, sith) {
+                TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                     assert.ok(!err);
-                    var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
 
-                    // Create 2 users from the same tenant as the group
-                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                    // Create the group, including sith as a user
+                    var uniqueString = TestsUtil.generateTestUserId('public-group-visibility');
+                    RestAPI.Group.createGroup(jack.restContext, uniqueString, uniqueString, 'public', 'no', [], [sith.user.id], function(err, group) {
                         assert.ok(!err);
-                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                        // Verify anonymous user search can access it
+                        SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                             assert.ok(!err);
-                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
+                            var groupDoc = _getDocById(results, group.id);
+                            assert.ok(groupDoc);
+                            assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                            assert.equal(groupDoc.resourceType, 'group');
+                            assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                            assert.equal(groupDoc.id, group.id);
+                            assert.equal(groupDoc.displayName, group.displayName);
+                            assert.equal(groupDoc.visibility, group.visibility);
+                            assert.equal(groupDoc._extra, undefined);
+                            assert.equal(groupDoc._type, undefined);
+                            assert.equal(groupDoc.q_high, undefined);
+                            assert.equal(groupDoc.q_low, undefined);
+                            assert.equal(groupDoc.sort, undefined);
 
-                            // Create the group, including sith as a user
-                            RestAPI.Group.createGroup(jackRestContext, uniqueString, uniqueString, 'public', 'no', [], [sith.id], function(err, group) {
+                            // Verify cross-tenant user can query the group
+                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
                                 assert.ok(!err);
+                                var groupDoc = _getDocById(results, group.id);
+                                assert.ok(groupDoc);
+                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                assert.equal(groupDoc.resourceType, 'group');
+                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                                assert.equal(groupDoc.id, group.id);
+                                assert.equal(groupDoc.displayName, group.displayName);
+                                assert.equal(groupDoc.visibility, group.visibility);
+                                assert.equal(groupDoc._extra, undefined);
+                                assert.equal(groupDoc._type, undefined);
+                                assert.equal(groupDoc.q_high, undefined);
+                                assert.equal(groupDoc.q_low, undefined);
+                                assert.equal(groupDoc.sort, undefined);
 
-                                // Verify anonymous user search can access it
-                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
+                                // Verify cross-tenant *member* can query the group
+                                SearchTestsUtil.searchRefreshed(sith.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_tenant'}, function(err, results) {
                                     assert.ok(!err);
                                     var groupDoc = _getDocById(results, group.id);
                                     assert.ok(groupDoc);
@@ -1896,8 +1828,8 @@ describe('General Search', function() {
                                     assert.equal(groupDoc.q_low, undefined);
                                     assert.equal(groupDoc.sort, undefined);
 
-                                    // Verify cross-tenant user can query the group
-                                    SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_network'}, function(err, results) {
+                                    // Verify another same-tenant loggedin user can query it
+                                    SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                                         assert.ok(!err);
                                         var groupDoc = _getDocById(results, group.id);
                                         assert.ok(groupDoc);
@@ -1913,8 +1845,8 @@ describe('General Search', function() {
                                         assert.equal(groupDoc.q_low, undefined);
                                         assert.equal(groupDoc.sort, undefined);
 
-                                        // Verify cross-tenant *member* can query the group
-                                        SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString, 'scope': '_tenant'}, function(err, results) {
+                                        // Verify member user can query it
+                                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
                                             assert.ok(!err);
                                             var groupDoc = _getDocById(results, group.id);
                                             assert.ok(groupDoc);
@@ -1930,43 +1862,7 @@ describe('General Search', function() {
                                             assert.equal(groupDoc.q_low, undefined);
                                             assert.equal(groupDoc.sort, undefined);
 
-                                            // Verify another same-tenant loggedin user can query it
-                                            SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
-                                                assert.ok(!err);
-                                                var groupDoc = _getDocById(results, group.id);
-                                                assert.ok(groupDoc);
-                                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
-                                                assert.equal(groupDoc.resourceType, 'group');
-                                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                assert.equal(groupDoc.id, group.id);
-                                                assert.equal(groupDoc.displayName, group.displayName);
-                                                assert.equal(groupDoc.visibility, group.visibility);
-                                                assert.equal(groupDoc._extra, undefined);
-                                                assert.equal(groupDoc._type, undefined);
-                                                assert.equal(groupDoc.q_high, undefined);
-                                                assert.equal(groupDoc.q_low, undefined);
-                                                assert.equal(groupDoc.sort, undefined);
-
-                                                // Verify member user can query it
-                                                SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueString}, function(err, results) {
-                                                    assert.ok(!err);
-                                                    var groupDoc = _getDocById(results, group.id);
-                                                    assert.ok(groupDoc);
-                                                    assert.equal(groupDoc.tenantAlias, group.tenant.alias);
-                                                    assert.equal(groupDoc.resourceType, 'group');
-                                                    assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                    assert.equal(groupDoc.id, group.id);
-                                                    assert.equal(groupDoc.displayName, group.displayName);
-                                                    assert.equal(groupDoc.visibility, group.visibility);
-                                                    assert.equal(groupDoc._extra, undefined);
-                                                    assert.equal(groupDoc._type, undefined);
-                                                    assert.equal(groupDoc.q_high, undefined);
-                                                    assert.equal(groupDoc.q_low, undefined);
-                                                    assert.equal(groupDoc.sort, undefined);
-
-                                                    return callback();
-                                                });
-                                            });
+                                            return callback();
                                         });
                                     });
                                 });
@@ -1985,11 +1881,6 @@ describe('General Search', function() {
          * will not be able to join the group, so there is no point in showing it in the results.
          */
         it('verify loggedin group search visibility', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-            var lukeSkywalkerUsername = TestsUtil.generateTestUserId('lukeSkywalker');
             var privateTenantAlias = TenantsTestUtil.generateTestTenantAlias('privateTenant');
             var uniqueStringA = TestsUtil.generateTestUserId('loggedin-group-visibility');
             var uniqueStringB = TestsUtil.generateTestUserId('loggedin-group-visibility');
@@ -2003,63 +1894,84 @@ describe('General Search', function() {
                 ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, privateTenantAlias, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(privateTenantAdminRestContext, lukeSkywalkerUsername, 'password', 'Luke Skywalker', null, function(err, lukeSkywalker) {
+                    TestsUtil.generateTestUsers(privateTenantAdminRestContext, 1, function(err, users, lukeSkywalker) {
                         assert.ok(!err);
-                        var lukeSkywalkerRestContext = TestsUtil.createTenantRestContext(privateTenantAlias, lukeSkywalkerUsername, 'password');
 
-                        RestAPI.Group.createGroup(lukeSkywalkerRestContext, uniqueStringC, uniqueStringC, 'loggedin', 'yes', [], [], function(err, privateTenantGroup) {
+                        RestAPI.Group.createGroup(lukeSkywalker.restContext, uniqueStringC, uniqueStringC, 'loggedin', 'yes', [], [], function(err, privateTenantGroup) {
                             assert.ok(!err);
 
                             // Create 2 users from another public tenant tenant (gt), one of which has access to the group, and 2 users from the same tenant
-                            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                            TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                                 assert.ok(!err);
-                                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                                // Create another user, this user will also be a member of the group
-                                RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy Sitherson', null, function(err, sith) {
-                                    assert.ok(!err);
-                                    var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
+                                TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
 
-                                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                                    // Create the group, including sith as a user
+                                    RestAPI.Group.createGroup(jack.restContext, uniqueStringA, uniqueStringA, 'loggedin', 'no', [], [sith.user.id], function(err, group) {
                                         assert.ok(!err);
-                                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                                        // Create the joinable group, including sith as a user
+                                        RestAPI.Group.createGroup(jack.restContext, uniqueStringB, uniqueStringB, 'loggedin', 'request', [], [sith.user.id], function(err, groupJoinable) {
                                             assert.ok(!err);
-                                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
-                                            // Create the group, including sith as a user
-                                            RestAPI.Group.createGroup(jackRestContext, uniqueStringA, uniqueStringA, 'loggedin', 'no', [], [sith.id], function(err, group) {
+                                            // Verify anonymous user search cannot access either
+                                            SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                 assert.ok(!err);
+                                                var groupDoc = _getDocById(results, group.id);
+                                                assert.ok(!groupDoc);
 
-                                                // Create the joinable group, including sith as a user
-                                                RestAPI.Group.createGroup(jackRestContext, uniqueStringB, uniqueStringB, 'loggedin', 'request', [], [sith.id], function(err, groupJoinable) {
+                                                SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB}, function(err, results) {
                                                     assert.ok(!err);
+                                                    var groupDoc = _getDocById(results, groupJoinable.id);
+                                                    assert.ok(!groupDoc);
 
-                                                    // Verify anonymous user search cannot access either
-                                                    SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                    // Verify cross-tenant user cannot query the unjoinable group
+                                                    SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA, 'scope': '_network'}, function(err, results) {
                                                         assert.ok(!err);
                                                         var groupDoc = _getDocById(results, group.id);
                                                         assert.ok(!groupDoc);
 
-                                                        SearchTestsUtil.searchRefreshed(anonymousRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB}, function(err, results) {
+                                                        // Verify cross-tenant user cannot query the joinable group
+                                                        SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
                                                             assert.ok(!err);
-                                                            var groupDoc = _getDocById(results, groupJoinable.id);
-                                                            assert.ok(!groupDoc);
+                                                            assert.ok(!_getDocById(results, groupJoinable.id));
 
-                                                            // Verify cross-tenant user cannot query the unjoinable group
-                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA, 'scope': '_network'}, function(err, results) {
+                                                            // Verify cross-tenant member can query the unjoinable group
+                                                            SearchTestsUtil.searchRefreshed(sith.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 var groupDoc = _getDocById(results, group.id);
-                                                                assert.ok(!groupDoc);
+                                                                assert.ok(groupDoc);
+                                                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                                                assert.equal(groupDoc.resourceType, 'group');
+                                                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                                                                assert.equal(groupDoc.id, group.id);
+                                                                assert.equal(groupDoc.displayName, group.displayName);
+                                                                assert.equal(groupDoc.visibility, group.visibility);
+                                                                assert.equal(groupDoc._extra, undefined);
+                                                                assert.equal(groupDoc._type, undefined);
+                                                                assert.equal(groupDoc.q_high, undefined);
+                                                                assert.equal(groupDoc.q_low, undefined);
+                                                                assert.equal(groupDoc.sort, undefined);
 
-                                                                // Verify cross-tenant user cannot query the joinable group
-                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
+                                                                // Verify another same-tenant loggedin user can query it
+                                                                SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                                     assert.ok(!err);
-                                                                    assert.ok(!_getDocById(results, groupJoinable.id));
+                                                                    var groupDoc = _getDocById(results, group.id);
+                                                                    assert.ok(groupDoc);
+                                                                    assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                                                    assert.equal(groupDoc.resourceType, 'group');
+                                                                    assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
+                                                                    assert.equal(groupDoc.id, group.id);
+                                                                    assert.equal(groupDoc.displayName, group.displayName);
+                                                                    assert.equal(groupDoc.visibility, group.visibility);
+                                                                    assert.equal(groupDoc._extra, undefined);
+                                                                    assert.equal(groupDoc._type, undefined);
+                                                                    assert.equal(groupDoc.q_high, undefined);
+                                                                    assert.equal(groupDoc.q_low, undefined);
+                                                                    assert.equal(groupDoc.sort, undefined);
 
-                                                                    // Verify cross-tenant member can query the unjoinable group
-                                                                    SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                                    // Verify member user can query it
+                                                                    SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
                                                                         assert.ok(!err);
                                                                         var groupDoc = _getDocById(results, group.id);
                                                                         assert.ok(groupDoc);
@@ -2075,71 +1987,35 @@ describe('General Search', function() {
                                                                         assert.equal(groupDoc.q_low, undefined);
                                                                         assert.equal(groupDoc.sort, undefined);
 
-                                                                        // Verify another same-tenant loggedin user can query it
-                                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                                        // Sanity check luke skywalker's query to own loggedin group
+                                                                        SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC}, function(err, results) {
                                                                             assert.ok(!err);
-                                                                            var groupDoc = _getDocById(results, group.id);
+                                                                            var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                             assert.ok(groupDoc);
-                                                                            assert.equal(groupDoc.tenantAlias, group.tenant.alias);
+                                                                            assert.equal(groupDoc.tenantAlias, privateTenantGroup.tenant.alias);
                                                                             assert.equal(groupDoc.resourceType, 'group');
                                                                             assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                                            assert.equal(groupDoc.id, group.id);
-                                                                            assert.equal(groupDoc.displayName, group.displayName);
-                                                                            assert.equal(groupDoc.visibility, group.visibility);
+                                                                            assert.equal(groupDoc.id, privateTenantGroup.id);
+                                                                            assert.equal(groupDoc.displayName, privateTenantGroup.displayName);
+                                                                            assert.equal(groupDoc.visibility, privateTenantGroup.visibility);
                                                                             assert.equal(groupDoc._extra, undefined);
                                                                             assert.equal(groupDoc._type, undefined);
                                                                             assert.equal(groupDoc.q_high, undefined);
                                                                             assert.equal(groupDoc.q_low, undefined);
                                                                             assert.equal(groupDoc.sort, undefined);
 
-                                                                            // Verify member user can query it
-                                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringA}, function(err, results) {
+                                                                            // Verify a user from a private tenant cannot query an external loggedin joinable group
+                                                                            SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
                                                                                 assert.ok(!err);
-                                                                                var groupDoc = _getDocById(results, group.id);
-                                                                                assert.ok(groupDoc);
-                                                                                assert.equal(groupDoc.tenantAlias, group.tenant.alias);
-                                                                                assert.equal(groupDoc.resourceType, 'group');
-                                                                                assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                                                assert.equal(groupDoc.id, group.id);
-                                                                                assert.equal(groupDoc.displayName, group.displayName);
-                                                                                assert.equal(groupDoc.visibility, group.visibility);
-                                                                                assert.equal(groupDoc._extra, undefined);
-                                                                                assert.equal(groupDoc._type, undefined);
-                                                                                assert.equal(groupDoc.q_high, undefined);
-                                                                                assert.equal(groupDoc.q_low, undefined);
-                                                                                assert.equal(groupDoc.sort, undefined);
+                                                                                var groupDoc = _getDocById(results, groupJoinable.id);
+                                                                                assert.ok(!groupDoc);
 
-                                                                                // Sanity check luke skywalker's query to own loggedin group
-                                                                                SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC}, function(err, results) {
+                                                                                // Verify that user from a public tenant cannot query a loggedin joinable group that belongs to a private tenant (luke skywalker's tenant and group)
+                                                                                SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC, 'scope': '_network'}, function(err, results) {
                                                                                     assert.ok(!err);
                                                                                     var groupDoc = _getDocById(results, privateTenantGroup.id);
-                                                                                    assert.ok(groupDoc);
-                                                                                    assert.equal(groupDoc.tenantAlias, privateTenantGroup.tenant.alias);
-                                                                                    assert.equal(groupDoc.resourceType, 'group');
-                                                                                    assert.equal(groupDoc.profilePath, '/group/' + groupDoc.tenant.alias + '/' + AuthzUtil.getResourceFromId(groupDoc.id).resourceId);
-                                                                                    assert.equal(groupDoc.id, privateTenantGroup.id);
-                                                                                    assert.equal(groupDoc.displayName, privateTenantGroup.displayName);
-                                                                                    assert.equal(groupDoc.visibility, privateTenantGroup.visibility);
-                                                                                    assert.equal(groupDoc._extra, undefined);
-                                                                                    assert.equal(groupDoc._type, undefined);
-                                                                                    assert.equal(groupDoc.q_high, undefined);
-                                                                                    assert.equal(groupDoc.q_low, undefined);
-                                                                                    assert.equal(groupDoc.sort, undefined);
-
-                                                                                    // Verify a user from a private tenant cannot query an external loggedin joinable group
-                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringB, 'scope': '_network'}, function(err, results) {
-                                                                                        assert.ok(!err);
-                                                                                        var groupDoc = _getDocById(results, groupJoinable.id);
-                                                                                        assert.ok(!groupDoc);
-
-                                                                                        // Verify that user from a public tenant cannot query a loggedin joinable group that belongs to a private tenant (luke skywalker's tenant and group)
-                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': uniqueStringC, 'scope': '_network'}, function(err, results) {
-                                                                                            assert.ok(!err);
-                                                                                            var groupDoc = _getDocById(results, privateTenantGroup.id);
-                                                                                            assert.ok(!groupDoc);
-                                                                                            callback();
-                                                                                        });
-                                                                                    });
+                                                                                    assert.ok(!groupDoc);
+                                                                                    return callback();
                                                                                 });
                                                                             });
                                                                         });
@@ -2165,51 +2041,45 @@ describe('General Search', function() {
          * that it is searchable by authenticated users from other tenants so long as the group's tenant *and* the other tenant are both public.
          */
         it('verify private group search visibility', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-            var janeUsername = TestsUtil.generateTestUserId('jane');
-            var darthVaderUsername = TestsUtil.generateTestUserId('darthVader');
-            var sithUsername = TestsUtil.generateTestUserId('sith');
-            var lukeSkywalkerUsername = TestsUtil.generateTestUserId('lukeSkywalker');
             var privateTenantAlias = TenantsTestUtil.generateTestTenantAlias('privateTenant');
+            var uniqueStringA = TestsUtil.generateTestUserId('loggedin-group-visibility');
+            var uniqueStringB = TestsUtil.generateTestUserId('loggedin-group-visibility');
+            var uniqueStringC = TestsUtil.generateTestUserId('loggedin-group-visibility-skywalker');
 
-            // Create a private tenant with a user and a private joinable group
+            // Create a private tenant with a user and a loggedin joinable group. These will be used to test searches for cross-tenant private groups where
+            // you do not have access to join the group. In those cases, you should not get the group in the search results.
             TestsUtil.createTenantWithAdmin(privateTenantAlias, privateTenantAlias, function(err, privateTenant, privateTenantAdminRestContext) {
                 assert.ok(!err);
 
                 ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, privateTenantAlias, {'oae-tenants/tenantprivacy/tenantprivate': true}, function(err) {
                     assert.ok(!err);
 
-                    RestAPI.User.createUser(privateTenantAdminRestContext, lukeSkywalkerUsername, 'password', 'Luke Skywalker', null, function(err, lukeSkywalker) {
+                    TestsUtil.generateTestUsers(privateTenantAdminRestContext, 1, function(err, users, lukeSkywalker) {
                         assert.ok(!err);
-                        var lukeSkywalkerRestContext = TestsUtil.createTenantRestContext(privateTenantAlias, lukeSkywalkerUsername, 'password');
 
-                        RestAPI.Group.createGroup(lukeSkywalkerRestContext, TestsUtil.generateTestUserId('privateTenantGroup'), 'A luke skywalker tenant group', 'private', 'yes', [], [], function(err, privateTenantGroup) {
+                        RestAPI.Group.createGroup(lukeSkywalker.restContext, TestsUtil.generateTestUserId('privateTenantGroup'), 'A luke skywalker tenant group', 'private', 'yes', [], [], function(err, privateTenantGroup) {
                             assert.ok(!err);
 
-                            // Create a user from another tenant, a loggedin user from the same tenant, and a user from the same tenant that has access
-                            RestAPI.User.createUser(gtAdminRestContext, darthVaderUsername, 'password', 'Darth Vader', null, function(err, darthVader) {
+                            // Create 2 users from another public tenant tenant (gt), one of which has access to the group, and 2 users from the same tenant
+                            TestsUtil.generateTestUsers(gtAdminRestContext, 2, function(err, users, darthVader, sith) {
                                 assert.ok(!err);
-                                var darthVaderRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, darthVaderUsername, 'password');
 
-                                // Create another user, this user will also be a member of the group
-                                RestAPI.User.createUser(gtAdminRestContext, sithUsername, 'password', 'Sithy Sitherson', null, function(err, sith) {
-                                    assert.ok(!err);
-                                    var sithRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, sithUsername, 'password');
+                                TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, jack, jane) {
 
-                                    RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack McJackerson', null, function(err, jack) {
+                                    // Create the group, including sith as a user
+                                    RestAPI.Group.createGroup(jack.restContext, uniqueStringA, uniqueStringA, 'loggedin', 'no', [], [sith.user.id], function(err, group) {
                                         assert.ok(!err);
-                                        var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                                        RestAPI.User.createUser(camAdminRestContext, janeUsername, 'password', 'Janey McJaneFace', null, function(err, jane) {
+                                        // Create the joinable group, including sith as a user
+                                        RestAPI.Group.createGroup(jack.restContext, uniqueStringB, uniqueStringB, 'loggedin', 'request', [], [sith.user.id], function(err, groupJoinable) {
                                             assert.ok(!err);
-                                            var janeRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, janeUsername, 'password');
 
                                             // Create the unjoinable group, including sith as a user
-                                            RestAPI.Group.createGroup(jackRestContext, TestsUtil.generateTestUserId('group'), 'A really awesome group', 'private', 'no', [], [sith.id], function(err, group) {
+                                            RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestUserId('group'), 'A really awesome group', 'private', 'no', [], [sith.user.id], function(err, group) {
                                                 assert.ok(!err);
 
                                                 // Create the joinable group, including sith as a user
-                                                RestAPI.Group.createGroup(jackRestContext, TestsUtil.generateTestUserId('groupJoinable'), 'A really super joinable group', 'private', 'request', [], [sith.id], function(err, groupJoinable) {
+                                                RestAPI.Group.createGroup(jack.restContext, TestsUtil.generateTestUserId('groupJoinable'), 'A really super joinable group', 'private', 'request', [], [sith.user.id], function(err, groupJoinable) {
                                                     assert.ok(!err);
 
                                                     // Verify anonymous user search cannot access either
@@ -2224,18 +2094,18 @@ describe('General Search', function() {
                                                             assert.ok(!groupDoc);
 
                                                             // Verify cross-tenant user cannot query the unjoinable group
-                                                            SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome', 'scope': '_network'}, function(err, results) {
+                                                            SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome', 'scope': '_network'}, function(err, results) {
                                                                 assert.ok(!err);
                                                                 var groupDoc = _getDocById(results, group.id);
                                                                 assert.ok(!groupDoc);
 
                                                                 // Verify cross-tenant user cannot query the joinable group
-                                                                SearchTestsUtil.searchRefreshed(darthVaderRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
+                                                                SearchTestsUtil.searchRefreshed(darthVader.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
                                                                     assert.ok(!err);
                                                                     assert.ok(!_getDocById(results, groupJoinable.id));
 
                                                                     // Verify cross-tenant member can query the unjoinable group
-                                                                    SearchTestsUtil.searchRefreshed(sithRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
+                                                                    SearchTestsUtil.searchRefreshed(sith.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
                                                                         assert.ok(!err);
 
                                                                         var groupDoc = _getDocById(results, group.id);
@@ -2253,13 +2123,13 @@ describe('General Search', function() {
                                                                         assert.equal(groupDoc.sort, undefined);
 
                                                                         // Verify another same-tenant loggedin user cannot query the unjoinable group
-                                                                        SearchTestsUtil.searchRefreshed(janeRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
+                                                                        SearchTestsUtil.searchRefreshed(jane.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
                                                                             assert.ok(!err);
                                                                             var groupDoc = _getDocById(results, group.id);
                                                                             assert.ok(!groupDoc);
 
                                                                             // Verify member user can query the unjoinable group
-                                                                            SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
+                                                                            SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'awesome'}, function(err, results) {
                                                                                 assert.ok(!err);
 
                                                                                 var groupDoc = _getDocById(results, group.id);
@@ -2277,7 +2147,7 @@ describe('General Search', function() {
                                                                                 assert.equal(groupDoc.sort, undefined);
 
                                                                                 // Sanity check luke skywalker's query to own group
-                                                                                SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker'}, function(err, results) {
+                                                                                SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker'}, function(err, results) {
                                                                                     assert.ok(!err);
 
                                                                                     var groupDoc = _getDocById(results, privateTenantGroup.id);
@@ -2295,13 +2165,13 @@ describe('General Search', function() {
                                                                                     assert.equal(groupDoc.sort, undefined);
 
                                                                                     // Verify a user from a private tenant cannot query an external private joinable group
-                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalkerRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
+                                                                                    SearchTestsUtil.searchRefreshed(lukeSkywalker.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'joinable', 'scope': '_network'}, function(err, results) {
                                                                                         assert.ok(!err);
                                                                                         var groupDoc = _getDocById(results, groupJoinable.id);
                                                                                         assert.ok(!groupDoc);
 
                                                                                         // Verify that user from a public tenant cannot query a private joinable group that belongs to a private tenant (luke skywalker's tenant and group)
-                                                                                        SearchTestsUtil.searchRefreshed(jackRestContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'scope': '_network'}, function(err, results) {
+                                                                                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': 'skywalker', 'scope': '_network'}, function(err, results) {
                                                                                             assert.ok(!err);
                                                                                             var groupDoc = _getDocById(results, privateTenantGroup.id);
                                                                                             assert.ok(!groupDoc);
@@ -2356,15 +2226,14 @@ describe('General Search', function() {
          * reasonably well.
          */
         it('verify edgengram analyzer of 3 for auto-suggest', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Search for just the first 3 characters to ensure it matches "Xyzforedgengram"
-                    SearchTestsUtil.searchRefreshed(doerRestContext, 'general', null, {'q': 'Xyz'}, function(err, results) {
+                    SearchTestsUtil.searchRefreshed(doer.restContext, 'general', null, {'q': 'Xyz'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
                         callback();
@@ -2377,15 +2246,14 @@ describe('General Search', function() {
          * Verifies that the search analyzer is not case-sensitive
          */
         it('verify search indexing is not case-sensitive', function(callback) {
-            var doerUsername = TestsUtil.generateTestUserId('doer');
-            RestAPI.User.createUser(camAdminRestContext, doerUsername, 'password', 'Doer', null, function(err, doer) {
-                var doerRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, doerUsername, 'password');
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, doer) {
+                assert.ok(!err);
 
-                RestAPI.Content.createLink(doerRestContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                RestAPI.Content.createLink(doer.restContext, 'Apereo Xyzforedgengram', 'Link to Apereo Foundation Website', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                     assert.ok(!err);
 
                     // Search using a lowercase querystring on an item that was indexed with upper case
-                    SearchTestsUtil.searchAll(doerRestContext, 'general', null, {'q': 'apereo'}, function(err, results) {
+                    SearchTestsUtil.searchAll(doer.restContext, 'general', null, {'q': 'apereo'}, function(err, results) {
                         assert.ok(!err);
                         assert.ok(_getDocById(results, content.id));
                         callback();
@@ -2467,9 +2335,11 @@ describe('General Search', function() {
          * Test that verifies that displayName matches are boosted correctly, even across spaces in the displayName
          */
         it('verify displayName matches are boosted across spaces', function(callback) {
-            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon Gaeremynck', null, function(err, simonGaeremynck) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon Gaeremynck', email, {}, function(err, simonGaeremynck) {
                 assert.ok(!err);
-                RestAPI.User.createUser(gtAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon The Great', null, function(err, simonTheGreat) {
+                email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(gtAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon The Great', email, {}, function(err, simonTheGreat) {
                     assert.ok(!err);
 
                     // When searching for 'Simon G', the 'Simon Gaeremynck' user should
@@ -2494,9 +2364,11 @@ describe('General Search', function() {
             // Generate 2 identical users on 2 tenants
             var username = TestsUtil.generateRandomText(1);
             var displayName = TestsUtil.generateRandomText(2);
-            RestAPI.User.createUser(camAdminRestContext, username, 'password', displayName, null, function(err, camUser) {
+            var email = TestsUtil.generateTestEmailAddress();
+            RestAPI.User.createUser(camAdminRestContext, username, 'password', displayName, email, {}, function(err, camUser) {
                 assert.ok(!err);
-                RestAPI.User.createUser(gtAdminRestContext, username, 'password', displayName, null, function(err, gtUser) {
+                email = TestsUtil.generateTestEmailAddress();
+                RestAPI.User.createUser(gtAdminRestContext, username, 'password', displayName, email, {}, function(err, gtUser) {
                     assert.ok(!err);
 
                     // When searching on the cambridge tenant, the user from the cambridge
@@ -2533,40 +2405,37 @@ describe('General Search', function() {
          * Test that verifies the resourceType parameter in the general search properly filter results by user, group and content.
          */
         it('verify resourceType scope param', function(callback) {
-            var jackUsername = TestsUtil.generateTestUserId('jack');
-
             // Ensure a user, group and content item exist in the search index to ensure they are not included in resource-scoped searches
-            RestAPI.User.createUser(camAdminRestContext, jackUsername, 'password', 'Jack JickMackerson', null, function(err, jack) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jack) {
                 assert.ok(!err);
-                var jackCtx = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUsername, 'password');
 
-                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestUserId('group'), 'A group for Jack', 'public', 'no', [], [], function(err, group) {
+                RestAPI.Group.createGroup(camAdminRestContext, TestsUtil.generateTestUserId('group'), 'A group for ' + jack.user.displayName, 'public', 'no', [], [], function(err, group) {
                     assert.ok(!err);
 
-                    RestAPI.Content.createLink(camAdminRestContext, 'Apereo Foundation', 'Link to Jack', 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
+                    RestAPI.Content.createLink(camAdminRestContext, 'Apereo Foundation', 'Link to ' + jack.user.displayName, 'public', 'http://www.apereo.org', [], [], [], function(err, content) {
                         assert.ok(!err);
 
                         // Verify we only get users from a user search
-                        SearchTestsUtil.searchRefreshed(jackCtx, 'general', null, {'resourceTypes': 'user', 'q': 'Jack'}, function(err, results) {
+                        SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'user', 'q': jack.user.displayName}, function(err, results) {
                             assert.ok(!err);
-                            assert.ok(_getDocById(results, jack.id));
+                            assert.ok(_getDocById(results, jack.user.id));
                             assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group'; }).length, 0);
                             assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content'; }).length, 0);
 
                             // Verify we only get groups from a group search
-                            SearchTestsUtil.searchRefreshed(jackCtx, 'general', null, {'resourceTypes': 'group', 'q': 'Jack'}, function(err, results) {
+                            SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'group', 'q': jack.user.displayName}, function(err, results) {
                                 assert.ok(!err);
                                 assert.ok(_getDocById(results, group.id));
                                 assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user'; }).length, 0);
                                 assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'content'; }).length, 0);
 
                                 // Verify we only get content from a content search
-                                SearchTestsUtil.searchRefreshed(jackCtx, 'general', null, {'resourceTypes': 'content', 'q': 'Jack'}, function(err, results) {
+                                SearchTestsUtil.searchRefreshed(jack.restContext, 'general', null, {'resourceTypes': 'content', 'q': jack.user.displayName}, function(err, results) {
                                     assert.ok(!err);
                                     assert.ok(_getDocById(results, content.id));
                                     assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'user'; }).length, 0);
                                     assert.equal(_.filter(results.results, function(result) { return result.resourceType === 'group'; }).length, 0);
-                                    callback();
+                                    return callback();
                                 });
                             });
                         });

--- a/node_modules/oae-telemetry/tests/test-telemetry.js
+++ b/node_modules/oae-telemetry/tests/test-telemetry.js
@@ -41,8 +41,6 @@ describe('Telemetry', function() {
     var camAdminRestContext = null;
     // Rest context that can be used every time we need to make a request as a global admin
     var globalAdminRestContext = null;
-    // Rest context for a user that will be used inside of the tests
-    var johnRestContext = null;
 
     /**
      * Function that will fill up the global admin, tenant admin and anymous rest context
@@ -56,12 +54,7 @@ describe('Telemetry', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         // Fill up the global admin rest context
         globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
-        // Fill up the rest context for our test user
-        var userId = TestsUtil.generateTestUserId('john');
-        RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-            johnRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
-            callback();
-        });
+        return callback();
     });
 
     /**
@@ -180,32 +173,35 @@ describe('Telemetry', function() {
          * Test that verifies that only a global admin can request the telemetry data
          */
         it('verify that only a global admin can request the telemetry data', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+                assert.ok(!err);
 
-            // Request the telemetry data using an anonymous tenant user
-            RestAPI.Telemetry.getTelemetryData(anonymousCamRestContext, function(err, res) {
-                assert.ok(err);
-                assert.equal(err.code, 404);
-
-                // Request the telemetry data using an anonymous global user
-                RestAPI.Telemetry.getTelemetryData(anonymousGlobalRestContext, function(err, res) {
+                // Request the telemetry data using an anonymous tenant user
+                RestAPI.Telemetry.getTelemetryData(anonymousCamRestContext, function(err, res) {
                     assert.ok(err);
-                    assert.equal(err.code, 401);
-                    assert.equal(err.msg, 'Only global administrators are allowed to retrieve telemetry data');
+                    assert.equal(err.code, 404);
 
-                    // Request the telemetry data using a tenant user
-                    RestAPI.Telemetry.getTelemetryData(johnRestContext, function(err, res) {
+                    // Request the telemetry data using an anonymous global user
+                    RestAPI.Telemetry.getTelemetryData(anonymousGlobalRestContext, function(err, res) {
                         assert.ok(err);
-                        assert.equal(err.code, 404);
+                        assert.equal(err.code, 401);
+                        assert.equal(err.msg, 'Only global administrators are allowed to retrieve telemetry data');
 
-                        // Request the telemetry data using a tenant admin
-                        RestAPI.Telemetry.getTelemetryData(camAdminRestContext, function(err, res) {
+                        // Request the telemetry data using a tenant user
+                        RestAPI.Telemetry.getTelemetryData(john.restContext, function(err, res) {
                             assert.ok(err);
                             assert.equal(err.code, 404);
 
-                            // Request the telemetry data using a global admin
-                            RestAPI.Telemetry.getTelemetryData(globalAdminRestContext, function(err, res) {
-                                assert.ok(!err);
-                                return callback();
+                            // Request the telemetry data using a tenant admin
+                            RestAPI.Telemetry.getTelemetryData(camAdminRestContext, function(err, res) {
+                                assert.ok(err);
+                                assert.equal(err.code, 404);
+
+                                // Request the telemetry data using a global admin
+                                RestAPI.Telemetry.getTelemetryData(globalAdminRestContext, function(err, res) {
+                                    assert.ok(!err);
+                                    return callback();
+                                });
                             });
                         });
                     });

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -685,25 +685,24 @@ describe('Tenants', function() {
                                     assert.equal(err.code, 401);
 
                                     // Create a regular non-admin user
-                                    var userId = TestsUtil.generateTestUserId('john');
-                                    RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'John Doe', null, function(err, createdUser) {
-                                        var johnCamRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, userId, 'password');
+                                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, john) {
+                                        assert.ok(!err);
 
                                         // Try to update the tenant's display name as a non-admin user on a user tenant
-                                        RestAPI.Tenants.updateTenant(johnCamRestContext, null, {'displayName': 'Anglia Ruskin University'}, function(err) {
+                                        RestAPI.Tenants.updateTenant(john.restContext, null, {'displayName': 'Anglia Ruskin University'}, function(err) {
                                             assert.ok(err);
                                             assert.equal(err.code, 401);
 
                                             // Try to update the tenant's host as a non-admin user on a user tenant
-                                            RestAPI.Tenants.updateTenant(johnCamRestContext, null, {'host': 'newcamtest.oae.com'}, function(err) {
+                                            RestAPI.Tenants.updateTenant(john.restContext, null, {'host': 'newcamtest.oae.com'}, function(err) {
                                                 assert.ok(err);
                                                 assert.equal(err.code, 401);
 
                                                 // Try to update tenant's display name and host as a non-admin user on a user tenant
-                                                RestAPI.Tenants.updateTenant(johnCamRestContext, null, {'displayName': 'Anglia Ruskin University', 'host': 'newcamtest.oae.com'}, function(err) {
+                                                RestAPI.Tenants.updateTenant(john.restContext, null, {'displayName': 'Anglia Ruskin University', 'host': 'newcamtest.oae.com'}, function(err) {
                                                     assert.ok(err);
                                                     assert.equal(err.code, 401);
-                                                    callback();
+                                                    return callback();
                                                 });
                                             });
                                         });

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -38,6 +38,7 @@ var OaeUtil = require('oae-util/lib/util');
 var PreviewAPI = require('oae-preview-processor/lib/api');
 var PreviewConstants = require('oae-preview-processor/lib/constants');
 var PrincipalsAPI = require('oae-principals');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
 var Pubsub = require('oae-util/lib/pubsub');
 var Redis = require('oae-util/lib/redis');
 var RestAPI = require('oae-rest');
@@ -95,7 +96,7 @@ var createTestServer = module.exports.createTestServer = function(callback, _att
  * @throws {Error}                  An assertion error is thrown if an unexpected error occurs
  */
 var clearAllData = module.exports.clearAllData = function(callback) {
-    var columnFamiliesToClear = ['Content', 'Discussions', 'Folders', 'Principals', 'AuthenticationLoginId', 'AuthenticationUserLoginId'];
+    var columnFamiliesToClear = ['Content', 'Discussions', 'Folders', 'Principals', 'PrincipalsByEmail', 'AuthenticationLoginId', 'AuthenticationUserLoginId'];
 
     /*!
      * Once all column families have been truncated, we re-populate the administrators
@@ -106,15 +107,13 @@ var clearAllData = module.exports.clearAllData = function(callback) {
             assert.ok(!err);
 
             // Mock a global admin request context so we can create a proper global administrator in the system
-            var globalTenant = TenantsAPI.getTenant('admin');
-            var globalUser = new User(globalTenant.alias, 'u:admin:admin', 'Global Administrator', {
-                'visibility': 'admin',
-                'isGlobalAdmin': true
-            });
-            var globalContext = new Context(globalTenant, globalUser);
+            var globalContext = createGlobalAdminContext();
 
             // Create the global admin user if they don't exist yet with the username "administrator"
-            AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', null, function(err) {
+            var opts = {
+                'email': generateTestEmailAddress()
+            };
+            AuthenticationAPI.getOrCreateGlobalAdminUser(globalContext, 'administrator', 'administrator', 'Global Administrator', opts, function(err) {
                 assert.ok(!err);
 
                 // Re-create the tenant administrators
@@ -220,14 +219,11 @@ var _setUpTenantAdmins = function(callback) {
  */
 var _setupTenantAdmin = function(tenant, callback) {
     var adminLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, 'administrator', { 'password': 'administrator' });
-    var mockUserId = 'u:' + tenant.alias + ':admin';
-    var adminUser = new User(tenant.alias, mockUserId, 'The admin User', {
-        'isGlobalAdmin': false,
-        'isTenantAdmin': true
-    });
+    var displayName = generateRandomText(2);
+    var email = generateTestEmailAddress();
 
-    var ctx = new Context(tenant, adminUser);
-    AuthenticationAPI.createUser(ctx, adminLoginId, adminUser.displayName, null, function(err, createdUser) {
+    var ctx = createTenantAdminContext(tenant);
+    AuthenticationAPI.createUser(ctx, adminLoginId, displayName, {'email': email}, function(err, createdUser) {
         assert.ok(!err);
 
         return PrincipalsAPI.setTenantAdmin(ctx, createdUser.id, true, callback);
@@ -270,23 +266,28 @@ var generateTestUsers = module.exports.generateTestUsers = function(restCtx, tot
         var username = generateTestUserId('random-user');
         var displayName = generateTestGroupId('random-user');
         var email = generateTestEmailAddress(username);
-        RestAPI.User.createUser(restCtx, username, 'password', displayName, {'email': email}, function(err, user) {
+        RestAPI.User.createUser(restCtx, username, 'password', displayName, email, {}, function(err, user) {
             if (err) {
                 return callback(err);
             }
 
-            _createdUsers.push({
-                'user': user,
-                'restContext': new RestContext(restCtx.host, {
-                    'hostHeader': restCtx.hostHeader,
-                    'username': username,
-                    'userPassword': 'password',
-                    'strictSSL': restCtx.strictSSL
-                })
-            });
+            // Manually verify the user their email address
+            PrincipalsDAO.setEmailAddress(user, email.toLowerCase(), function(err, user) {
+                assert.ok(!err);
 
-            // Recursively continue creating users
-            return generateTestUsers(restCtx, --total, callback, _createdUsers);
+                _createdUsers.push({
+                    'user': user,
+                    'restContext': new RestContext(restCtx.host, {
+                        'hostHeader': restCtx.hostHeader,
+                        'username': username,
+                        'userPassword': 'password',
+                        'strictSSL': restCtx.strictSSL
+                    })
+                });
+
+                // Recursively continue creating users
+                return generateTestUsers(restCtx, --total, callback, _createdUsers);
+            });
         });
     });
 };
@@ -342,32 +343,40 @@ var createTenantWithAdmin = module.exports.createTenantWithAdmin = function(tena
             return callback(err);
         }
 
-        // Disable recaptcha so we can create a user
+        // Disable reCaptcha so we can create a user
         ConfigTestUtil.updateConfigAndWait(adminCtx, tenantAlias, {'oae-principals/recaptcha/enabled': false}, function(err) {
             if (err) {
                 return callback(err);
             }
 
-            // Create the user and make them admin
+            // Create the user and make them a tenant administrator
             var anonymousCtx = createTenantRestContext(tenantHost);
-            RestAPI.User.createUser(anonymousCtx, 'administrator', 'administrator', 'Tenant Administrator', null, function(err, tenantAdmin) {
+            var email = generateTestEmailAddress('administrator');
+            RestAPI.User.createUser(anonymousCtx, 'administrator', 'administrator', 'Tenant Administrator', email, null, function(err, tenantAdmin) {
                 if (err) {
                     return callback(err);
                 }
 
-                RestAPI.User.setTenantAdmin(adminCtx, tenantAdmin.id, true, function(err) {
+                // Verify their email address
+                PrincipalsDAO.setEmailAddress(tenantAdmin, email, function(err, tenantAdmin) {
                     if (err) {
                         return callback(err);
                     }
 
-                    // Re-enable captcha
-                    var tenantAdminRestCtx = createTenantAdminRestContext(tenantHost);
-                    ConfigTestUtil.updateConfigAndWait(tenantAdminRestCtx, null, {'oae-principals/recaptcha/enabled': true}, function(err) {
+                    RestAPI.User.setTenantAdmin(adminCtx, tenantAdmin.id, true, function(err) {
                         if (err) {
                             return callback(err);
                         }
 
-                        return callback(null, tenant, tenantAdminRestCtx, tenantAdmin);
+                        // Re-enable reCaptcha
+                        var tenantAdminRestCtx = createTenantAdminRestContext(tenantHost);
+                        ConfigTestUtil.updateConfigAndWait(tenantAdminRestCtx, null, {'oae-principals/recaptcha/enabled': true}, function(err) {
+                            if (err) {
+                                return callback(err);
+                            }
+
+                            return callback(null, tenant, tenantAdminRestCtx, tenantAdmin);
+                        });
                     });
                 });
             });
@@ -516,7 +525,8 @@ var createGlobalAdminRestContext = module.exports.createGlobalAdminRestContext =
  * @return {Context}           The api context that represents an administrator of the tenant
  */
 var createTenantAdminContext = module.exports.createTenantAdminContext = function(tenant) {
-    return new Context(tenant, new User(tenant.alias, 'u:' + tenant.alias + ':admin', 'Tenant Administrator', {'isTenantAdmin': true}));
+    var email = util.format('tenant-admin-%s', tenant.alias);
+    return new Context(tenant, new User(tenant.alias, 'u:' + tenant.alias + ':admin', 'Tenant Administrator', email, {'isTenantAdmin': true}));
 };
 
 /**
@@ -526,7 +536,12 @@ var createTenantAdminContext = module.exports.createTenantAdminContext = functio
  */
 var createGlobalAdminContext = module.exports.createGlobalAdminContext = function() {
     var globalTenant = global.oaeTests.tenants.global;
-    return new Context(globalTenant, new User(globalTenant.alias, 'u:' + globalTenant.alias + ':admin', 'Global Administrator', {'isGlobalAdmin': true}));
+    var globalAdminId = 'u:' + globalTenant.alias + ':admin';
+    var globalUser = new User(globalTenant.alias, globalAdminId, 'Global Administrator', 'admin@example.com', {
+        'visibility': 'private',
+        'isGlobalAdmin': true
+    });
+    return new Context(globalTenant, globalUser);
 };
 
 /**
@@ -819,7 +834,8 @@ var _createUserWithVisibility = function(restCtx, visibility, callback) {
     var password = 'password-' + randomId;
     var displayName = 'displayName-' + randomId;
     var publicAlias = 'publicAlias-' + randomId;
-    RestAPI.User.createUser(restCtx, username, password, displayName, {'visibility': visibility, 'publicAlias': publicAlias}, function(err, user) {
+    var email = generateTestEmailAddress();
+    RestAPI.User.createUser(restCtx, username, password, displayName, email, {'visibility': visibility, 'publicAlias': publicAlias}, function(err, user) {
         assert.ok(!err);
         return callback({'user': user, 'restContext': createTenantRestContext(restCtx.hostHeader, username, password)});
     });

--- a/node_modules/oae-tests/runner/beforeTests.js
+++ b/node_modules/oae-tests/runner/beforeTests.js
@@ -51,6 +51,14 @@ beforeEach(function(callback) {
 });
 
 afterEach(function(callback) {
+    var nock = require('nock');
+
+    // Ensure we don't mess with the HTTP stack by accident
+    nock.enableNetConnect();
+
+    // Clean up all the mocks
+    nock.cleanAll();
+
     log().info('Finishing test "%s"', this.currentTest.title);
     return callback();
 });

--- a/node_modules/oae-ui/lib/api.js
+++ b/node_modules/oae-ui/lib/api.js
@@ -926,15 +926,16 @@ var _cacheBundleFile = function(bundlePath, callback) {
 /**
  * Renders and translates a template
  *
- * @param  {String}     template    The template to render
- * @param  {Object}     data        The data that should be passed into the template renderer
- * @param  {String}     locale      The locale that should be used to translate any i18n keys. Defaults to `en_US` if none is provided
- * @return {String}                 The rendered and translated template
+ * @param  {String|Function}    template    The template to render. String-templates will be compiled through `compileTemplate`, function-templates are expected to have run through `compileTemplate` earlier
+ * @param  {Object}             data        The data that should be passed into the template renderer
+ * @param  {String}             locale      The locale that should be used to translate any i18n keys. Defaults to `en_US` if none is provided
+ * @return {String}                         The rendered and translated template
  */
 var renderTemplate = module.exports.renderTemplate = function(template, data, locale) {
     data = data || {};
     locale = locale || 'en_US';
 
+    // Pass in some utility functions
     data.util = {
         'html': {
             /*!
@@ -1125,13 +1126,72 @@ var renderTemplate = module.exports.renderTemplate = function(template, data, lo
              *
              * @see http://nodejs.org/docs/latest/api/url.html#url_url_parse_urlstr_parsequerystring_slashesdenotehost
              */
-            'parse': url.parse
+            'parse': url.parse,
+
+            /**
+             * Escape all characters except the following: alphabetic, decimal digits, - _ . ! ~ * ' ( )
+             *
+             * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+             */
+            'encode': encodeURIComponent,
+
+            /**
+             * Ensure that a link is an absolute URL. If a relative link is
+             * passed in, it will be prefixed with the base url.
+             *
+             * @param  {String}     link        The link to check
+             * @param  {String}     baseUrl     The base url that can be used to prefix relative urls
+             * @return {String}                 The absolute link prefixed with the base url
+             */
+            'ensureAbsoluteLink': function(link, baseUrl) {
+                // If the link is empty or null, we return the empty string. This can happen when
+                // we try to link a private user (private users are scrubbed and have no profile path)
+                if (!link) {
+                    return '';
+
+                // If the link already has `http` in it (e.g., twitter profile pics) we return as-is
+                } else if (link.indexOf('http') === 0) {
+                    return link;
+
+                // Otherwise we prefix it with the base url
+                } else {
+                    return baseUrl + link;
+                }
+            },
+
+            /**
+             * Ensure that each link in an HTML fragment is an abolute url, If a relative link is
+             * found, it will be prefixed with the base url.
+             *
+             * @param  {String}     str         The html string in which to check for absolute links
+             * @param  {String}     baseUrl     The base url that can be used to prefix relative urls
+             * @return {String}                 The html in which each link is absolute
+             */
+            'ensureAbsoluteLinks': function(str, baseUrl) {
+                var html = $('<div>' + str + '</div>');
+                html.find('a').each(function(i, elem) {
+                    var link = $(this).attr('href');
+                    link = data.util.url.ensureAbsoluteLink(link, baseUrl);
+                    $(this).attr('href', link);
+                });
+                return html.html();
+            }
         }
     };
 
     // Parse and process it with Underscore
     try {
-        var compiledTemplate = _.template(template);
+        var compiledTemplate = null;
+        if (_.isString(template)) {
+            compiledTemplate = compileTemplate(template);
+        } else if (_.isFunction(template)) {
+            compiledTemplate = template;
+        } else {
+            log().error('A malformed template was passed in');
+            return '';
+        }
+
+        // Render the template
         var renderedTemplate = compiledTemplate(data);
 
         // Remove HTML comments
@@ -1146,6 +1206,28 @@ var renderTemplate = module.exports.renderTemplate = function(template, data, lo
         log().error({'err': err}, 'Unable to render template');
         return '';
     }
+};
+
+/**
+ * Compile a template to a function. This function allows you to compile a template, cache it and
+ * render it multiple times. This is useful when you're often rendering the same template(s).
+ *
+ * @param  {String}     template    The template to compile
+ * @return {Function}               The compiled template
+ */
+var compileTemplate = module.exports.compileTemplate = function(template) {
+    // Support <% include path/to/other/template.jst %>
+    template = template.replace(/<%\s*include\s*(.*?)\s*%>/g, function(match, path) {
+        if (fs.existsSync(path)) {
+            return fs.readFileSync(path, 'utf8');
+        } else {
+            log().warn({'path': path}, 'Could not find an underscore template');
+            return '';
+        }
+    });
+
+    // Compile the template
+    return _.template(template);
 };
 
 

--- a/node_modules/oae-util/tests/test-validator.js
+++ b/node_modules/oae-util/tests/test-validator.js
@@ -241,9 +241,9 @@ describe('Utilities', function() {
             // Invalid tenant
             var tenant2 = new Tenant(null, 'Invalid tenant', 2002);
             // Valid users
-            var user1 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'public', 'Nicolaas', 'Matthijs', 'Nicolaas Matthijs');
-            var user2 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'private', 'Nicolaas', 'Matthijs', 'Nicolaas Matthijs');
-            var user3 = new User(tenant1.alias, 'u:camtest:nm417', null, null, null, null, null);
+            var user1 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
+            var user2 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
+            var user3 = new User(tenant1.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
 
             ////////////////////////////
             // Single test successful //
@@ -324,7 +324,7 @@ describe('Utilities', function() {
             var gtTenant = global.oaeTests.tenants.gt;
 
             // Test user
-            var user1 = new User(camTenant.alias, 'u:camtest:nm417', 'nm417', 'public', 'Nicolaas', 'Matthijs', 'Nicolaas Matthijs');
+            var user1 = new User(camTenant.alias, 'u:camtest:nm417', 'nm417', 'nm417@example.com');
 
             // Ensure it gives a validation error when not authenticated
             var validator = new Validator();


### PR DESCRIPTION
Makes it so that when users add / update an email address manually (i.e., it isn't provided by an external authentication source), users must verify the email VIA an email that is sent to them.

Depends on:
 - https://github.com/oaeproject/3akai-ux/pull/4031
 - https://github.com/oaeproject/oae-rest/pull/15