### PR TITLE
Email from should default to tenant displayname

### DIFF
--- a/node_modules/oae-email/lib/api.js
+++ b/node_modules/oae-email/lib/api.js
@@ -362,7 +362,7 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
 
     // If the `from` headers aren't set, we generate an intelligent `from` header based on the tenant host
     var tenant = TenantsAPI.getTenant(toUser.tenant.alias);
-    var fromName = EmailConfig.getValue(tenant.alias, 'general', 'fromName') || 'Apereo OAE';
+    var fromName = EmailConfig.getValue(tenant.alias, 'general', 'fromName') || tenant.displayName;
     var fromAddr = EmailConfig.getValue(tenant.alias, 'general', 'fromAddress') || util.format('noreply@%s', tenant.host);
     var from = util.format('"%s" <%s>', fromName, fromAddr);
 

--- a/node_modules/oae-email/tests/test-email.js
+++ b/node_modules/oae-email/tests/test-email.js
@@ -246,7 +246,7 @@ describe('Emails', function() {
                 EmailTestsUtil.sendEmail('oae-email', 'test_html_only', mrvisser.user, null, null, function(err, message) {
                     assert.ok(!err);
 
-                    assert.equal(message.from[0].name, 'Apereo OAE');
+                    assert.equal(message.from[0].name, 'Cambridge University Test');
                     assert.equal(message.from[0].address, util.format('noreply@%s', mrvisser.restContext.hostHeader));
                     assert.equal(message.subject, 'test html only');
                     assert.equal(message.to[0].address, mrvisser.user.email);
@@ -257,7 +257,7 @@ describe('Emails', function() {
                     EmailTestsUtil.sendEmail('oae-email', 'test_txt_only', mrvisser.user, null, null, function(err, message) {
                         assert.ok(!err);
 
-                        assert.equal(message.from[0].name, 'Apereo OAE');
+                        assert.equal(message.from[0].name, 'Cambridge University Test');
                         assert.equal(message.from[0].address, util.format('noreply@%s', mrvisser.restContext.hostHeader));
                         assert.equal(message.subject, 'test txt only');
                         assert.equal(message.to[0].address, mrvisser.user.email);
@@ -268,7 +268,7 @@ describe('Emails', function() {
                         EmailTestsUtil.sendEmail('oae-email', 'test_html_and_txt', mrvisser.user, null, null, function(err, message) {
                             assert.ok(!err);
 
-                            assert.equal(message.from[0].name, 'Apereo OAE');
+                            assert.equal(message.from[0].name, 'Cambridge University Test');
                             assert.equal(message.from[0].address, util.format('noreply@%s', mrvisser.restContext.hostHeader));
                             assert.equal(message.subject, 'test html and txt');
                             assert.equal(message.to[0].address, mrvisser.user.email);
@@ -410,7 +410,7 @@ describe('Emails', function() {
                             assert.ok(messages);
                             assert.ok(!_.isEmpty(messages));
                             assert.strictEqual(messages[0].to[0].address, simong.user.email);
-                            assert.equal(messages[0].from[0].name, 'Apereo OAE');
+                            assert.equal(messages[0].from[0].name, 'Cambridge University Test');
                             assert.strictEqual(messages[0].from[0].address, 'noreply@blahblahblah.com');
 
                             // Clear the `from` header configuration in the email module. This allows the application to compose a tenant based `from` header
@@ -427,7 +427,7 @@ describe('Emails', function() {
                                         assert.ok(messages);
                                         assert.ok(messages.length);
                                         assert.strictEqual(messages[0].to[0].address, coenego.user.email);
-                                        assert.equal(messages[0].from[0].name, 'Apereo OAE');
+                                        assert.equal(messages[0].from[0].name, 'Cambridge University Test');
                                         assert.equal(messages[0].from[0].address, util.format('noreply@%s', coenego.restContext.hostHeader));
 
                                         // Set the `from` name

--- a/node_modules/oae-email/tests/test-email.js
+++ b/node_modules/oae-email/tests/test-email.js
@@ -422,7 +422,7 @@ describe('Emails', function() {
                                     assert.ok(!err);
                                     assert.ok(comment);
 
-                                    // Assert that coenego receives an email with `"Apereo OAE" <noreply@cambridge.oae.com>` as the composed `from` header
+                                    // Assert that coenego receives an email with `"Cambridge University Test" <noreply@cambridge.oae.com>` as the composed `from` header
                                     EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
                                         assert.ok(messages);
                                         assert.ok(messages.length);


### PR DESCRIPTION
Follow up for https://github.com/oaeproject/Hilary/pull/1206/files.
The "Email from" currently defaults to Apereo OAE. However, it should default to the tenant displayname instead