### PR TITLE
There is an unused folder visibility configuration in the content module

### DIFF
--- a/node_modules/oae-content/config/content.js
+++ b/node_modules/oae-content/config/content.js
@@ -62,20 +62,6 @@ module.exports = {
                     'name': 'Private',
                     'value': 'private'
                 }
-            ]),
-            'folders': new Fields.List('Folders Visibility', 'Default visibility for new folders', 'public', [
-                {
-                    'name': 'Public',
-                    'value': 'public'
-                },
-                {
-                    'name': 'Logged in users',
-                    'value': 'loggedin'
-                },
-                {
-                    'name': 'Private',
-                    'value': 'private'
-                }
             ])
         }
     }


### PR DESCRIPTION
There appears to be a configuration for folders visibility in both the `oae-content/config/content.js` and `oae-folders/config/folders.js` file.

Only the `oae-folders/config/folders.js` is used, so we should be able to just remove the oae-content version of this configuration.