### PR TITLE
Deleted user account is not being scrubbed in members list

### DIFF
--- a/node_modules/oae-principals/lib/util.js
+++ b/node_modules/oae-principals/lib/util.js
@@ -184,15 +184,15 @@ var hideUserData = module.exports.hideUserData = function(ctx, user) {
     var isLoggedIn = TenantsUtil.isLoggedIn(ctx, user.tenant.alias);
     var isTargetUser = (!isAnon && ctx.user().id === user.id);
     var isAdmin = (!isAnon && ctx.user().isAdmin && ctx.user().isAdmin(user.tenant.alias));
+    var needsLoggedIn = user.visibility === AuthzConstants.visibility.LOGGEDIN;
+    var isPrivate = user.visibility === AuthzConstants.visibility.PRIVATE;
 
     if (isAdmin || isTargetUser) {
         return user;
     }
 
     // Hide the sensitive profile information if the user has limited access
-    if ((user.deleted ||
-        user.visibility === AuthzConstants.visibility.LOGGEDIN && !isLoggedIn) ||
-        (user.visibility === AuthzConstants.visibility.PRIVATE && !isTargetUser)) {
+    if (user.deleted || (needsLoggedIn && !isLoggedIn) || (isPrivate && !isTargetUser)) {
 
         user.displayName = user.publicAlias;
         user.picture = {};

--- a/node_modules/oae-principals/lib/util.js
+++ b/node_modules/oae-principals/lib/util.js
@@ -190,7 +190,8 @@ var hideUserData = module.exports.hideUserData = function(ctx, user) {
     }
 
     // Hide the sensitive profile information if the user has limited access
-    if ((user.visibility === AuthzConstants.visibility.LOGGEDIN && !isLoggedIn) ||
+    if ((user.deleted ||
+        user.visibility === AuthzConstants.visibility.LOGGEDIN && !isLoggedIn) ||
         (user.visibility === AuthzConstants.visibility.PRIVATE && !isTargetUser)) {
 
         user.displayName = user.publicAlias;

--- a/node_modules/oae-principals/tests/test-delete.js
+++ b/node_modules/oae-principals/tests/test-delete.js
@@ -657,36 +657,52 @@ describe('Principals Delete and Restore', function() {
          * "deleted"
          */
         it('verify deleting and restoring a user leaves them in members lists but marked as deleted', function(callback) {
-            // Generate a user and a group to test with
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, user) {
+            // Generate users and a group to test with
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, user1, user2) {
                 assert.ok(!err);
                 TestsUtil.generateTestGroups(camAdminRestContext, 1, function(group) {
 
-                    // Add the user to the group members library
-                    var roleChanges = {};
-                    roleChanges[user.user.id] = 'member';
-                    PrincipalsTestUtil.assertSetGroupMembersSucceeds(camAdminRestContext, camAdminRestContext, group.group.id, roleChanges, function() {
+                    // Change user1's publicAlias
+                    RestAPI.User.updateUser(user1.restContext, user1.user.id, {'publicAlias': 'Clark Kent'}, function(err, user) {
+                        console.log(err);
+                        assert.ok(!err);
 
-                        // Delete the user
-                        PrincipalsTestUtil.assertDeleteUserSucceeds(camAdminRestContext, user.restContext, user.user.id, function() {
+                        // Add the user to the group members library
+                        var roleChanges = {};
+                        roleChanges[user1.user.id] = 'member';
+                        PrincipalsTestUtil.assertSetGroupMembersSucceeds(camAdminRestContext, camAdminRestContext, group.group.id, roleChanges, function() {
 
-                            // Get the members library for the group, ensuring the user is still there and marked as deleted
-                            PrincipalsTestUtil.assertGetMembersLibrarySucceeds(camAdminRestContext, group.group.id, null, null, function(result) {
-                                result = _.pluck(result.results, 'profile');
-                                var userEntry = _.findWhere(result, {'id': user.user.id});
-                                assert.ok(userEntry);
-                                assert.ok(_.isNumber(userEntry.deleted));
+                            // Delete the user
+                            PrincipalsTestUtil.assertDeleteUserSucceeds(camAdminRestContext, user1.restContext, user1.user.id, function() {
 
-                                // Restore the user
-                                PrincipalsTestUtil.assertRestoreUserSucceeds(camAdminRestContext, user.user.id, function() {
+                                // Get the members library for the group, ensuring the user is still there and marked as deleted
+                                PrincipalsTestUtil.assertGetMembersLibrarySucceeds(camAdminRestContext, group.group.id, null, null, function(result) {
+                                    result = _.pluck(result.results, 'profile');
+                                    var userEntry = _.findWhere(result, {'id': user1.user.id});
+                                    assert.ok(userEntry);
+                                    assert.ok(_.isNumber(userEntry.deleted));
 
-                                    // Get the members library for the group, ensuring the user is still there and no longer marked as deleted
-                                    PrincipalsTestUtil.assertGetMembersLibrarySucceeds(camAdminRestContext, group.group.id, null, null, function(result) {
+                                    // Get the members as a non-admin to verify the profile is masked
+                                    PrincipalsTestUtil.assertGetMembersLibrarySucceeds(user2.restContext, group.group.id, null, null, function(result) {
                                         result = _.pluck(result.results, 'profile');
-                                        var userEntry = _.findWhere(result, {'id': user.user.id});
+                                        var userEntry = _.findWhere(result, {'id': user1.user.id});
                                         assert.ok(userEntry);
-                                        assert.ok(!userEntry.deleted);
-                                        return callback();
+                                        assert.ok(!userEntry.profilePath);
+                                        assert.equal('Clark Kent', userEntry.displayName);
+                                        assert.ok(_.isNumber(userEntry.deleted));
+
+                                        // Restore the user
+                                        PrincipalsTestUtil.assertRestoreUserSucceeds(camAdminRestContext, user1.user.id, function() {
+
+                                            // Get the members library for the group, ensuring the user is still there and no longer marked as deleted
+                                            PrincipalsTestUtil.assertGetMembersLibrarySucceeds(camAdminRestContext, group.group.id, null, null, function(result) {
+                                                result = _.pluck(result.results, 'profile');
+                                                var userEntry = _.findWhere(result, {'id': user1.user.id});
+                                                assert.ok(userEntry);
+                                                assert.ok(!userEntry.deleted);
+                                                return callback();
+                                            });
+                                        });
                                     });
                                 });
                             });

--- a/node_modules/oae-principals/tests/test-delete.js
+++ b/node_modules/oae-principals/tests/test-delete.js
@@ -664,7 +664,6 @@ describe('Principals Delete and Restore', function() {
 
                     // Change user1's publicAlias
                     RestAPI.User.updateUser(user1.restContext, user1.user.id, {'publicAlias': 'Clark Kent'}, function(err, user) {
-                        console.log(err);
                         assert.ok(!err);
 
                         // Add the user to the group members library


### PR DESCRIPTION
Currently if you create a user, add them to a group, then delete them, their entry should remain in the group members list, but have its profile path and display name "scrubbed" / obfuscated.

It appears that is currently not the case.
