### PR TITLE
Trim all form field values in requests

### DIFF
--- a/node_modules/oae-principals/lib/api.user.js
+++ b/node_modules/oae-principals/lib/api.user.js
@@ -444,7 +444,7 @@ var updateUser = module.exports.updateUser = function(ctx, userId, profileFields
     var invalidKeys = _.intersection(PrincipalsDAO.getRestrictedFields(), profileFieldKeys);
     validator.check(invalidKeys.length, {'code': 400, 'msg': 'Restricted property was attempted to be set.'}).max(0);
 
-    if (profileFields['displayName']) {
+    if (_.contains(profileFieldKeys, 'displayName')) {
         validator.check(profileFields['displayName'], {'code': 400, 'msg': 'A display name cannot be empty'}).notEmpty();
         validator.check(profileFields['displayName'], {'code': 400, 'msg': 'A display name can be at most 1000 characters long'}).isShortString();
     }

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -1949,7 +1949,7 @@ describe('Users', function() {
                                             // Create user with an empty displayName
                                             RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'displayName': '\n'}, function(err) {
                                                 assert.ok(err);
-                                                assert.equal(err.code, 401);
+                                                assert.equal(err.code, 400);
 
                                                 // Verify an incorrect visibility is invalid
                                                 RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'visibility': 'so incorrect'}, function(err) {

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -1336,7 +1336,7 @@ describe('Users', function() {
                                 assert.strictEqual(meData.tenant.displayName, privateTenant1.tenant.displayName);
                                 assert.strictEqual(meData.tenant.alias, privateTenant1.tenant.alias);
                                 assert.strictEqual(meData.tenant.isPrivate, true);
-                        
+
                                 return callback();
                             });
                         });
@@ -1949,7 +1949,7 @@ describe('Users', function() {
                                             // Create user with an empty displayName
                                             RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'displayName': '\n'}, function(err) {
                                                 assert.ok(err);
-                                                assert.equal(err.code, 400);
+                                                assert.equal(err.code, 401);
 
                                                 // Verify an incorrect visibility is invalid
                                                 RestAPI.User.updateUser(updateUserRestContext, userObj.id, {'visibility': 'so incorrect'}, function(err) {

--- a/node_modules/oae-util/lib/server.js
+++ b/node_modules/oae-util/lib/server.js
@@ -86,6 +86,16 @@ var setupServer = module.exports.setupServer = function(port, _config) {
         return next();
     });
 
+    // Trim whitespace on all post parameters
+    app.use(function(req, res, next) {
+        _.each(req.body, function(value, key) {
+            if (_.isString(value)){
+                req.body[key] = value.trim();
+            }
+        });
+        return next();
+    });
+
     return app;
 };
 


### PR DESCRIPTION
There are some bizarre characters in an import we've done: Tabs, trailing whitespace weirdly enough `\u000b`. These characters should be erradicated in the APIs when the tenant is created or updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oaeproject/hilary/1205)
<!-- Reviewable:end -->
