### PR TITLE
Split email from configuration into 2 separate fields

### DIFF
--- a/node_modules/oae-config/tests/test-config.js
+++ b/node_modules/oae-config/tests/test-config.js
@@ -69,7 +69,8 @@ describe('Configuration', function() {
             'oae-authentication/twitter/enabled',
             'oae-content/storage/amazons3-access-key',
             'oae-content/storage/backend',
-            'oae-email/general/from',
+            'oae-email/general/fromAddress',
+            'oae-email/general/fromName',
             'oae-google-analytics/google-analytics/globalEnabled',
             'oae-principals/group/visibility',
             'oae-principals/recaptcha/privateKey',
@@ -80,7 +81,8 @@ describe('Configuration', function() {
         // An array of values to clear on the tenant admin
         var tenantClearValues = [
             'oae-authentication/twitter/enabled',
-            'oae-email/general/from',
+            'oae-email/general/fromAddress',
+            'oae-email/general/fromName',
             'oae-principals/group/visibility',
             'oae-principals/recaptcha/publicKey',
             'oae-principals/termsAndConditions/text'
@@ -175,7 +177,7 @@ describe('Configuration', function() {
         it('verify defaultValue always returns', function(callback) {
             RestAPI.Config.getSchema(globalAdminRestContext, function(err, schema) {
                 assert.ok(!err);
-                assert.equal(schema['oae-email']['general'].elements['from'].defaultValue, '');
+                assert.equal(schema['oae-email']['general'].elements['fromAddress'].defaultValue, '');
                 return callback();
             });
         });
@@ -805,20 +807,20 @@ describe('Configuration', function() {
                                                     assert.ok(config);
 
                                                     // Change the value to '1' and ensure it isn't coerced to a boolean
-                                                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.cam.alias, {'oae-email/general/from': '1'}, function(err) {
+                                                    ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.cam.alias, {'oae-email/general/fromName': '1'}, function(err) {
                                                         assert.ok(!err);
                                                         RestAPI.Config.getTenantConfig(globalAdminRestContext, global.oaeTests.tenants.cam.alias, function(err, config) {
                                                             assert.ok(!err);
                                                             assert.ok(config);
-                                                            assert.strictEqual(config['oae-email']['general']['from'], '1');
+                                                            assert.strictEqual(config['oae-email']['general']['fromName'], '1');
 
                                                             // Change the value to '0' and ensure it isn't coerced to a boolean
-                                                            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.cam.alias, {'oae-email/general/from': '0'}, function(err) {
+                                                            ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, global.oaeTests.tenants.cam.alias, {'oae-email/general/fromName': '0'}, function(err) {
                                                                 assert.ok(!err);
                                                                 RestAPI.Config.getTenantConfig(globalAdminRestContext, global.oaeTests.tenants.cam.alias, function(err, config) {
                                                                     assert.ok(!err);
                                                                     assert.ok(config);
-                                                                    assert.strictEqual(config['oae-email']['general']['from'], '0');
+                                                                    assert.strictEqual(config['oae-email']['general']['fromName'], '0');
 
                                                                     return callback();
                                                                 });

--- a/node_modules/oae-email/config/email.js
+++ b/node_modules/oae-email/config/email.js
@@ -21,7 +21,8 @@ module.exports = {
         'name': 'General',
         'description': 'General e-mail configuration',
         'elements': {
-            'from': new Fields.Text('From', 'The "From" header for emails sent by the system. e.g., "Apereo OAE" <noreply@myorganization>')
+            'fromName': new Fields.Text('Sender Name', 'The name that will appear in the "From" header for emails sent by the system. e.g., "Apereo OAE"'),
+            'fromAddress': new Fields.Text('Sender Address', 'The address that will appear in the "From" header for emails sent by the system. e.g., "noreply@example.com"')
         }
     }
 };

--- a/node_modules/oae-email/lib/api.js
+++ b/node_modules/oae-email/lib/api.js
@@ -362,7 +362,9 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
 
     // If the `from` header is not set, we generate an intelligent `from` header based on the tenant host
     var tenant = TenantsAPI.getTenant(toUser.tenant.alias);
-    var from = EmailConfig.getValue(tenant.alias, 'general', 'from') || util.format('"Apereo OAE" <noreply@%s>', tenant.host);
+    var fromName = EmailConfig.getValue(tenant.alias, 'general', 'fromName') || 'Apereo OAE';
+    var fromAddr = EmailConfig.getValue(tenant.alias, 'general', 'fromAddress') || util.format('noreply@%s', tenant.host);
+    var from = util.format('"%s" <%s>', fromName, fromAddr);
 
     // Build the email object that will be sent through nodemailer. The 'from' property can be overridden by
     // the meta.json, then we further override that with some hard values

--- a/node_modules/oae-email/tests/test-email.js
+++ b/node_modules/oae-email/tests/test-email.js
@@ -397,7 +397,7 @@ describe('Emails', function() {
                 assert.ok(!err);
 
                 // Set the `from` header for the email module
-                ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-email/general/from': 'noreply@blahblahblah.com'}, function(err) {
+                ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-email/general/fromAddress': 'noreply@blahblahblah.com'}, function(err) {
                     assert.ok(!err);
 
                     // Create a new link with the coenego user. The simong user will receive an email
@@ -410,10 +410,11 @@ describe('Emails', function() {
                             assert.ok(messages);
                             assert.ok(!_.isEmpty(messages));
                             assert.strictEqual(messages[0].to[0].address, simong.user.email);
+                            assert.equal(messages[0].from[0].name, 'Apereo OAE');
                             assert.strictEqual(messages[0].from[0].address, 'noreply@blahblahblah.com');
 
                             // Clear the `from` header configuration in the email module. This allows the application to compose a tenant based `from` header
-                            RestAPI.Config.clearConfig(camAdminRestContext, null, ['oae-email/general/from'], function(err) {
+                            RestAPI.Config.clearConfig(camAdminRestContext, null, ['oae-email/general/fromAddress'], function(err) {
                                 assert.ok(!err);
 
                                 // Create a comment with the simong user. The coenego user will receive an email
@@ -421,14 +422,35 @@ describe('Emails', function() {
                                     assert.ok(!err);
                                     assert.ok(comment);
 
-                                    // Assert that coenego receives an email with `"camtest" <noreply@cambridge.oae.com>` as the composed `from` header
+                                    // Assert that coenego receives an email with `"Apereo OAE" <noreply@cambridge.oae.com>` as the composed `from` header
                                     EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
                                         assert.ok(messages);
                                         assert.ok(messages.length);
                                         assert.strictEqual(messages[0].to[0].address, coenego.user.email);
                                         assert.equal(messages[0].from[0].name, 'Apereo OAE');
                                         assert.equal(messages[0].from[0].address, util.format('noreply@%s', coenego.restContext.hostHeader));
-                                        return callback();
+
+                                        // Set the `from` name
+                                        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-email/general/fromName': 'Cambridge Test OAE'}, function(err) {
+                                            assert.ok(!err);
+
+                                            // Create a comment with the simong user. The coenego user will receive an email
+                                            RestAPI.Content.createComment(simong.restContext, link.id, 'I am going to share this with all my friends!', null, function(err, comment) {
+                                                assert.ok(!err);
+                                                assert.ok(comment);
+
+                                                // Assert that coenego receives an email with `"Cambridge Test OAE" <noreply@cambridge.oae.com>`
+                                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                    assert.ok(messages);
+                                                    assert.ok(messages.length);
+                                                    assert.strictEqual(messages[0].to[0].address, coenego.user.email);
+                                                    assert.equal(messages[0].from[0].name, 'Cambridge Test OAE');
+                                                    assert.equal(messages[0].from[0].address, util.format('noreply@%s', coenego.restContext.hostHeader));
+
+                                                    return callback();
+                                                });
+                                            });
+                                        });
                                     });
                                 });
                             });


### PR DESCRIPTION
The email from configuration is currently a single field in the form of `Apereo OAE <noreply@research.unity.ac>`. This should be split into 2 separate config fields:

- Sender Name: this should default to the name of the tenant
- Sender Address: this should default to `noreply@<tenantdomain>`