### PR TITLE
Pull passport-cas from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "oauth2orize": "latest",
     "optimist": "latest",
     "passport": "latest",
-    "passport-cas": "git://github.com/oaeproject/passport-cas#samlValidateLoginUrl",
+    "passport-cas": "0.1.0",
     "passport-facebook": "git://github.com/oaeproject/passport-facebook",
     "passport-google-oauth": "latest",
     "passport-http": "latest",


### PR DESCRIPTION
The SAML validation PR has been merged and published to npm so we can just pull it from there. As we don't really test CAS much in QA prior to releases, we should probably just bind to the fixed version?