### PR TITLE
Tenant list should be paged and searchable

### DIFF
--- a/node_modules/oae-search/lib/rest.js
+++ b/node_modules/oae-search/lib/rest.js
@@ -16,6 +16,8 @@ var _ = require('underscore');
 var util = require('util');
 
 var OAE = require('oae-util/lib/oae');
+var OaeUtil = require('oae-util/lib/util');
+var TenantsAPI = require('oae-tenants/lib/api');
 
 var SearchAPI = require('oae-search');
 var SearchUtil = require('oae-search/lib/util');
@@ -44,6 +46,32 @@ OAE.globalAdminRouter.on('post', '/api/search/reindexAll', function(req, res) {
         return res.send(200);
     });
 });
+
+/**
+ * @REST getSearchTenants
+ *
+ * Search through tenants in the system
+ *
+ * @Server      admin,tenant
+ * @Method      GET
+ * @Path        /search/tenants
+ * @QueryParam  {number}                [limit]             The maximum number of search results to return. Defaults to returning all matching tenants
+ * @QueryParam  {string}                [q]                 The search query. Defaults to returning all tenants
+ * @QueryParam  {number}                [start]             The document index from which to start. Defaults to 0
+ * @Return      {SearchResponse}                            The retrieved search results
+ * @HttpResponse                        200                 Search results available
+ */
+var _handleSearchTenants = function(req, res) {
+    var q = req.query.q;
+    var opts = _.pick(req.query, 'start', 'limit', 'disabled');
+
+    opts.disabled = OaeUtil.castToBoolean(opts.disabled);
+
+    res.send(200, TenantsAPI.searchTenants(q, opts));
+};
+
+OAE.tenantRouter.on('get', '/api/search/tenants', _handleSearchTenants);
+OAE.globalAdminRouter.on('get', '/api/search/tenants', _handleSearchTenants);
 
 /**
  * @REST getSearch

--- a/node_modules/oae-search/tests/test-tenants-search.js
+++ b/node_modules/oae-search/tests/test-tenants-search.js
@@ -1,0 +1,212 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+var assert = require('assert');
+
+var TenantsTestUtil = require('oae-tenants/lib/test/util');
+var TestsUtil = require('oae-tests');
+
+var SearchTestsUtil = require('oae-search/lib/test/util');
+
+describe('Tenants Search', function() {
+
+    // Rest context that can be used every time we need to make a request as an anonymous user
+    var anonymousRestContext = null;
+    // Rest context that can be used every time we need to make a request as a global admin
+    var globalAdminRestContext = null;
+
+    /*!
+     * Initialize our rest contexts before each test
+     */
+    beforeEach(function(callback) {
+        // Fill up anonymous rest context
+        anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
+        // Fill up global admin rest context
+        globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
+
+        callback();
+    });
+
+    /**
+     * Test that verifies tenant search is available on the global admin server
+     */
+    it('verify tenants search works on the global admin server', function(callback) {
+        SearchTestsUtil.assertSearchSucceeds(globalAdminRestContext, 'tenants', null, {'q': 'Some querystring'}, function(result) {
+            _assertEmptyTenantsSearchResult(result);
+            return callback();
+        });
+    });
+
+    /**
+     * Test that verifies tenants search matches a tenant by all expected properties
+     */
+    it('verify it matches a tenant by alias, display name and host with case-insensitive search', function(callback) {
+        var alias = TenantsTestUtil.generateTestTenantAlias();
+        var displayName = TestsUtil.generateRandomText();
+        var host = TenantsTestUtil.generateTestTenantHost();
+
+        // Ensure none of the strings match a tenant yet
+        SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': alias.toLowerCase()}, function(result) {
+            _assertEmptyTenantsSearchResult(result);
+            SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': displayName.toLowerCase()}, function(result) {
+                _assertEmptyTenantsSearchResult(result);
+                SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': host.toLowerCase()}, function(result) {
+                    _assertEmptyTenantsSearchResult(result);
+
+                    // Create a tenant with the alias, display name an dhost
+                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias, displayName, host, function(err) {
+                        assert.ok(!err);
+
+                        // Ensure we get the tenant in all searches now
+                        SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': alias.toLowerCase()}, function(result) {
+                            assert.strictEqual(result.total, 1);
+                            assert.strictEqual(result.results[0].alias, alias);
+                            assert.strictEqual(result.results[0].displayName, displayName);
+                            assert.strictEqual(result.results[0].host, host);
+                            SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': displayName.toLowerCase()}, function(result) {
+                                assert.strictEqual(result.total, 1);
+                                assert.strictEqual(result.results[0].alias, alias);
+                                assert.strictEqual(result.results[0].displayName, displayName);
+                                assert.strictEqual(result.results[0].host, host);
+                                SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': host.toLowerCase()}, function(result) {
+                                    assert.strictEqual(result.total, 1);
+                                    assert.strictEqual(result.results[0].alias, alias);
+                                    assert.strictEqual(result.results[0].displayName, displayName);
+                                    assert.strictEqual(result.results[0].host, host);
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    /**
+     * Test that verifies partial matches get results
+     */
+    it('verify it matches partial matches', function(callback) {
+        TenantsTestUtil.generateTestTenants(globalAdminRestContext, 1, function(tenant) {
+            var alias = tenant.alias.toLowerCase().slice(0, 3);
+            var displayName = tenant.displayName.toLowerCase().slice(0, 3);
+            var host = tenant.host.toLowerCase().slice(0, 3);
+
+            // Take just the first 3 characters of each field and ensure we get the tenant
+            SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': alias}, function(result) {
+                assert.ok(_.findWhere(result.results, {'alias': tenant.alias}));
+                SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': displayName}, function(result) {
+                    assert.ok(_.findWhere(result.results, {'alias': tenant.alias}));
+                    SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': host}, function(result) {
+                        assert.ok(_.findWhere(result.results, {'alias': tenant.alias}));
+                        return callback();
+                    });
+                });
+            });
+        });
+    });
+
+    /**
+     * Test that verifies tenant updates are persisted in the search index and that disabled tenants
+     * can be included or excluded from results when specified
+     */
+    it('verify tenant updates are persisted and search for disabled tenants', function(callback) {
+        TenantsTestUtil.generateTestTenants(globalAdminRestContext, 1, function(tenant) {
+            // Ensure the tenant can be found in search
+            SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': tenant.alias}, function(result) {
+                assert.ok(_.findWhere(result.results, {'alias': tenant.alias}));
+
+                // Stop the tenant and ensure it no longer appears
+                TenantsTestUtil.stopTenantAndWait(globalAdminRestContext, tenant.alias, function() {
+                    SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': tenant.alias}, function(result) {
+                        _assertEmptyTenantsSearchResult(result);
+
+                        // Search while enabling disabled tenants and ensure it appears again
+                        SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': tenant.alias, 'disabled': true}, function(result) {
+                            assert.ok(_.findWhere(result.results, {'alias': tenant.alias}));
+
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    /**
+     * Test that verifies the paging properties of tenant search
+     */
+    it('verify tenant search paging', function(callback) {
+        // Get the first 3 tenants in search
+        SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'start': 0, 'limit': 3}, function(result) {
+            _assertTenantsSearchResult(result);
+            assert.strictEqual(result.results.length, 3);
+            var tenants = result.results;
+
+            // Get just the first, second and third and ensure you get just the one tenant
+            SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'start': 0, 'limit': 1}, function(result) {
+                _assertTenantsSearchResult(result);
+                assert.deepEqual(result.results, tenants.slice(0, 1));
+
+                SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'start': 1, 'limit': 1}, function(result) {
+                    _assertTenantsSearchResult(result);
+                    assert.deepEqual(result.results, tenants.slice(1, 2));
+                    SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'start': 2, 'limit': 1}, function(result) {
+                        _assertTenantsSearchResult(result);
+                        assert.deepEqual(result.results, tenants.slice(2, 3));
+
+                        // Get 2 at a time and ensure you get the two expected
+                        SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'start': 0, 'limit': 2}, function(result) {
+                            _assertTenantsSearchResult(result);
+                            assert.deepEqual(result.results, tenants.slice(0, 2));
+                            SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'start': 1, 'limit': 2}, function(result) {
+                                _assertTenantsSearchResult(result);
+                                assert.deepEqual(result.results, tenants.slice(1, 3));
+
+                                return callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});
+
+/*!
+ * Ensure the given search result object matches the expected format and indicates 0 results
+ *
+ * @param  {SearchResult}   result  The search result object
+ * @throws {AssertionError}         Thrown if the result object doesn't match the intended format or is not empty
+ */
+var _assertEmptyTenantsSearchResult = function(result) {
+    _assertTenantsSearchResult(result);
+    assert.strictEqual(result.total, 0);
+    assert.strictEqual(result.results.length, 0);
+};
+
+/*!
+ * Perform a sanity assertion on the tenants earch result object
+ *
+ * @param  {SearchResult}   result  The search result object
+ * @throws {AssertionError}         Thrown if the result object doesn't match the intended format
+ */
+var _assertTenantsSearchResult = function(result) {
+    assert.ok(result);
+    assert.ok(_.isNumber(result.total));
+    assert.ok(_.isArray(result.results));
+    assert.ok(result.results.length <= result.total);
+};

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -65,14 +65,21 @@ Pubsub.on('oae-tenants', function (message) {
     var cmd = args.shift();
     var alias = args.shift();
 
-    // Re-cache the available tenants
-    _cacheTenants(function(err) {
+    var callback = function(err) {
         if (err) {
             return log().error('There was an error caching the tenants');
         }
 
         TenantsAPI.emit(cmd, getTenant(alias));
-    });
+    };
+
+    if (_.contains(['start', 'stop', 'created'], cmd)) {
+        // Update the cached version of the tenant
+        _updateCachedTenant(alias, callback);
+    } else {
+        // Re-cache the available tenants
+        _cacheTenants(callback);
+    }
 });
 
 /**
@@ -225,6 +232,52 @@ var _cacheTenants = function(callback) {
 
         // Cache the sorted list
         sortedTenants = _.sortBy(tenants, 'alias');
+
+        // Indicate that all tenants have been cached
+        TenantsAPI.emit('cached');
+
+        return callback(null, tenants);
+    });
+};
+
+/**
+ * Fetch the tenant and update it's entry in the cache
+ *
+ * @param  {String}         tenantAlias         The alias of the tenant to be re-cached
+ * @param  {Function}       [callback]          Standard callback function
+ * @param  {Object}         [callback.err]      Error object containing the error code and message
+ * @api private
+ */
+var _updateCachedTenant = function(tenantAlias, callback) {
+    callback = callback || function(err) {
+        if (err) {
+            log().error({'err': err}, 'Failed to re-cache the tenants');
+        }
+    };
+
+    // Get the available tenants
+    Cassandra.runQuery('SELECT * FROM "Tenant" WHERE "alias" = ?', [tenantAlias], function(err, rows) {
+        if (err) {
+            return callback(err);
+        }
+
+        _.each(rows, function(row) {
+            var tenant = mapToTenant(row);
+            // Cache all tenants
+            tenants[tenant.alias] = tenant;
+            tenantsByHost[tenant.host] = tenant;
+
+            // Insert at the correct location in the sorted list
+            var index = _.findIndex(sortedTenants, function(t){
+                return t.alias === tenantAlias;
+            });
+            if (index === -1) {
+                index = _.sortedIndex(sortedTenants, tenant, 'alias');
+                sortedTenants.splice(index, 0, tenant);
+            } else {
+                sortedTenants[index] = tenant;
+            }
+        });
 
         // Indicate that all tenants have been cached
         TenantsAPI.emit('cached');

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -35,6 +35,8 @@ var tenants = {};
 // Variable that caches the available tenants, keyed by their hostname. This will be used for
 // quick look-ups when checking whether or not a hostname is associated to a tenant
 var tenantsByHost = {};
+// Variable that caches the available tenants sorted by alias
+var sortedTenants = [];
 
 // Variable that caches the global administration tenant object
 var globalTenant = null;
@@ -145,8 +147,7 @@ var getTenants = module.exports.getTenants = function(excludeDisabled, start, li
 
     var filteredTenants = {};
     // Filter out the admin tenant and disabled tenants if requested
-    var preFiltered = excludeDisabled? _.where(tenants, {active: true, isGlobalAdminServer: false}): _.where(tenants, {isGlobalAdminServer: false});
-    preFiltered = _.sortBy(preFiltered, 'alias');
+    var preFiltered = excludeDisabled? _.where(sortedTenants, {active: true, isGlobalAdminServer: false}): _.where(sortedTenants, {isGlobalAdminServer: false});
     // Calculate the end index for paging
     var end = preFiltered.length;
     if (limit) {
@@ -215,6 +216,9 @@ var _cacheTenants = function(callback) {
             tenants[tenant.alias] = tenant;
             tenantsByHost[tenant.host] = tenant;
         });
+
+        // Cache the sorted list
+        sortedTenants = _.sortBy(tenants, 'alias');
 
         // Indicate that all tenants have been cached
         TenantsAPI.emit('cached');

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -132,15 +132,23 @@ var init = module.exports.init = function(_serverConfig, callback) {
  * Get a list of all available tenants from cache. The global admin tenant will be excluded from the resulting tenant list
  *
  * @param  {Boolean}        [excludeDisabled]   Whether or not disabled tenants should be included. By default, all tenants will be returned
+ * @param  {Number}         [start]             The index to start paging at, defaults to 0
+ * @param  {Number}         [limit]             The maximum number of tenants to return, if not specified all tenants will be returned
  * @return {Object}                             An object keyed by tenant alias holding all the tenants
  */
-var getTenants = module.exports.getTenants = function(excludeDisabled) {
+var getTenants = module.exports.getTenants = function(excludeDisabled, start, limit) {
     var filteredTenants = {};
-    _.each(tenants, function(tenant, tenantAlias) {
-        // Exclude all disabled tenants when `exludeDisabled` has been provided
-        if (!tenant.isGlobalAdminServer && (!excludeDisabled || tenant.active)) {
-            filteredTenants[tenantAlias] = _copyTenant(tenant);
-        }
+    start = start || 0;
+    // Filter out the admin tenant and disabled tenants if requested
+    var preFiltered = excludeDisabled? _.where(tenants, {active: true, isGlobalAdminServer: false}): _.where(tenants, {isGlobalAdminServer: false});
+    preFiltered = _.sortBy(preFiltered, 'alias');
+    // Calculate the end index for paging
+    var end = preFiltered.length;
+    if (limit) {
+        end = parseInt(limit) + parseInt(start);
+    }
+    _.each(preFiltered.slice(start, end), function(tenant) {
+        filteredTenants[tenant.alias] = _copyTenant(tenant);
     });
     return filteredTenants;
 };

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -14,6 +14,7 @@
  */
 
 var _ = require('underscore');
+var lunr = require('lunr');
 var util = require('util');
 
 var Cassandra = require('oae-util/lib/cassandra');
@@ -25,6 +26,7 @@ var Pubsub = require('oae-util/lib/pubsub');
 var Validator = require('oae-util/lib/validator').Validator;
 
 var Tenant = require('./model').Tenant;
+var TenantIndex = require('./internal/tenantIndex');
 var TenantNetworksDAO = require('./internal/dao.networks');
 
 // Variable that caches the server configuration as specified in the config.js file
@@ -40,6 +42,9 @@ var sortedTenants = [];
 
 // Variable that caches the global administration tenant object
 var globalTenant = null;
+
+// Variable that caches a search index for all tenants in the system
+var tenantSearchIndex = null;
 
 /**
  * ### Events
@@ -141,35 +146,81 @@ var init = module.exports.init = function(_serverConfig, callback) {
 /**
  * Get a list of all available tenants from cache. The global admin tenant will be excluded from the resulting tenant list
  *
- * @param  {Boolean}        [excludeDisabled]   Whether or not disabled tenants should be included. By default, all tenants will be returned
- * @param  {Number}         [start]             The index to start paging at, defaults to 0
- * @param  {Number}         [limit]             The maximum number of tenants to return, if not specified all tenants will be returned
- * @param  {String}         [q]                 Query string used to filter results
- * @return {Object}                             An object keyed by tenant alias holding all the tenants
+ * @param  {Boolean}    [excludeDisabled]   Whether or not disabled tenants should be included. By default, all tenants will be returned
+ * @return {Object}                         An object keyed by tenant alias holding all the tenants
  */
-var getTenants = module.exports.getTenants = function(excludeDisabled, start, limit, q) {
+var getTenants = module.exports.getTenants = function(excludeDisabled) {
     excludeDisabled = OaeUtil.castToBoolean(excludeDisabled);
-    start = OaeUtil.getNumberParam(start, 0);
-    // Note that we don't apply a default limit here as some methods need ALL tenants
-    limit = OaeUtil.getNumberParam(limit);
 
     var filteredTenants = {};
-    // Filter out the admin tenant and disabled tenants if requested
-    var preFiltered = excludeDisabled? _.where(sortedTenants, {active: true, isGlobalAdminServer: false}): _.where(sortedTenants, {isGlobalAdminServer: false});
-    if (_.isString(q)) {
-        preFiltered = _.filter(preFiltered, function(tenant) {
-            return tenant.alias.indexOf(q) !== -1 || tenant.displayName.indexOf(q) !== -1 || tenant.host.indexOf(q) !== -1;
-        });
-    }
-    // Calculate the end index for paging
-    var end = preFiltered.length;
-    if (limit) {
-        end = parseInt(limit) + parseInt(start);
-    }
-    _.each(preFiltered.slice(start, end), function(tenant) {
-        filteredTenants[tenant.alias] = _copyTenant(tenant);
+    _.each(tenants, function(tenant, tenantAlias) {
+        // Exclude all disabled tenants when `exludeDisabled` has been provided
+        if (!tenant.isGlobalAdminServer && (!excludeDisabled || tenant.active)) {
+            filteredTenants[tenantAlias] = _copyTenant(tenant);
+        }
     });
+
     return filteredTenants;
+};
+
+/**
+ * Search for tenants based on a full-text search query
+ *
+ * @param  {String}         [q]                 The full-text query to perform. If unspecified, all tenants will be returned
+ * @param  {Object}         [opts]              Optional arguments
+ * @param  {Number}         [opts.start]        The index at which to begin returning results
+ * @param  {Number}         [opts.limit]        The maximum number of results to return. If unspecified, returns all results
+ * @param  {Boolean}        [opts.disabled]     If `true`, will include tenants that are disabled or deleted. Otherwise, they are ommitted from results
+ * @return {SearchResult}                       The search result object containing the tenants
+ */
+var searchTenants = module.exports.searchTenants = function(q, opts) {
+    q = (_.isString(q)) ? q.trim() : null;
+    opts = opts || {};
+    opts.start = OaeUtil.getNumberParam(opts.start, 0);
+
+    // Determine if we should included disabled/deleted tenants
+    var includeDisabled = (_.isBoolean(opts.disabled)) ? opts.disabled : false;
+
+    // Create a sorted result of tenants based on the user's query. If there was no query, we will
+    // pull the pre-sorted list of tenants from the global cache
+    var results = null;
+    if (q) {
+        results = _.chain(tenantSearchIndex.search(q))
+            .sortBy('ref')
+            .sortBy('score')
+            .pluck('ref')
+            .map(getTenant)
+            .value();
+    } else {
+        results = sortedTenants;
+    }
+
+    // Filter out the global admin server and deleted tenancies
+    results = _.filter(results, function(tenant) {
+        return (!tenant.isGlobalAdminServer);
+    });
+
+    // Filter out disabled or deleted tenants if they aren't said to be included
+    if (!includeDisabled) {
+        results = _.where(results, {'active': true, 'deleted': false});
+    }
+
+    // Keep track of how many results we had in total
+    var total = _.size(results);
+
+    // Determine the end of our page slice
+    opts.limit = OaeUtil.getNumberParam(opts.limit, results.length);
+    var end = opts.start + opts.limit;
+
+    // Cut down to just the requested page, and clone the tenants to avoid tenants being updated
+    // in the cache
+    results = results.slice(opts.start, end);
+    results = _.map(results, _copyTenant);
+
+    return {
+        'total': total,
+        'results': results
+    };
 };
 
 /**
@@ -233,6 +284,9 @@ var _cacheTenants = function(callback) {
         // Cache the sorted list
         sortedTenants = _.sortBy(tenants, 'alias');
 
+        // Build the search index for all tenants
+        tenantSearchIndex = new TenantIndex(tenants);
+
         // Indicate that all tenants have been cached
         TenantsAPI.emit('cached');
 
@@ -277,6 +331,8 @@ var _updateCachedTenant = function(tenantAlias, callback) {
             } else {
                 sortedTenants[index] = tenant;
             }
+
+            tenantSearchIndex.update(tenant);
         });
 
         // Indicate that all tenants have been cached

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -20,6 +20,7 @@ var Cassandra = require('oae-util/lib/cassandra');
 var EmitterAPI = require('oae-emitter');
 var log = require('oae-logger').logger('oae-tenants');
 var OAE = require('oae-util/lib/oae');
+var OaeUtil = require('oae-util/lib/util');
 var Pubsub = require('oae-util/lib/pubsub');
 var Validator = require('oae-util/lib/validator').Validator;
 
@@ -137,8 +138,12 @@ var init = module.exports.init = function(_serverConfig, callback) {
  * @return {Object}                             An object keyed by tenant alias holding all the tenants
  */
 var getTenants = module.exports.getTenants = function(excludeDisabled, start, limit) {
+    excludeDisabled = OaeUtil.castToBoolean(excludeDisabled);
+    start = OaeUtil.getNumberParam(start, 0);
+    // Note that we don't apply a default limit here as some methods need ALL tenants
+    limit = OaeUtil.getNumberParam(limit);
+
     var filteredTenants = {};
-    start = start || 0;
     // Filter out the admin tenant and disabled tenants if requested
     var preFiltered = excludeDisabled? _.where(tenants, {active: true, isGlobalAdminServer: false}): _.where(tenants, {isGlobalAdminServer: false});
     preFiltered = _.sortBy(preFiltered, 'alias');

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -14,7 +14,6 @@
  */
 
 var _ = require('underscore');
-var lunr = require('lunr');
 var util = require('util');
 
 var Cassandra = require('oae-util/lib/cassandra');
@@ -196,14 +195,15 @@ var searchTenants = module.exports.searchTenants = function(q, opts) {
     }
 
     // Filter out the global admin server and deleted tenancies
-    results = _.filter(results, function(tenant) {
-        return (!tenant.isGlobalAdminServer);
-    });
+    var filter = {'isGlobalAdminServer': false};
 
     // Filter out disabled or deleted tenants if they aren't said to be included
     if (!includeDisabled) {
-        results = _.where(results, {'active': true, 'deleted': false});
+        filter.active = true;
+        filter.deleted = false;
     }
+
+    results = _.where(results, filter);
 
     // Keep track of how many results we had in total
     var total = _.size(results);
@@ -315,25 +315,23 @@ var _updateCachedTenant = function(tenantAlias, callback) {
             return callback(err);
         }
 
-        _.each(rows, function(row) {
-            var tenant = mapToTenant(row);
-            // Cache all tenants
-            tenants[tenant.alias] = tenant;
-            tenantsByHost[tenant.host] = tenant;
+        var tenant = mapToTenant(rows[0]);
+        // Cache all tenants
+        tenants[tenant.alias] = tenant;
+        tenantsByHost[tenant.host] = tenant;
 
-            // Insert at the correct location in the sorted list
-            var index = _.findIndex(sortedTenants, function(t){
-                return t.alias === tenantAlias;
-            });
-            if (index === -1) {
-                index = _.sortedIndex(sortedTenants, tenant, 'alias');
-                sortedTenants.splice(index, 0, tenant);
-            } else {
-                sortedTenants[index] = tenant;
-            }
-
-            tenantSearchIndex.update(tenant);
+        // Insert at the correct location in the sorted list
+        var index = _.findIndex(sortedTenants, function(t){
+            return t.alias === tenantAlias;
         });
+        if (index === -1) {
+            index = _.sortedIndex(sortedTenants, tenant, 'alias');
+            sortedTenants.splice(index, 0, tenant);
+        } else {
+            sortedTenants[index] = tenant;
+        }
+
+        tenantSearchIndex.update(tenant);
 
         // Indicate that all tenants have been cached
         TenantsAPI.emit('cached');

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -137,9 +137,10 @@ var init = module.exports.init = function(_serverConfig, callback) {
  * @param  {Boolean}        [excludeDisabled]   Whether or not disabled tenants should be included. By default, all tenants will be returned
  * @param  {Number}         [start]             The index to start paging at, defaults to 0
  * @param  {Number}         [limit]             The maximum number of tenants to return, if not specified all tenants will be returned
+ * @param  {String}         [q]                 Query string used to filter results
  * @return {Object}                             An object keyed by tenant alias holding all the tenants
  */
-var getTenants = module.exports.getTenants = function(excludeDisabled, start, limit) {
+var getTenants = module.exports.getTenants = function(excludeDisabled, start, limit, q) {
     excludeDisabled = OaeUtil.castToBoolean(excludeDisabled);
     start = OaeUtil.getNumberParam(start, 0);
     // Note that we don't apply a default limit here as some methods need ALL tenants
@@ -148,6 +149,11 @@ var getTenants = module.exports.getTenants = function(excludeDisabled, start, li
     var filteredTenants = {};
     // Filter out the admin tenant and disabled tenants if requested
     var preFiltered = excludeDisabled? _.where(sortedTenants, {active: true, isGlobalAdminServer: false}): _.where(sortedTenants, {isGlobalAdminServer: false});
+    if (_.isString(q)) {
+        preFiltered = _.filter(preFiltered, function(tenant) {
+            return tenant.alias.indexOf(q) !== -1 || tenant.displayName.indexOf(q) !== -1 || tenant.host.indexOf(q) !== -1;
+        });
+    }
     // Calculate the end index for paging
     var end = preFiltered.length;
     if (limit) {

--- a/node_modules/oae-tenants/lib/internal/tenantIndex.js
+++ b/node_modules/oae-tenants/lib/internal/tenantIndex.js
@@ -1,0 +1,77 @@
+
+var _ = require('underscore');
+var lunr = require('lunr');
+
+/**
+ * Represents an index where tenants can be indexed and then later full-text searched
+ *
+ * @param  {Tenant[]}   tenants     The tenants that should be indexed
+ */
+var TenantIndex = module.exports = function(tenants) {
+    var lunrIndex = _createIndex(tenants);
+    return {
+
+        /**
+         * Search for a tenant based on a user-input query
+         *
+         * @param  {String}     q               The query to use to search
+         * @return {Object[]}   docs            The search documents
+         * @return {String}     docs[i].ref     The "id" of the document (i.e., the tenant alias)
+         * @return {Number}     docs[i].score   The search match score, on which the results will be sorted from highest to lowest
+         */
+        'search': function(q) {
+            return lunrIndex.search(q);
+        },
+
+        /**
+         * Add / update the given tenants in the search index
+         *
+         * @param  {Tenant|Tenant[]}    tenants     The tenants to add or update in the index
+         */
+        'update': function(tenants) {
+            tenants = (_.isArray(tenants)) ? tenants : [tenants];
+            _.chain(tenants)
+                .map(_tenantToDocument)
+                .each(lunrIndex.update.bind(lunrIndex))
+                .value();
+        }
+    };
+};
+
+/**
+ * Create the index with the given tenants stored in it
+ *
+ * @param  {Tenants[]}  tenants     The tenants to add
+ * @return {lunr.Index}             The lunr index loaded with the tenants
+ * @api private
+ */
+var _createIndex = function(tenants) {
+    // Create an index that ids its documents by an "alias" field, so we can uniquely update
+    // tenants by alias
+    var lunrIndex = lunr(function() {
+        this.ref('alias');
+        this.field('alias');
+        this.field('host');
+        this.field('displayName');
+    });
+
+    _.chain(tenants)
+        .map(_tenantToDocument)
+        .each(function(doc) {
+            lunrIndex.add(doc);
+        })
+        .value();
+
+    return lunrIndex;
+};
+
+/**
+ * Convert a tenant to the lunr tenant document model
+ *
+ * @param  {Tenant}     tenant  The tenant to convert to a document
+ * @return {Object}             The lunr document that represents the tenant
+ * @api private
+ */
+var _tenantToDocument = function(tenant) {
+    return _.pick(tenant, 'alias', 'host', 'displayName');
+};

--- a/node_modules/oae-tenants/lib/internal/tenantIndex.js
+++ b/node_modules/oae-tenants/lib/internal/tenantIndex.js
@@ -1,3 +1,17 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 
 var _ = require('underscore');
 var lunr = require('lunr');

--- a/node_modules/oae-tenants/lib/rest.js
+++ b/node_modules/oae-tenants/lib/rest.js
@@ -15,6 +15,7 @@
 
 var _ = require('underscore');
 var OAE = require('oae-util/lib/oae');
+var OaeUtil = require('oae-util/lib/util');
 
 var TenantsAPI = require('oae-tenants/lib/api');
 var TenantNetworksAPI = require('oae-tenants/lib/api.networks');
@@ -220,12 +221,13 @@ OAE.globalAdminRouter.on('post', '/api/tenant/create', function(req, res) {
  * @Method      GET
  * @Path        /tenants
  * @QueryParam  {number}        [start]         The index to start paging from
- * @QueryParam  {number}        [limit]         The maximum number of results to return
+ * @QueryParam  {number}        [limit]         The maximum number of results to return, defaults to 10
  * @Return      {Tenants}                       All available tenants
  * @HttpResponse                200             Tenants available
  */
 OAE.globalAdminRouter.on('get', '/api/tenants', function(req, res, next) {
-    var tenants = TenantsAPI.getTenants(false, req.query.start, req.query.limit);
+    var limit = OaeUtil.getNumberParam(req.query.limit, 10, 1);
+    var tenants = TenantsAPI.getTenants(false, req.query.start, limit);
     res.send(200, tenants);
 });
 

--- a/node_modules/oae-tenants/lib/rest.js
+++ b/node_modules/oae-tenants/lib/rest.js
@@ -227,7 +227,7 @@ OAE.globalAdminRouter.on('post', '/api/tenant/create', function(req, res) {
  */
 OAE.globalAdminRouter.on('get', '/api/tenants', function(req, res, next) {
     var limit = OaeUtil.getNumberParam(req.query.limit, 10, 1);
-    var tenants = TenantsAPI.getTenants(false, req.query.start, limit);
+    var tenants = TenantsAPI.getTenants(false, req.query.start, limit, req.query.q);
     res.send(200, tenants);
 });
 

--- a/node_modules/oae-tenants/lib/rest.js
+++ b/node_modules/oae-tenants/lib/rest.js
@@ -219,11 +219,13 @@ OAE.globalAdminRouter.on('post', '/api/tenant/create', function(req, res) {
  * @Server      admin
  * @Method      GET
  * @Path        /tenants
+ * @QueryParam  {number}        [start]         The index to start paging from
+ * @QueryParam  {number}        [limit]         The maximum number of results to return
  * @Return      {Tenants}                       All available tenants
  * @HttpResponse                200             Tenants available
  */
 OAE.globalAdminRouter.on('get', '/api/tenants', function(req, res, next) {
-    var tenants = TenantsAPI.getTenants();
+    var tenants = TenantsAPI.getTenants(false, req.query.start, req.query.limit);
     res.send(200, tenants);
 });
 

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -65,7 +65,7 @@ describe('Tenants', function() {
             var tenantHost = TenantsTestUtil.generateTestTenantHost();
 
             // Get all tenants, check that there are 2
-            RestAPI.Tenants.getTenants(globalAdminRestContext, function(err, tenants) {
+            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, function(err, tenants) {
                 assert.ok(!err);
                 assert.ok(tenants);
                 assert.ok(tenants['camtest']);
@@ -77,10 +77,8 @@ describe('Tenants', function() {
                 TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, function(err) {
                     assert.ok(!err);
                     // Get all tenants, check that there are 3
-                    RestAPI.Tenants.getTenants(globalAdminRestContext, function(err, tenants) {
+                    RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, function(err, tenants) {
                         assert.ok(tenants);
-                        assert.ok(tenants['camtest']);
-                        assert.equal(tenants['camtest'].host, 'cambridge.oae.com');
                         assert.ok(tenants['gttest']);
                         assert.equal(tenants['gttest'].host, 'gt.oae.com');
                         assert.equal(tenants['camtest'].host, 'cambridge.oae.com');
@@ -89,7 +87,12 @@ describe('Tenants', function() {
                         // Verify that the global admin tenant is not included
                         assert.ok(!tenants['admin']);
 
-                        callback();
+                        // Check that paging works
+                        RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1, function(err, tenants) {
+                            assert.ok(tenants);
+                            assert.equal(_.keys(tenants).length, 1);
+                            callback();
+                        });
                     });
                 });
             });
@@ -510,7 +513,7 @@ describe('Tenants', function() {
                             assert.equal(TenantsAPI.getTenants()[testTenant.alias].active, false);
 
                             // Verify that it's still part of the all tenants feed
-                            RestAPI.Tenants.getTenants(globalAdminRestContext, function(err, tenants) {
+                            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, function(err, tenants) {
                                 assert.ok(!err);
                                 assert.ok(tenants);
                                 assert.ok(tenants[testTenant.alias]);

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -65,7 +65,7 @@ describe('Tenants', function() {
             var tenantHost = TenantsTestUtil.generateTestTenantHost();
 
             // Get all tenants, check that there are 2
-            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, null, function(err, tenants) {
+            RestAPI.Tenants.getTenants(globalAdminRestContext, function(err, tenants) {
                 assert.ok(!err);
                 assert.ok(tenants);
                 assert.ok(tenants['camtest']);
@@ -77,9 +77,10 @@ describe('Tenants', function() {
                 TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, function(err) {
                     assert.ok(!err);
                     // Get all tenants, check that there are 3
-                    RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1000, null, function(err, tenants) {
+                    RestAPI.Tenants.getTenants(globalAdminRestContext, function(err, tenants) {
                         assert.ok(tenants);
                         assert.ok(tenants['gttest']);
+                        assert.ok(tenants['camtest']);
                         assert.equal(tenants['gttest'].host, 'gt.oae.com');
                         assert.equal(tenants['camtest'].host, 'cambridge.oae.com');
                         assert.ok(tenants[tenantAlias]);
@@ -87,28 +88,7 @@ describe('Tenants', function() {
                         // Verify that the global admin tenant is not included
                         assert.ok(!tenants['admin']);
 
-                        var firstTwo = _.sortBy(tenants, 'alias').slice(0,2);
-                        // Check that paging works
-                        RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1, null, function(err, tenants) {
-                            assert.ok(!err);
-                            assert.ok(tenants);
-                            assert.equal(_.keys(tenants).length, 1);
-                            assert.ok(tenants[firstTwo[0].alias]);
-                            RestAPI.Tenants.getTenants(globalAdminRestContext, 1, 1, null, function(err, tenants) {
-                                assert.ok(!err);
-                                assert.ok(tenants);
-                                assert.equal(_.keys(tenants).length, 1);
-                                assert.ok(tenants[firstTwo[1].alias]);
-                                // Check that filtering works
-                                RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, 'cambridge', function(err, tenants) {
-                                    assert.ok(!err);
-                                    assert.ok(tenants);
-                                    assert.equal(_.keys(tenants).length, 1);
-                                    assert.equal(tenants['camtest'].host, 'cambridge.oae.com');
-                                    callback();
-                                });
-                            });
-                        });
+                        return callback();
                     });
                 });
             });
@@ -529,7 +509,7 @@ describe('Tenants', function() {
                             assert.equal(TenantsAPI.getTenants()[testTenant.alias].active, false);
 
                             // Verify that it's still part of the all tenants feed
-                            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1, testTenant.alias, function(err, tenants) {
+                            RestAPI.Tenants.getTenants(globalAdminRestContext, function(err, tenants) {
                                 assert.ok(!err);
                                 assert.ok(tenants);
                                 assert.ok(tenants[testTenant.alias]);

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -87,11 +87,18 @@ describe('Tenants', function() {
                         // Verify that the global admin tenant is not included
                         assert.ok(!tenants['admin']);
 
+                        var firstTwo = _.sortBy(tenants, 'alias').slice(0,2);
                         // Check that paging works
                         RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1, function(err, tenants) {
                             assert.ok(tenants);
                             assert.equal(_.keys(tenants).length, 1);
-                            callback();
+                            assert.ok(tenants[firstTwo[0].alias]);
+                            RestAPI.Tenants.getTenants(globalAdminRestContext, 1, 1, function(err, tenants) {
+                                assert.ok(tenants);
+                                assert.equal(_.keys(tenants).length, 1);
+                                assert.ok(tenants[firstTwo[1].alias]);
+                                callback();
+                            });
                         });
                     });
                 });

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -65,7 +65,7 @@ describe('Tenants', function() {
             var tenantHost = TenantsTestUtil.generateTestTenantHost();
 
             // Get all tenants, check that there are 2
-            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, function(err, tenants) {
+            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, function(err, tenants) {
                 assert.ok(!err);
                 assert.ok(tenants);
                 assert.ok(tenants['camtest']);
@@ -77,7 +77,7 @@ describe('Tenants', function() {
                 TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, function(err) {
                     assert.ok(!err);
                     // Get all tenants, check that there are 3
-                    RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, function(err, tenants) {
+                    RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, function(err, tenants) {
                         assert.ok(tenants);
                         assert.ok(tenants['gttest']);
                         assert.equal(tenants['gttest'].host, 'gt.oae.com');
@@ -513,7 +513,7 @@ describe('Tenants', function() {
                             assert.equal(TenantsAPI.getTenants()[testTenant.alias].active, false);
 
                             // Verify that it's still part of the all tenants feed
-                            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, function(err, tenants) {
+                            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, function(err, tenants) {
                                 assert.ok(!err);
                                 assert.ok(tenants);
                                 assert.ok(tenants[testTenant.alias]);

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -65,7 +65,7 @@ describe('Tenants', function() {
             var tenantHost = TenantsTestUtil.generateTestTenantHost();
 
             // Get all tenants, check that there are 2
-            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, function(err, tenants) {
+            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, null, function(err, tenants) {
                 assert.ok(!err);
                 assert.ok(tenants);
                 assert.ok(tenants['camtest']);
@@ -77,7 +77,7 @@ describe('Tenants', function() {
                 TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, function(err) {
                     assert.ok(!err);
                     // Get all tenants, check that there are 3
-                    RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, function(err, tenants) {
+                    RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1000, null, function(err, tenants) {
                         assert.ok(tenants);
                         assert.ok(tenants['gttest']);
                         assert.equal(tenants['gttest'].host, 'gt.oae.com');
@@ -89,15 +89,24 @@ describe('Tenants', function() {
 
                         var firstTwo = _.sortBy(tenants, 'alias').slice(0,2);
                         // Check that paging works
-                        RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1, function(err, tenants) {
+                        RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1, null, function(err, tenants) {
+                            assert.ok(!err);
                             assert.ok(tenants);
                             assert.equal(_.keys(tenants).length, 1);
                             assert.ok(tenants[firstTwo[0].alias]);
-                            RestAPI.Tenants.getTenants(globalAdminRestContext, 1, 1, function(err, tenants) {
+                            RestAPI.Tenants.getTenants(globalAdminRestContext, 1, 1, null, function(err, tenants) {
+                                assert.ok(!err);
                                 assert.ok(tenants);
                                 assert.equal(_.keys(tenants).length, 1);
                                 assert.ok(tenants[firstTwo[1].alias]);
-                                callback();
+                                // Check that filtering works
+                                RestAPI.Tenants.getTenants(globalAdminRestContext, 0, null, 'cambridge', function(err, tenants) {
+                                    assert.ok(!err);
+                                    assert.ok(tenants);
+                                    assert.equal(_.keys(tenants).length, 1);
+                                    assert.equal(tenants['camtest'].host, 'cambridge.oae.com');
+                                    callback();
+                                });
                             });
                         });
                     });
@@ -520,7 +529,7 @@ describe('Tenants', function() {
                             assert.equal(TenantsAPI.getTenants()[testTenant.alias].active, false);
 
                             // Verify that it's still part of the all tenants feed
-                            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 100, function(err, tenants) {
+                            RestAPI.Tenants.getTenants(globalAdminRestContext, 0, 1, testTenant.alias, function(err, tenants) {
                                 assert.ok(!err);
                                 assert.ok(tenants);
                                 assert.ok(tenants[testTenant.alias]);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "juice": "latest",
     "less": "1.7.5",
     "locale": "latest",
+    "lunr": "latest",
     "mailparser": "latest",
     "marked": "latest",
     "mime": "latest",


### PR DESCRIPTION
We will soon have 1000+ tenants in the production environment. The list of available tenancies in the admin UI should become (infinitely) paged and we should create a separate endpoint to search through the list of available tenancies.

After this, we should run a performance test with 1000s of tenancies (and their users) to ensure that having this number of tenancies doesn't cause any performance regressions.