### PR TITLE
Emails still being sent to users that were deleted

### DIFF
--- a/node_modules/oae-activity/lib/internal/email.js
+++ b/node_modules/oae-activity/lib/internal/email.js
@@ -735,7 +735,7 @@ var _getEmailRecipientResources = function(emailRecipientIds, callback) {
         });
 
         // If there were user recipients, get the user profiles
-        OaeUtil.invokeIfNecessary(!_.isEmpty(userIds), PrincipalsDAO.getPrincipals, userIds, ['principalId', 'tenantAlias', 'email', 'emailPreference'], function(err, usersById) {
+        OaeUtil.invokeIfNecessary(!_.isEmpty(userIds), PrincipalsDAO.getPrincipals, userIds, ['principalId', 'tenantAlias', 'deleted', 'email', 'emailPreference'], function(err, usersById) {
             if (err) {
                 return callback(err);
             }

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -21,7 +21,8 @@ var util = require('util');
 
 var AuthzUtil = require('oae-authz/lib/util');
 var ConfigTestUtil = require('oae-config/lib/test/util');
-var EmailTestUtil = require('oae-email/lib/test/util');
+var ContentTestUtil = require('oae-content/lib/test/util');
+var EmailTestUtil= require('oae-email/lib/test/util');
 var MqTestUtil = require('oae-util/lib/test/mq-util');
 var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
@@ -860,46 +861,52 @@ describe('Activity Email', function() {
      * profiles
      */
     it('verify email is not delivered to users who have since deleted their profile', function(callback) {
-        TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
+        // Create a user to perform actions (simong) and one to receive emails
+        // (mrvisser) through a group
+        TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, mrvisser, simong, nico) {
             assert.ok(!err);
+            PrincipalsTestUtil.assertCreateGroupSucceeds(mrvisser.restContext, 'displayName', 'description', 'public', 'yes', [nico.user.id], null, function(group) {
+                var expectedRecipients = [mrvisser.user.email, nico.user.email].sort();
 
-            // Set the appropriate email preference for mrvisser
-            RestAPI.User.updateUser(mrvisser.restContext, mrvisser.user.id, {'emailPreference': 'immediate'}, function(err) {
-                assert.ok(!err);
+                // Ensure we have no emails queued to send
+                EmailTestUtil.collectAndFetchAllEmails(function() {
 
-                // Generate an email activity for mrvisser
-                RestAPI.Content.createLink(simong.restContext, 'Google First', 'Awesome Google', 'public', 'http://www.google.ca/firstlink', [mrvisser.user.id], [], [], function(err, link) {
-                    assert.ok(!err);
+                    // Generate an email activity for the group, ensuring both
+                    ContentTestUtil.assertCreateLinkSucceeds(simong.restContext, 'displayName', 'description', 'public', 'http://www.google.ca/firstlink', null, [group.id], null, function(link1) {
+                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
+                            assert.strictEqual(messages.length, 2);
 
-                    // Ensure activities and notifications get delivered to mrvisser
-                    MqTestUtil.whenTasksEmpty(ActivityConstants.mq.TASK_ACTIVITY, function() {
-                        ActivityNotifications.whenNotificationsEmpty(function() {
+                            // Ensure the 2 recipients are mrvisser and nico
+                            var recipients = _.chain(messages)
+                                .pluck('headers')
+                                .pluck('to')
+                                .value()
+                                .sort();
+                            assert.deepEqual(recipients, expectedRecipients);
 
-                            // Delete mrvisser now with pending emails in their notifications feed
+                            // Delete and ensure the same action results in only nico receiving the email
                             PrincipalsTestUtil.assertDeleteUserSucceeds(camAdminRestContext, camAdminRestContext, mrvisser.user.id, function() {
+                                ContentTestUtil.assertCreateLinkSucceeds(simong.restContext, 'displayName', 'description', 'public', 'http://www.google.ca/firstlink', null, [group.id], null, function(link2) {
+                                    EmailTestUtil.collectAndFetchAllEmails(function(messages) {
+                                        assert.strictEqual(messages.length, 1);
+                                        assert.strictEqual(messages[0].headers.to, nico.user.email);
 
-                                // Deliver the activity and collect all emails associated to it,
-                                // ensuring no emails actually get delivered
-                                EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
-                                    assert.strictEqual(messages.length, 0);
+                                        // Restore the user and ensure the same action once again results in an email
+                                        PrincipalsTestUtil.assertRestoreUserSucceeds(camAdminRestContext, mrvisser.user.id, function() {
+                                            ContentTestUtil.assertCreateLinkSucceeds(simong.restContext, 'displayName', 'description', 'public', 'http://www.google.ca/firstlink', null, [group.id], null, function(link2) {
+                                                EmailTestUtil.collectAndFetchAllEmails(function(messages) {
+                                                    assert.strictEqual(messages.length, 2);
 
-                                    // Restore mrvisser
-                                    PrincipalsTestUtil.assertRestoreUserSucceeds(camAdminRestContext, mrvisser.user.id, function() {
+                                                    // Ensure the 2 recipients are mrvisser and nico
+                                                    var recipients = _.chain(messages)
+                                                        .pluck('headers')
+                                                        .pluck('to')
+                                                        .value()
+                                                        .sort();
+                                                    assert.deepEqual(recipients, expectedRecipients);
 
-                                        // Simong will trigger another activity, annoying-sauce
-                                        RestAPI.Content.createLink(simong.restContext, 'Google Second', 'Awesome Google', 'public', 'http://www.google.ca/secondlink', [mrvisser.user.id], [], [], function(err, link) {
-                                            assert.ok(!err);
-
-                                            // Collect and ensure mrvisser now gets the email for the latest activity
-                                            EmailTestUtil.collectAndFetchEmailsForBucket(0, 'immediate', null, null, function(messages) {
-                                                assert.strictEqual(messages.length, 1);
-                                                assert.strictEqual(messages[0].to[0].address, mrvisser.user.email);
-
-                                                // Since the second link will aggregate with the first in the feed, we'll now have an email
-                                                // that contains both links that were created aggregated together
-                                                assert.notEqual(messages[0].html.indexOf('Google First'), -1);
-                                                assert.notEqual(messages[0].html.indexOf('Google Second'), -1);
-                                                return callback();
+                                                    return callback();
+                                                });
                                             });
                                         });
                                     });

--- a/node_modules/oae-activity/tests/test-email.js
+++ b/node_modules/oae-activity/tests/test-email.js
@@ -871,7 +871,7 @@ describe('Activity Email', function() {
                 // Ensure we have no emails queued to send
                 EmailTestUtil.collectAndFetchAllEmails(function() {
 
-                    // Generate an email activity for the group, ensuring both
+                    // Generate an email activity for the group, ensuring both mrvisser and nico receive it
                     ContentTestUtil.assertCreateLinkSucceeds(simong.restContext, 'displayName', 'description', 'public', 'http://www.google.ca/firstlink', null, [group.id], null, function(link1) {
                         EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                             assert.strictEqual(messages.length, 2);
@@ -884,14 +884,15 @@ describe('Activity Email', function() {
                                 .sort();
                             assert.deepEqual(recipients, expectedRecipients);
 
-                            // Delete and ensure the same action results in only nico receiving the email
+                            // Delete mrvisser and ensure the same action results in only nico receiving the email
                             PrincipalsTestUtil.assertDeleteUserSucceeds(camAdminRestContext, camAdminRestContext, mrvisser.user.id, function() {
                                 ContentTestUtil.assertCreateLinkSucceeds(simong.restContext, 'displayName', 'description', 'public', 'http://www.google.ca/firstlink', null, [group.id], null, function(link2) {
                                     EmailTestUtil.collectAndFetchAllEmails(function(messages) {
                                         assert.strictEqual(messages.length, 1);
                                         assert.strictEqual(messages[0].headers.to, nico.user.email);
 
-                                        // Restore the user and ensure the same action once again results in an email
+                                        // Restore mrvisser and ensure the same action once again results in an email to both
+                                        // mrvisser and nico
                                         PrincipalsTestUtil.assertRestoreUserSucceeds(camAdminRestContext, mrvisser.user.id, function() {
                                             ContentTestUtil.assertCreateLinkSucceeds(simong.restContext, 'displayName', 'description', 'public', 'http://www.google.ca/firstlink', null, [group.id], null, function(link2) {
                                                 EmailTestUtil.collectAndFetchAllEmails(function(messages) {


### PR DESCRIPTION
It appears the issue fixed in #1216 is no longer taking effect.

At the least, this change seems to have been reverted while pulling inviting-guests into master: https://github.com/oaeproject/Hilary/pull/1216/files#diff-603d08a65509e4f3d08aae9970eaafa0R94

There is obviously also an issue w/ the unit tests that was created for it since it is not failing as a result of this.