### PR TITLE
Activity summary emails are sent to deleted users

### DIFF
--- a/node_modules/oae-activity/lib/internal/email.js
+++ b/node_modules/oae-activity/lib/internal/email.js
@@ -91,7 +91,7 @@ ActivityEmitter.on(ActivityConstants.events.DELIVERED_ACTIVITIES, function(deliv
     scheduledEmailsCounter.incr();
 
     // We need to know the email preferences for each user so we know whether and when to send them an e-mail
-    PrincipalsDAO.getPrincipals(usersToMail, ['principalId', 'tenantAlias', 'email', 'emailPreference'], function(err, users) {
+    PrincipalsDAO.getPrincipals(usersToMail, ['principalId', 'tenantAlias', 'email', 'emailPreference', 'deleted'], function(err, users) {
         if (err) {
             scheduledEmailsCounter.decr();
             return log().error({'err': err, 'usersToMail': usersToMail}, 'Failed to get the email preference field for all the users in this activity');
@@ -99,7 +99,7 @@ ActivityEmitter.on(ActivityConstants.events.DELIVERED_ACTIVITIES, function(deliv
 
         var usersToQueue = _.filter(users, function(user) {
             // Users without a valid email address or who've opted out of email notifications should not get emails
-            return (user.email && user.emailPreference !== PrincipalsConstants.emailPreferences.NEVER);
+            return (!user.deleted && user.email && user.emailPreference !== PrincipalsConstants.emailPreferences.NEVER);
         });
 
         var emailBuckets = {};

--- a/node_modules/oae-activity/lib/internal/email.js
+++ b/node_modules/oae-activity/lib/internal/email.js
@@ -97,8 +97,8 @@ ActivityEmitter.on(ActivityConstants.events.DELIVERED_ACTIVITIES, function(deliv
             return log().error({'err': err, 'usersToMail': usersToMail}, 'Failed to get the email preference field for all the users in this activity');
         }
 
+        // Filter out users who should not get emails
         var usersToQueue = _.filter(users, function(user) {
-            // Users without a valid email address or who've opted out of email notifications should not get emails
             return (!user.deleted && user.email && user.emailPreference !== PrincipalsConstants.emailPreferences.NEVER);
         });
 

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -883,7 +883,22 @@ describe('Activity Email', function() {
                                 // ensuring no emails actually get delivered
                                 EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
                                     assert.strictEqual(messages.length, 0);
-                                    return callback();
+
+                                    // Restore mrvisser
+                                    PrincipalsTestUtil.assertRestoreUserSucceeds(camAdminRestContext, mrvisser.user.id, function() {
+
+                                        // Simong will trigger another activity, annoying-sauce
+                                        RestAPI.Content.createLink(simong.restContext, 'Google', 'Awesome Google', 'public', 'http://www.google.ca', [mrvisser.user.id], [], [], function(err, link) {
+                                            assert.ok(!err);
+
+                                            // Collect and ensure mrvisser now gets the email for the latest activity
+                                            EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
+                                                assert.strictEqual(messages.length, 1);
+                                                assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
+                                                return callback();
+                                            });
+                                        });
+                                    });
                                 });
                             });
                         });

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -869,7 +869,7 @@ describe('Activity Email', function() {
                 assert.ok(!err);
 
                 // Generate an email activity for mrvisser
-                RestAPI.Content.createLink(simong.restContext, 'Google', 'Awesome Google', 'public', 'http://www.google.ca', [mrvisser.user.id], [], [], function(err, link) {
+                RestAPI.Content.createLink(simong.restContext, 'Google First', 'Awesome Google', 'public', 'http://www.google.ca/firstlink', [mrvisser.user.id], [], [], function(err, link) {
                     assert.ok(!err);
 
                     // Ensure activities and notifications get delivered to mrvisser
@@ -888,13 +888,18 @@ describe('Activity Email', function() {
                                     PrincipalsTestUtil.assertRestoreUserSucceeds(camAdminRestContext, mrvisser.user.id, function() {
 
                                         // Simong will trigger another activity, annoying-sauce
-                                        RestAPI.Content.createLink(simong.restContext, 'Google', 'Awesome Google', 'public', 'http://www.google.ca', [mrvisser.user.id], [], [], function(err, link) {
+                                        RestAPI.Content.createLink(simong.restContext, 'Google Second', 'Awesome Google', 'public', 'http://www.google.ca/secondlink', [mrvisser.user.id], [], [], function(err, link) {
                                             assert.ok(!err);
 
                                             // Collect and ensure mrvisser now gets the email for the latest activity
                                             EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
                                                 assert.strictEqual(messages.length, 1);
                                                 assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
+
+                                                // Since the second link will aggregate with the first in the feed, we'll now have an email
+                                                // that contains both links that were created aggregated together
+                                                assert.notEqual(messages[0].html.indexOf('Google First'), -1);
+                                                assert.notEqual(messages[0].html.indexOf('Google Second'), -1);
                                                 return callback();
                                             });
                                         });

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -879,10 +879,10 @@ describe('Activity Email', function() {
                             // Delete mrvisser now with pending emails in their notifications feed
                             PrincipalsTestUtil.assertDeleteUserSucceeds(camAdminRestContext, camAdminRestContext, mrvisser.user.id, function() {
 
-                                // Deliver the activity and collect all emails associated to it
+                                // Deliver the activity and collect all emails associated to it,
+                                // ensuring no emails actually get delivered
                                 EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
                                     assert.strictEqual(messages.length, 0);
-                                    //console.log(JSON.stringify(messages, null, 2));
                                     return callback();
                                 });
                             });

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -22,6 +22,7 @@ var util = require('util');
 var AuthzUtil = require('oae-authz/lib/util');
 var ConfigTestUtil = require('oae-config/lib/test/util');
 var EmailTestUtil = require('oae-email/lib/test/util');
+var MqTestUtil = require('oae-util/lib/test/mq-util');
 var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var RestContext = require('oae-rest/lib/model').RestContext;
@@ -34,6 +35,7 @@ var ActivityAPI = require('oae-activity');
 var ActivityConstants = require('oae-activity/lib/constants').ActivityConstants;
 var ActivityDAO = require('oae-activity/lib/internal/dao');
 var ActivityEmail = require('oae-activity/lib/internal/email');
+var ActivityNotifications = require('oae-activity/lib/internal/notifications');
 var ActivitySystemConfig = require('oae-activity/lib/internal/config');
 var ActivityTestUtil = require('oae-activity/lib/test/util');
 var ActivityUtil = require('oae-activity/lib/util');
@@ -853,6 +855,44 @@ describe('Activity Email', function() {
             });
         });
     });
+
+    /**
+     * Test that verifies that activity emails are not delivered to users who have deleted their
+     * profiles
+     */
+    it('verify email is not delivered to users who have since deleted their profile', function(callback) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
+            assert.ok(!err);
+
+            // Set the appropriate email preference for mrvisser
+            RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, {'emailPreference': 'immediate'}, function(err) {
+                assert.ok(!err);
+
+                // Generate an email activity for mrvisser
+                RestAPI.Content.createLink(simong.restContext, 'Google', 'Awesome Google', 'public', 'http://www.google.ca', [mrvisser.user.id], [], [], function(err, link) {
+                    assert.ok(!err);
+
+                    // Ensure activities and notifications get delivered to mrvisser
+                    MqTestUtil.whenTasksEmpty(ActivityConstants.mq.TASK_ACTIVITY, function() {
+                        ActivityNotifications.whenNotificationsEmpty(function() {
+
+                            // Delete mrvisser now with pending emails in their notifications feed
+                            PrincipalsTestUtil.assertDeleteUserSucceeds(camAdminRestContext, camAdminRestContext, mrvisser.user.id, function() {
+
+                                // Deliver the activity and collect all emails associated to it
+                                EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
+                                    assert.strictEqual(messages.length, 0);
+                                    //console.log(JSON.stringify(messages, null, 2));
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
 
     /**
      * Test that verifies that old activities are not included in an immediate email when they are not situated in the email interval


### PR DESCRIPTION
The example I have observed is from a user on the *Unity implementation, the user was deleted on 13th July however they were still sent a weekly summary email on 17th July.

I can provide further details of the case but do not believe there to be anything unusual about this account, Therefore I believe this to be a general issue.