### PR TITLE
Allow for templatization of the email From header

### DIFF
--- a/node_modules/oae-email/lib/api.js
+++ b/node_modules/oae-email/lib/api.js
@@ -365,6 +365,7 @@ var sendEmail = module.exports.sendEmail = function(templateModule, templateId, 
     // If the `from` headers aren't set, we generate an intelligent `from` header based on the tenant host
     var tenant = TenantsAPI.getTenant(recipient.tenant.alias);
     var fromName = EmailConfig.getValue(tenant.alias, 'general', 'fromName') || tenant.displayName;
+    fromName = fromName.replace('${tenant}', tenant.displayName);
     var fromAddr = EmailConfig.getValue(tenant.alias, 'general', 'fromAddress') || util.format('noreply@%s', tenant.host);
     var from = util.format('"%s" <%s>', fromName, fromAddr);
 

--- a/node_modules/oae-email/tests/test-email.js
+++ b/node_modules/oae-email/tests/test-email.js
@@ -412,8 +412,12 @@ describe('Emails', function() {
             TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, camUsers, simong, coenego) {
                 assert.ok(!err);
 
-                // Set the `from` header for the email module
-                ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-email/general/fromAddress': 'noreply@blahblahblah.com'}, function(err) {
+                // Configure the `from` header for the email module
+                var config = {
+                    'oae-email/general/fromName': 'The Cambridge Collaborative system',
+                    'oae-email/general/fromAddress': 'noreply@blahblahblah.com'
+                };
+                ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, config, function(err) {
                     assert.ok(!err);
 
                     // Create a new link with the coenego user. The simong user will receive an email
@@ -426,11 +430,12 @@ describe('Emails', function() {
                             assert.ok(messages);
                             assert.ok(!_.isEmpty(messages));
                             assert.strictEqual(messages[0].to[0].address, simong.user.email);
-                            assert.equal(messages[0].from[0].name, 'Cambridge University Test');
+                            assert.equal(messages[0].from[0].name, 'The Cambridge Collaborative system');
                             assert.strictEqual(messages[0].from[0].address, 'noreply@blahblahblah.com');
 
-                            // Clear the `from` header configuration in the email module. This allows the application to compose a tenant based `from` header
-                            RestAPI.Config.clearConfig(camAdminRestContext, null, ['oae-email/general/fromAddress'], function(err) {
+                            // Clear the configuration
+                            var configToClear = ['oae-email/general/fromAddress', 'oae-email/general/fromName'];
+                            RestAPI.Config.clearConfig(camAdminRestContext, null, configToClear, function(err) {
                                 assert.ok(!err);
 
                                 // Create a comment with the simong user. The coenego user will receive an email
@@ -443,11 +448,14 @@ describe('Emails', function() {
                                         assert.ok(messages);
                                         assert.ok(messages.length);
                                         assert.strictEqual(messages[0].to[0].address, coenego.user.email);
-                                        assert.equal(messages[0].from[0].name, 'Cambridge University Test');
-                                        assert.equal(messages[0].from[0].address, util.format('noreply@%s', coenego.restContext.hostHeader));
+                                        assert.equal(messages[0].from[0].name, global.oaeTests.tenants.cam.displayName);
+                                        assert.equal(messages[0].from[0].address, util.format('noreply@%s', global.oaeTests.tenants.cam.host));
 
-                                        // Set the `from` name
-                                        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-email/general/fromName': 'Cambridge Test OAE'}, function(err) {
+                                        // Configure a name with the `${tenant}` variable
+                                        config = {
+                                            'oae-email/general/fromName': 'OAE for ${tenant}'
+                                        };
+                                        ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, config, function(err) {
                                             assert.ok(!err);
 
                                             // Create a comment with the simong user. The coenego user will receive an email
@@ -455,15 +463,43 @@ describe('Emails', function() {
                                                 assert.ok(!err);
                                                 assert.ok(comment);
 
-                                                // Assert that coenego receives an email with `"Cambridge Test OAE" <noreply@cambridge.oae.com>`
+                                                // Assert that coenego receives an email with `"OAE for Cambridge University Test" <noreply@cambridge.oae.com>`
                                                 EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
                                                     assert.ok(messages);
                                                     assert.ok(messages.length);
                                                     assert.strictEqual(messages[0].to[0].address, coenego.user.email);
-                                                    assert.equal(messages[0].from[0].name, 'Cambridge Test OAE');
-                                                    assert.equal(messages[0].from[0].address, util.format('noreply@%s', coenego.restContext.hostHeader));
+                                                    assert.equal(messages[0].from[0].name, 'OAE for ' + global.oaeTests.tenants.cam.displayName);
+                                                    assert.equal(messages[0].from[0].address, util.format('noreply@%s', global.oaeTests.tenants.cam.host));
 
-                                                    return callback();
+                                                    // Sanity check that the from header can be configured on a global level
+                                                    configToClear = ['oae-email/general/fromAddress', 'oae-email/general/fromName'];
+                                                    RestAPI.Config.clearConfig(camAdminRestContext, null, configToClear, function(err) {
+                                                        assert.ok(!err);
+                                                        var globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
+                                                        config = {
+                                                            'oae-email/general/fromName': 'The glorious OAE for ${tenant}'
+                                                        };
+                                                        ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, null, config, function(err) {
+                                                            assert.ok(!err);
+
+                                                            // Create a comment with the simong user. The coenego user will receive an email
+                                                            RestAPI.Content.createComment(simong.restContext, link.id, 'I am going to share this with all my friends!', null, function(err, comment) {
+                                                                assert.ok(!err);
+                                                                assert.ok(comment);
+
+                                                                // Assert that coenego receives an email with `"The glorious OAE for Cambridge University Test" <noreply@cambridge.oae.com>`
+                                                                EmailTestsUtil.collectAndFetchAllEmails(function(messages) {
+                                                                    assert.ok(messages);
+                                                                    assert.ok(messages.length);
+                                                                    assert.strictEqual(messages[0].to[0].address, coenego.user.email);
+                                                                    assert.equal(messages[0].from[0].name, 'The glorious OAE for ' + global.oaeTests.tenants.cam.displayName);
+                                                                    assert.equal(messages[0].from[0].address, util.format('noreply@%s', global.oaeTests.tenants.cam.host));
+
+                                                                    return callback();
+                                                                });
+                                                            });
+                                                        });
+                                                    });
                                                 });
                                             });
                                         });


### PR DESCRIPTION
Allow for the email From header configuration to contain `${tenant}`, which is then replaced by the tenant display name. This will be used to achieve the new default From header: `*Unity for <tenantName>` without requiring a custom configuration value for every tenant.