### PR TITLE
Make tenant email domain lower-cased when stored

### DIFF
--- a/node_modules/oae-authz/tests/test-invitations.js
+++ b/node_modules/oae-authz/tests/test-invitations.js
@@ -680,6 +680,41 @@ describe('Invitations', function() {
         });
 
         /**
+         * Test that verifies an email domain is case insensitive when choosing
+         * an invitation tenant
+         */
+        it('verify tenant email domain is case insensitive for choosing an invitation tenant', function(callback) {
+            var fns = resourceFns.content;
+            var tenantAlias = TenantsTestUtil.generateTestTenantAlias();
+            var tenantHost = TenantsTestUtil.generateTestTenantHost();
+            TestsUtil.createTenantWithAdmin(tenantAlias, tenantHost, function(err, tenant, tenantAdminRestContext) {
+                assert.ok(!err);
+                TestsUtil.generateTestUsers(tenantAdminRestContext, 1, function(err, users, user) {
+                    assert.ok(!err);
+
+                    // Use an email that differs from the tenant email domain
+                    // only by case
+                    var matchingEmailDomain = tenantHost.toUpperCase();
+                    var matchingEmail = _emailForDomain(matchingEmailDomain);
+                    fns.createSucceeds(user.restContext, 'public', [matchingEmail], [], function(resource) {
+                        EmailTestUtil.collectAndFetchAllEmails(function(messages) {
+                            assert.strictEqual(messages.length, 1);
+
+                            var message = _.first(messages);
+                            var toEmail = message.headers.to;
+                            var invitationUrl = AuthzTestUtil.parseInvitationUrlFromMessage(message);
+
+                            assert.strictEqual(toEmail, matchingEmail.toLowerCase());
+                            assert.strictEqual(invitationUrl.host, tenant.host);
+
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies it sends an aggregated email for all resource types
          */
         it('verify it sends an aggregated email for each resource type', function(callback) {

--- a/node_modules/oae-search/tests/test-tenants-search.js
+++ b/node_modules/oae-search/tests/test-tenants-search.js
@@ -77,17 +77,17 @@ describe('Tenants Search', function() {
                             assert.strictEqual(result.total, 1);
                             assert.strictEqual(result.results[0].alias, alias);
                             assert.strictEqual(result.results[0].displayName, displayName);
-                            assert.strictEqual(result.results[0].host, host);
+                            assert.strictEqual(result.results[0].host, host.toLowerCase());
                             SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': displayName.toLowerCase()}, function(result) {
                                 assert.strictEqual(result.total, 1);
                                 assert.strictEqual(result.results[0].alias, alias);
                                 assert.strictEqual(result.results[0].displayName, displayName);
-                                assert.strictEqual(result.results[0].host, host);
+                                assert.strictEqual(result.results[0].host, host.toLowerCase());
                                 SearchTestsUtil.assertSearchSucceeds(anonymousRestContext, 'tenants', null, {'q': host.toLowerCase()}, function(result) {
                                     assert.strictEqual(result.total, 1);
                                     assert.strictEqual(result.results[0].alias, alias);
                                     assert.strictEqual(result.results[0].displayName, displayName);
-                                    assert.strictEqual(result.results[0].host, host);
+                                    assert.strictEqual(result.results[0].host, host.toLowerCase());
                                     return callback();
                                 });
                             });

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -603,7 +603,7 @@ var updateTenant = module.exports.updateTenant = function(ctx, alias, tenantUpda
         } else if (updateField === 'host') {
             // Ensure the tenant host name is all lower case
             updateValue = updateValue.toLowerCase();
-            updateFields[updateField] = updateValue;
+            tenantUpdates[updateField] = updateValue;
 
             // Validate the lower-cased version
             validator.check(updateValue, {'code': 400, 'msg': 'A hostname cannot be empty'}).notEmpty();
@@ -612,7 +612,7 @@ var updateTenant = module.exports.updateTenant = function(ctx, alias, tenantUpda
         } else if (updateField === 'emailDomain') {
             // Ensure the tenant email domain is all lower case
             updateValue = updateValue.toLowerCase();
-            updateFields[updateField] = updateValue;
+            tenantUpdates[updateField] = updateValue;
 
             // Only a global admin can update the email domain
             validator.check(null, {'code': 401, 'msg': 'Only a global administrator can update the email domain'}).isGlobalAdministratorUser(ctx);
@@ -845,7 +845,7 @@ var _copyTenant = function(tenant) {
  */
 var _storageHashToTenant = function(alias, hash) {
     return new Tenant(alias, hash.displayName, hash.host.toLowerCase(), {
-        'emailDomain': hash.emailDomain,
+        'emailDomain': (hash.emailDomain && hash.emailDomain.toLowerCase()),
         'countryCode': hash.countryCode,
         'active': hash.active,
         'isGuestTenant': (alias === serverConfig.guestTenantAlias)

--- a/node_modules/oae-tenants/lib/internal/emailDomainIndex.js
+++ b/node_modules/oae-tenants/lib/internal/emailDomainIndex.js
@@ -197,7 +197,7 @@ var EmailDomainIndex = module.exports = function() {
          * @return {String}                     If specified, it is one of potential many aliases that conflicted. If `false`y, there was no conflict
          */
         'conflict': function(alias, emailDomain) {
-            return _conflict(alias, emailDomain);
+            return _conflict(alias, _toLowerCase(emailDomain));
         },
 
         /**
@@ -207,7 +207,7 @@ var EmailDomainIndex = module.exports = function() {
          * @return {String}                     The alias that was set for the matching domain, if any. If there are no matches, this will return `false`y
          */
         'match': function(emailDomain) {
-            return _match(emailDomain);
+            return _match(_toLowerCase(emailDomain));
         },
 
         /**
@@ -221,6 +221,9 @@ var EmailDomainIndex = module.exports = function() {
          * @param  {String}     [oldEmailDomain]    The previous email domain to which the alias was associated, if any
          */
         'update': function(alias, emailDomain, oldEmailDomain) {
+            emailDomain = _toLowerCase(emailDomain);
+            oldEmailDomain = _toLowerCase(oldEmailDomain);
+
             // Do nothing if there is no change to the email domain
             if (emailDomain === oldEmailDomain) {
                 return;
@@ -266,6 +269,21 @@ var _findStringLeaves = function(obj, _leaves) {
 
     // Return all the aggregated string leaf nodes
     return _leaves;
+};
+
+/**
+ * Lower case the given string if specified
+ *
+ * @param  {String}     [str]   The string to lower-case
+ * @return {String}             The string lower cased. If the string was falsey, will be returned verbatim
+ * @api private
+ */
+var _toLowerCase = function(str) {
+    if (str) {
+        return str.toLowerCase();
+    }
+
+    return str;
 };
 
 /**

--- a/node_modules/oae-tenants/lib/test/util.js
+++ b/node_modules/oae-tenants/lib/test/util.js
@@ -191,7 +191,7 @@ var generateTestTenantAlias = module.exports.generateTestTenantAlias = function(
  */
 var generateTestTenantHost = module.exports.generateTestTenantHost = function(seed) {
     seed = seed || 'host';
-    return util.format('%s-%s.local', seed, TestsUtil.generateRandomText()).toLowerCase();
+    return util.format('%s-%s.local', seed, TestsUtil.generateRandomText());
 };
 
 /**

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -63,15 +63,15 @@ describe('Tenants', function() {
             // Cambridge tenants
             {
                 'alias': 'cam-caret',
-                'domain': 'caret.cam.ac.uk'
+                'domain': 'Caret.Cam.Ac.Uk'
             },
             {
                 'alias': 'cam-uis',
-                'domain': 'uis.cam.ac.uk'
+                'domain': 'Uis.cam.ac.uk'
             },
             {
                 'alias': 'cam-library',
-                'domain': 'library.cam.ac.uk'
+                'domain': 'library.Cam.Ac.Uk'
             },
 
             // Oxford tenants
@@ -116,8 +116,11 @@ describe('Tenants', function() {
             var prefixes = [
                 '',
                 'something',
+                'Something',
                 'something.else',
+                'SOMETHING.else',
                 'cam-caret',
+                'Cam-Caret',
                 'cam-uis',
                 'cam-library',
                 'ox-caret',
@@ -133,11 +136,21 @@ describe('Tenants', function() {
                 .mapObject(function(entry) {
                     return entry.alias;
                 })
+                .tap(function(obj) {
+                    // In addition to the aliases, use upper-case versions of
+                    // them as well to match
+                    _.each(obj, function(alias, domain) {
+                        obj[domain.toUpperCase()] = alias;
+                    });
+                })
                 .value();
 
             var nonMatchingSuffixes = [
                 'com',
+                'Com',
+                'COM',
                 'something.com',
+                'Something.Com',
                 '*',
                 '',
                 'uk',
@@ -412,8 +425,8 @@ describe('Tenants', function() {
                         assert.strictEqual(tenants['gttest'].host, 'gt.oae.com');
                         assert.strictEqual(tenants['camtest'].host, 'cambridge.oae.com');
                         assert.ok(tenants[tenantAlias]);
-                        assert.strictEqual(tenants[tenantAlias].host, tenantHost);
-                        assert.strictEqual(tenants[tenantAlias].emailDomain, tenantEmailDomain);
+                        assert.strictEqual(tenants[tenantAlias].host, tenantHost.toLowerCase());
+                        assert.strictEqual(tenants[tenantAlias].emailDomain, tenantEmailDomain.toLowerCase());
                         assert.strictEqual(_.keys(tenants).length, numTenants + 1);
 
                         // Verify that the global admin tenant is not included
@@ -440,27 +453,27 @@ describe('Tenants', function() {
                 RestAPI.Tenants.getTenant(anonymousRestContext, null, function(err, tenant) {
                     assert.ok(!err);
                     assert.strictEqual(tenant.alias, tenantAlias);
-                    assert.strictEqual(tenant.host, tenantHost);
-                    assert.strictEqual(tenant.emailDomain, tenantEmailDomain);
+                    assert.strictEqual(tenant.host, tenantHost.toLowerCase());
+                    assert.strictEqual(tenant.emailDomain, tenantEmailDomain.toLowerCase());
 
                     // Verify that the tenant information is available through the global tenant
                     RestAPI.Tenants.getTenant(globalAdminRestContext, tenantAlias, function(err, tenant) {
                         assert.ok(!err);
                         assert.strictEqual(tenant.alias, tenantAlias);
-                        assert.strictEqual(tenant.host, tenantHost);
-                        assert.strictEqual(tenant.emailDomain, tenantEmailDomain);
+                        assert.strictEqual(tenant.host, tenantHost.toLowerCase());
+                        assert.strictEqual(tenant.emailDomain, tenantEmailDomain.toLowerCase());
 
                         // Get the tenant by host name
                         var tenantByHost = TenantsAPI.getTenantByHost(tenantHost);
                         assert.strictEqual(tenantByHost.alias, tenantAlias);
-                        assert.strictEqual(tenantByHost.host, tenantHost);
-                        assert.strictEqual(tenantByHost.emailDomain, tenantEmailDomain);
+                        assert.strictEqual(tenantByHost.host, tenantHost.toLowerCase());
+                        assert.strictEqual(tenantByHost.emailDomain, tenantEmailDomain.toLowerCase());
 
                         // Get the tenant by email domain
                         var tenantByEmailDomain = TenantsAPI.getTenantByEmail(tenantEmailDomain);
                         assert.strictEqual(tenantByEmailDomain.alias, tenantAlias);
-                        assert.strictEqual(tenantByEmailDomain.host, tenantHost);
-                        assert.strictEqual(tenantByEmailDomain.emailDomain, tenantEmailDomain);
+                        assert.strictEqual(tenantByEmailDomain.host, tenantHost.toLowerCase());
+                        assert.strictEqual(tenantByEmailDomain.emailDomain, tenantEmailDomain.toLowerCase());
 
                         return callback();
                     });
@@ -595,57 +608,57 @@ describe('Tenants', function() {
                     var gotTenant1 = TenantsAPI.getTenantByEmail(tenant1Opts.emailDomain);
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
-                    assert.strictEqual(gotTenant1.host, tenant1Host);
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain);
+                    assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
 
                     // Ensure we can get tenant 1 with an email address by an exact match
                     gotTenant1 = TenantsAPI.getTenantByEmail(util.format('mrvisser@%s', tenant1Opts.emailDomain));
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
-                    assert.strictEqual(gotTenant1.host, tenant1Host);
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain);
+                    assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
 
                     // Ensure we can get tenant 1 by a valid host suffix
                     gotTenant1 = TenantsAPI.getTenantByEmail(util.format('prefix.%s', tenant1Opts.emailDomain));
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
-                    assert.strictEqual(gotTenant1.host, tenant1Host);
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain);
+                    assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
 
                     // Ensure we can get tenant 1 by a valid host suffix in an email address
                     gotTenant1 = TenantsAPI.getTenantByEmail(util.format('mrvisser@prefix.%s', tenant1Opts.emailDomain));
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
-                    assert.strictEqual(gotTenant1.host, tenant1Host);
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain);
+                    assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
 
                     // Ensure we can get tenant 2 by an exact match
                     var gotTenant2 = TenantsAPI.getTenantByEmail(tenant2Opts.emailDomain);
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
-                    assert.strictEqual(gotTenant2.host, tenant2Host);
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain);
+                    assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
 
                     // Ensure we can get tenant 2 by an email address domain exact match
                     gotTenant2 = TenantsAPI.getTenantByEmail(util.format('mrvisser@%s', tenant2Opts.emailDomain));
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
-                    assert.strictEqual(gotTenant2.host, tenant2Host);
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain);
+                    assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
 
                     // Ensure we can get tenant 2 by a valid host suffix
                     gotTenant2 = TenantsAPI.getTenantByEmail(util.format('prefix.%s', tenant2Opts.emailDomain));
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
-                    assert.strictEqual(gotTenant2.host, tenant2Host);
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain);
+                    assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
 
                     // Ensure we can get tenant 2 by an email address with a valid host suffix
                     gotTenant2 = TenantsAPI.getTenantByEmail(util.format('mrvisser@prefix.%s', tenant2Opts.emailDomain));
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
-                    assert.strictEqual(gotTenant2.host, tenant2Host);
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain);
+                    assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
 
                     // Some subtle things that should fall back to the guest tenant:
                     var shouldBeGuest = [
@@ -824,7 +837,8 @@ describe('Tenants', function() {
                 assert.ok(!err);
                 assert.ok(tenant);
                 assert.strictEqual(tenant.alias, tenantAlias);
-                assert.strictEqual(tenant.host, tenantHost);
+                assert.strictEqual(tenant.host, tenantHost.toLowerCase());
+                assert.ok(!tenant.emailDomain);
                 assert.strictEqual(tenant.countryCode, 'CA');
 
                 // Get the tenant
@@ -833,14 +847,16 @@ describe('Tenants', function() {
                     assert.ok(!err);
                     assert.ok(tenant);
                     assert.strictEqual(tenant.alias, tenantAlias);
-                    assert.strictEqual(tenant.host, tenantHost);
+                    assert.strictEqual(tenant.host, tenantHost.toLowerCase());
+                    assert.ok(!tenant.emailDomain);
                     assert.strictEqual(tenant.countryCode, 'CA');
 
                     // Get the tenant by host
                     tenant = TenantsAPI.getTenantByHost(tenantHost);
                     assert.ok(tenant);
                     assert.strictEqual(tenant.alias, tenantAlias);
-                    assert.strictEqual(tenant.host, tenantHost);
+                    assert.strictEqual(tenant.host, tenantHost.toLowerCase());
+                    assert.ok(!tenant.emailDomain);
                     assert.strictEqual(tenant.countryCode, 'CA');
                     return callback();
                 });
@@ -967,14 +983,17 @@ describe('Tenants', function() {
         });
 
         /**
-         * Test that verifies that an uppercase host name for a tenant is lowercased and a tenant can be retrieved using an uppercase host name
+         * Test that verifies that an uppercase host and email domain for a
+         * tenant is lowercased and a tenant can be retrieved using an uppercase
+         * host name or email domain
          */
-        it('verify create tenant uppercase host', function(callback) {
+        it('verify create and update tenant uppercase host and email domain', function(callback) {
             var tenantAlias = TenantsTestUtil.generateTestTenantAlias();
             var tenantDescription = TestsUtil.generateRandomText();
             var tenantHost = TestsUtil.generateRandomText().toUpperCase();
+            var tenantHost2 = TestsUtil.generateRandomText().toUpperCase();
 
-            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, null, function(err) {
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, {'emailDomain': tenantHost}, function(err) {
                 assert.ok(!err);
 
                 // Verify that the existing tenant is still running
@@ -982,9 +1001,48 @@ describe('Tenants', function() {
                 RestAPI.Tenants.getTenant(uppercaseRestContext, null, function(err, tenant) {
                     assert.ok(!err);
                     assert.ok(tenant);
-                    assert.equal(tenant.alias, tenantAlias);
-                    assert.equal(tenant.host, tenantHost.toLowerCase());
-                    return callback();
+                    assert.strictEqual(tenant.alias, tenantAlias);
+                    assert.strictEqual(tenant.host, tenantHost.toLowerCase());
+                    assert.strictEqual(tenant.emailDomain, tenantHost.toLowerCase());
+
+                    // Verify we can get the tenant by email match
+                    var tenantByEmailMatch = TenantsAPI.getTenantByEmail(tenantHost);
+                    assert.ok(tenantByEmailMatch);
+                    assert.strictEqual(tenantByEmailMatch.alias, tenantAlias);
+                    assert.strictEqual(tenantByEmailMatch.host, tenantHost.toLowerCase());
+                    assert.strictEqual(tenantByEmailMatch.emailDomain, tenantHost.toLowerCase());
+
+                    // Update the tenant, ensuring that the host and email
+                    // domain remain lower case
+                    RestAPI.Tenants.updateTenant(globalAdminRestContext, tenantAlias, {'host': tenantHost2, 'emailDomain': tenantHost2}, function(err, updatedTenant) {
+                        assert.ok(!err);
+
+                        uppercaseRestContext = TestsUtil.createTenantRestContext(tenantHost2);
+                        RestAPI.Tenants.getTenant(uppercaseRestContext, null, function(err, tenant2) {
+                            assert.ok(!err);
+                            assert.ok(tenant2);
+                            assert.strictEqual(tenant2.alias, tenantAlias);
+                            assert.strictEqual(tenant2.host, tenantHost2.toLowerCase());
+                            assert.strictEqual(tenant2.emailDomain, tenantHost2.toLowerCase());
+
+
+                            // Verify we can still get the tenant by email domain
+                            // match
+                            tenantByEmailMatch = TenantsAPI.getTenantByEmail(tenantHost2);
+                            assert.ok(tenantByEmailMatch);
+                            assert.strictEqual(tenantByEmailMatch.alias, tenantAlias);
+                            assert.strictEqual(tenantByEmailMatch.host, tenantHost2.toLowerCase());
+                            assert.strictEqual(tenantByEmailMatch.emailDomain, tenantHost2.toLowerCase());
+
+                            tenantByEmailMatch = TenantsAPI.getTenantByEmail(tenantHost2.toLowerCase());
+                            assert.ok(tenantByEmailMatch);
+                            assert.strictEqual(tenantByEmailMatch.alias, tenantAlias);
+                            assert.strictEqual(tenantByEmailMatch.host, tenantHost2.toLowerCase());
+                            assert.strictEqual(tenantByEmailMatch.emailDomain, tenantHost2.toLowerCase());
+
+                            return callback();
+                        });
+                    });
                 });
             });
         });
@@ -1005,7 +1063,7 @@ describe('Tenants', function() {
                     assert.ok(!err);
                     assert.ok(tenant);
                     assert.equal(tenant.alias, tenantAlias.toLowerCase());
-                    assert.equal(tenant.host, tenantHost);
+                    assert.equal(tenant.host, tenantHost.toLowerCase());
                     callback();
                 });
             });
@@ -1472,10 +1530,10 @@ describe('Tenants', function() {
                                                         // Sanity check that the email domains are now set to what we would expect
                                                         RestAPI.Tenants.getTenant(tenantAdminRestContext, null, function(err, tenant) {
                                                             assert.ok(!err);
-                                                            assert.strictEqual(tenant.emailDomain, emailDomain1SuffixConflict1);
+                                                            assert.strictEqual(tenant.emailDomain, emailDomain1SuffixConflict1.toLowerCase());
                                                             RestAPI.Tenants.getTenant(globalAdminRestContext, uniqueString2, function(err, tenant) {
                                                                 assert.ok(!err);
-                                                                assert.strictEqual(tenant.emailDomain, emailDomain2);
+                                                                assert.strictEqual(tenant.emailDomain, emailDomain2.toLowerCase());
 
                                                                 return callback();
                                                             });
@@ -1544,7 +1602,7 @@ describe('Tenants', function() {
                                         assert.ok(!err);
                                         assert.ok(tenant);
                                         assert.equal(tenant.alias, 'camtest');
-                                        assert.equal(tenant.host, tenant1Host);
+                                        assert.equal(tenant.host, tenant1Host.toLowerCase());
                                         assert.equal(tenant.displayName, 'Queens College');
 
                                         // Update the tenant host to have uppercase characters
@@ -1558,7 +1616,7 @@ describe('Tenants', function() {
                                                 assert.ok(!err);
                                                 assert.ok(tenant);
                                                 assert.equal(tenant.alias, 'camtest');
-                                                assert.equal(tenant.host, tenant2Host);
+                                                assert.equal(tenant.host, tenant2Host.toLowerCase());
                                                 assert.equal(tenant.displayName, 'Queens College');
 
                                                 // Update the tenant host as the tenant admin
@@ -1576,7 +1634,7 @@ describe('Tenants', function() {
                                                             assert.ok(!err);
                                                             assert.ok(tenant);
                                                             assert.equal(tenant.alias, 'camtest');
-                                                            assert.equal(tenant.host, tenant3Host);
+                                                            assert.equal(tenant.host, tenant3Host.toLowerCase());
                                                             assert.equal(tenant.displayName, 'Queens College');
 
                                                             // Update the tenant display name and host as the tenant admin
@@ -1594,7 +1652,7 @@ describe('Tenants', function() {
                                                                         assert.ok(!err);
                                                                         assert.ok(tenant);
                                                                         assert.equal(tenant.alias, 'camtest');
-                                                                        assert.equal(tenant.host, tenant4Host);
+                                                                        assert.equal(tenant.host, tenant4Host.toLowerCase());
                                                                         assert.equal(tenant.displayName, tenant4Description);
 
                                                                         // Update the tenant display name and host as the tenant admin

--- a/node_modules/oae-tincanapi/tests/test-tincanapi.js
+++ b/node_modules/oae-tincanapi/tests/test-tincanapi.js
@@ -59,7 +59,7 @@ describe('TinCanAPI', function() {
                 onRequest(req);
                 res.send(200);
             });
-            
+
             // Set the endpoint for the LRS
             ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-tincanapi/lrs/endpoint': 'http://localhost:' + _port}, function(err) {
                 assert.ok(!err);

--- a/node_modules/oae-ui/tests/test-ui.js
+++ b/node_modules/oae-ui/tests/test-ui.js
@@ -440,7 +440,8 @@ describe('UI', function() {
         it('verify skin url variables are overridden by hash file mappings', function(callback) {
             // Create a fresh tenant to test against so we can ensure there are no skin variable overrides yet
             var testTenantAlias = TenantsTestUtil.generateTestTenantAlias();
-            TestsUtil.createTenantWithAdmin(testTenantAlias, testTenantAlias, function(err, testTenant, testTenantAdminRestContext) {
+            var testTenantHost = TenantsTestUtil.generateTestTenantHost();
+            TestsUtil.createTenantWithAdmin(testTenantAlias, testTenantHost, function(err, testTenant, testTenantAdminRestContext) {
                 assert.ok(!err);
 
                 RestAPI.UI.getSkinVariables(globalAdminRestContext, testTenantAlias, function(err, variables) {


### PR DESCRIPTION
Currently it validates and does everything case-insensitive. But the stored version is original case. Perhaps it should be lower cased in storage.