### PR TITLE
(3akai-ux Issue 4086) Fix comment link replacement issues with hosts that contain an 's'

### DIFF
--- a/node_modules/oae-messagebox/lib/api.js
+++ b/node_modules/oae-messagebox/lib/api.js
@@ -32,7 +32,7 @@ var DURATION_RECENT_CONTRIBUTIONS_SECONDS = 30 * 24 * 60 * 60;
 
 // A regex that will find links in the body. Note that we capture the characters just before and
 // after the URL so we can determine whether the URL is already provided in markdown format
-var REGEXP_LINK = new RegExp('(.?)https?://([^/\r\n\s]+)(/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])(.?)', 'gi');
+var REGEXP_LINK = new RegExp('(.?)https?://([^/\r\n ]+)(/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])(.?)', 'gi');
 
 /**
  * ### Events

--- a/node_modules/oae-messagebox/lib/api.js
+++ b/node_modules/oae-messagebox/lib/api.js
@@ -32,7 +32,7 @@ var DURATION_RECENT_CONTRIBUTIONS_SECONDS = 30 * 24 * 60 * 60;
 
 // A regex that will find links in the body. Note that we capture the characters just before and
 // after the URL so we can determine whether the URL is already provided in markdown format
-var REGEXP_LINK = new RegExp('(.?)https?://([^/\r\n ]+)(/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])(.?)', 'gi');
+var REGEXP_LINK = new RegExp('(.?)https?://([^/\\r\\n\\s]+)(/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])(.?)', 'gi');
 
 /**
  * ### Events

--- a/node_modules/oae-messagebox/tests/test-messagebox.js
+++ b/node_modules/oae-messagebox/tests/test-messagebox.js
@@ -18,6 +18,9 @@ var assert = require('assert');
 var ShortId = require('shortid');
 var util = require('util');
 
+var TenantsTestUtil = require('oae-tenants/lib/test/util');
+var TestsUtil = require('oae-tests/lib/util');
+
 var MessageBoxAPI = require('oae-messagebox');
 
 describe('Messagebox', function() {
@@ -163,47 +166,54 @@ describe('Messagebox', function() {
          * Test that verifies absolute link replacement in created messages
          */
         it('verify replacing bare, absolute OAE links in new message', function(callback) {
-            var url = '/path/-Z9+&@#%=~_|!:,.;/file?query=parameter#hash';
-            var messageBoxId = util.format('msg-box-test-%s', ShortId.generate());
-            MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', 'URL: http://cambridge.oae.com' + url + ' more', {}, function(err, message) {
+            // Test with a tenant that contains every letter in the alphabet in
+            // the host: https://github.com/oaeproject/3akai-ux/issues/4086
+            var newTenantAlias = TenantsTestUtil.generateTestTenantAlias();
+            var tenantHost = 'abcdefghijklmnop.qrstuvw.xyz';
+            TestsUtil.createTenantWithAdmin(newTenantAlias, tenantHost, function(err, tenant, tenantAdminRestContext) {
                 assert.ok(!err);
 
-                // Verify the link was replaced
-                MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
+                var url = '/path/-Z9+&@#%=~_|!:,.;/file?query=parameter#hash';
+                var messageBoxId = util.format('msg-box-test-%s', ShortId.generate());
+                MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URL: http://%s%s more', tenantHost, url), {}, function(err, message) {
                     assert.ok(!err);
-                    verifyMessage(messages[0].id, 'URL: [' + url + '](' + url + ') more', null, messages);
 
-                    // Verify multiple links
-                    var fullUrl = 'http://cambridge.oae.com' + url;
-                    MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', 'URLs: ' + fullUrl + ' ' + fullUrl, {}, function(err, message) {
+                    // Verify the link was replaced
+                    MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                         assert.ok(!err);
+                        verifyMessage(messages[0].id, util.format('URL: [%s](%s) more', url, url), null, messages);
 
-                        // Verify the link was replaced
-                        MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
+                        // Verify multiple links
+                        var fullUrl = util.format('http://%s%s', tenantHost, url);
+                        MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URLs: %s %s', fullUrl, fullUrl), {}, function(err, message) {
                             assert.ok(!err);
-                            var markdownFullUrl = '[' + url + '](' + url + ')';
-                            verifyMessage(messages[0].id, 'URLs: ' + markdownFullUrl + ' ' + markdownFullUrl, null, messages);
 
-                            // Verify multiple markdown links
-                            var markdownFullAbsoluteUrl = '[' + url + '](https://cambridge.oae.com' + url + ')';
-                            MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', 'URLs: ' + markdownFullUrl  + markdownFullUrl, {}, function(err, message) {
+                            // Verify the link was replaced
+                            MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                                 assert.ok(!err);
+                                var markdownFullUrl = util.format('[%s](%s)', url, url);
+                                verifyMessage(messages[0].id, util.format('URLs: %s %s', markdownFullUrl, markdownFullUrl), null, messages);
 
-                                // Verify the link was replaced
-                                MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
+                                // Verify multiple markdown links
+                                var markdownFullAbsoluteUrl = util.format('[%s](https://%s%s)', url, tenantHost, url);
+                                MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URLs: %s%s', markdownFullUrl, markdownFullUrl), {}, function(err, message) {
                                     assert.ok(!err);
-                                    var markdownFullUrl = '[' + url + '](' + url + ')';
-                                    verifyMessage(messages[0].id, 'URLs: ' + markdownFullUrl + markdownFullUrl, null, messages);
 
-                                    // Verify that quoted links aren't replaced
-                                    var quotedMarkdown = '`' + fullUrl + '` ` text ' + fullUrl + '`\n    ' + fullUrl + '\n\n    ' + fullUrl + '\n    text ' + fullUrl;
-                                    MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', quotedMarkdown, {}, function(err, message) {
+                                    // Verify the link was replaced
+                                    MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                                         assert.ok(!err);
-                                        MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
+                                        verifyMessage(messages[0].id, util.format('URLs: %s%s', markdownFullUrl, markdownFullUrl), null, messages);
+
+                                        // Verify that quoted links aren't replaced
+                                        var quotedMarkdown = util.format('`%s` ` text %s`\n    %s\n\n    %s\n    text %s', fullUrl, fullUrl, fullUrl, fullUrl, fullUrl);
+                                        MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', quotedMarkdown, {}, function(err, message) {
                                             assert.ok(!err);
-                                            var quotedExpected = '`' + fullUrl + '` ` text ' + fullUrl + '`\n    ' + markdownFullUrl + '\n\n    ' + fullUrl + '\n    text ' + fullUrl;
-                                            verifyMessage(messages[0].id, quotedExpected, null, messages);
-                                            return callback();
+                                            MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
+                                                assert.ok(!err);
+                                                var quotedExpected = util.format('`%s` ` text %s`\n    %s\n\n    %s\n    text %s', fullUrl, fullUrl, markdownFullUrl, fullUrl, fullUrl);
+                                                verifyMessage(messages[0].id, quotedExpected, null, messages);
+                                                return callback();
+                                            });
                                         });
                                     });
                                 });

--- a/node_modules/oae-messagebox/tests/test-messagebox.js
+++ b/node_modules/oae-messagebox/tests/test-messagebox.js
@@ -173,43 +173,46 @@ describe('Messagebox', function() {
             TestsUtil.createTenantWithAdmin(newTenantAlias, tenantHost, function(err, tenant, tenantAdminRestContext) {
                 assert.ok(!err);
 
-                var url = '/path/-Z9+&@#%=~_|!:,.;/file?query=parameter#hash';
+                var path = '/path/-Z9+&@#%=~_|!:,.;/file?query=parameter#hash';
+                var httpUrl = util.format('http://%s%s', tenantHost, path);
+                var httpsUrl = util.format('https://%s%s', tenantHost, path);
+                var markdownPath = util.format('[%s](%s)', path, path);
+                var markdownHttpUrl = util.format('[%s](%s)', httpUrl, httpUrl);
+
                 var messageBoxId = util.format('msg-box-test-%s', ShortId.generate());
-                MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URL: http://%s%s more', tenantHost, url), {}, function(err, message) {
+                MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URL: %s more', httpUrl), {}, function(err, message) {
                     assert.ok(!err);
 
                     // Verify the link was replaced
                     MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                         assert.ok(!err);
-                        verifyMessage(messages[0].id, util.format('URL: [%s](%s) more', url, url), null, messages);
+                        verifyMessage(messages[0].id, util.format('URL: %s more', markdownPath), null, messages);
 
                         // Verify multiple links
-                        var fullUrl = util.format('http://%s%s', tenantHost, url);
-                        MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URLs: %s %s', fullUrl, fullUrl), {}, function(err, message) {
+                        MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URLs: %s %s', httpUrl, httpUrl), {}, function(err, message) {
                             assert.ok(!err);
 
                             // Verify the link was replaced
                             MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                                 assert.ok(!err);
-                                var markdownFullUrl = util.format('[%s](%s)', url, url);
-                                verifyMessage(messages[0].id, util.format('URLs: %s %s', markdownFullUrl, markdownFullUrl), null, messages);
+                                verifyMessage(messages[0].id, util.format('URLs: %s %s', markdownPath, markdownPath), null, messages);
 
                                 // Verify multiple markdown links
-                                MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URLs: %s%s', markdownFullUrl, markdownFullUrl), {}, function(err, message) {
+                                MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URLs: %s%s', markdownHttpUrl, markdownHttpUrl), {}, function(err, message) {
                                     assert.ok(!err);
 
                                     // Verify the link was replaced
                                     MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                                         assert.ok(!err);
-                                        verifyMessage(messages[0].id, util.format('URLs: %s%s', markdownFullUrl, markdownFullUrl), null, messages);
+                                        verifyMessage(messages[0].id, util.format('URLs: %s%s', markdownPath, markdownPath), null, messages);
 
                                         // Verify that quoted links aren't replaced
-                                        var quotedMarkdown = util.format('`%s` ` text %s`\n    %s\n\n    %s\n    text %s', fullUrl, fullUrl, fullUrl, fullUrl, fullUrl);
+                                        var quotedMarkdown = util.format('`%s` ` text %s`\n    %s\n\n    %s\n    text %s', httpsUrl, httpsUrl, httpsUrl, httpsUrl, httpsUrl);
                                         MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', quotedMarkdown, {}, function(err, message) {
                                             assert.ok(!err);
                                             MessageBoxAPI.getMessagesFromMessageBox(messageBoxId, null, null, null, function(err, messages) {
                                                 assert.ok(!err);
-                                                var quotedExpected = util.format('`%s` ` text %s`\n    %s\n\n    %s\n    text %s', fullUrl, fullUrl, markdownFullUrl, fullUrl, fullUrl);
+                                                var quotedExpected = util.format('`%s` ` text %s`\n    %s\n\n    %s\n    text %s', httpsUrl, httpsUrl, markdownPath, httpsUrl, httpsUrl);
                                                 verifyMessage(messages[0].id, quotedExpected, null, messages);
                                                 return callback();
                                             });

--- a/node_modules/oae-messagebox/tests/test-messagebox.js
+++ b/node_modules/oae-messagebox/tests/test-messagebox.js
@@ -195,7 +195,6 @@ describe('Messagebox', function() {
                                 verifyMessage(messages[0].id, util.format('URLs: %s %s', markdownFullUrl, markdownFullUrl), null, messages);
 
                                 // Verify multiple markdown links
-                                var markdownFullAbsoluteUrl = util.format('[%s](https://%s%s)', url, tenantHost, url);
                                 MessageBoxAPI.createMessage(messageBoxId, 'u:camtest:foo', util.format('URLs: %s%s', markdownFullUrl, markdownFullUrl), {}, function(err, message) {
                                     assert.ok(!err);
 


### PR DESCRIPTION
The `\s` in the regex was matching on `s` in the host name, causing it to break on hosts that contained an `s`. It should have been a raw space in the regexp instead.