### PR TITLE
Add Mixpanel instrumentation for invites

### DIFF
--- a/node_modules/oae-content/lib/invitations.js
+++ b/node_modules/oae-content/lib/invitations.js
@@ -33,7 +33,7 @@ var log = require('oae-logger').logger('oae-content-invitations');
  * When an invitation is accepted, pass on the events to update content members and then feed back
  * the content item resources into the event emitter
  */
-ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, callback) {
+ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, token, callback) {
     // Filter the invitations and changes down to only content invitations
     var contentIds = _.chain(memberChangeInfosByResourceId)
         .keys()

--- a/node_modules/oae-discussions/lib/invitations.js
+++ b/node_modules/oae-discussions/lib/invitations.js
@@ -32,7 +32,7 @@ var log = require('oae-logger').logger('oae-discussions-invitations');
  * When an invitation is accepted, pass on the events to update discussion members and then feed
  * back the discussion resources into the event emitter
  */
-ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, callback) {
+ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, token, callback) {
     // Filter the invitations and changes down to only discussion invitations
     var discussionIds = _.chain(memberChangeInfosByResourceId)
         .keys()

--- a/node_modules/oae-folders/lib/invitations.js
+++ b/node_modules/oae-folders/lib/invitations.js
@@ -32,7 +32,7 @@ var log = require('oae-logger').logger('oae-folders-invitations');
  * When an invitation is accepted, pass on the events to update folder members and then feed back
  * the folder resources into the event emitter
  */
-ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, callback) {
+ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, token, callback) {
     // Filter the invitations and changes down to only folder invitations
     var folderGroupIds = _.chain(memberChangeInfosByResourceId)
         .keys()

--- a/node_modules/oae-mixpanel/lib/api.js
+++ b/node_modules/oae-mixpanel/lib/api.js
@@ -46,6 +46,7 @@ var _registerListeners = function(client, config) {
     require('./eventlisteners/folders')(client, config);
     require('./eventlisteners/following')(client, config);
     require('./eventlisteners/groups')(client, config);
+    require('./eventlisteners/invitations')(client, config);
     require('./eventlisteners/search')(client, config);
     require('./eventlisteners/users')(client, config);
 };

--- a/node_modules/oae-mixpanel/lib/eventlisteners/invitations.js
+++ b/node_modules/oae-mixpanel/lib/eventlisteners/invitations.js
@@ -1,0 +1,85 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+
+var AuthzUtil = require('oae-authz/lib/util');
+var ResourceActions = require('oae-resource/lib/actions');
+var ResourceConstants = require('oae-resource/lib/constants').ResourceConstants;
+var TenantsAPI = require('oae-tenants');
+
+var MixpanelUtil = require('oae-mixpanel/lib/util');
+
+module.exports = function(client) {
+
+    /**
+     * One or more invitations got sent out
+     */
+    MixpanelUtil.listen(ResourceActions, ResourceConstants.events.INVITED, function(ctx, invitations, emailTokens) {
+        _.each(invitations, function(invitation) {
+            var params = MixpanelUtil.getBasicParameters(ctx);
+            params.inviteToken = emailTokens[invitation.email];
+
+            // The user who is inviting the guest
+            params.invitedBy = ctx.user().id;
+
+            // The tenant to which the user was invited
+            params.tenantTo = TenantsAPI.getTenantByEmail(invitation.email).alias;
+
+            // The email domain of the invited guest
+            params.emailDomain = invitation.email.split('@').pop();
+
+            // Determine for which type of resource the guest was invited to collaborate on
+            var resource = AuthzUtil.getResourceFromId(invitation.resource.id);
+            if (resource.resourceType === 'c') {
+                params.resourceType = 'content';
+            } else if (resource.resourceType === 'd') {
+                params.resourceType = 'discussion';
+            } else if (resource.resourceType === 'g') {
+                params.resourceType = 'group';
+            } else if (resource.resourceType === 'f') {
+                params.resourceType = 'folder';
+            }
+
+            client.track(ResourceConstants.events.INVITED, params);
+            client.people.increment(params.distinct_id, ResourceConstants.events.INVITED);
+        });
+    });
+
+    /*!
+     * One or more invitations get accepted
+     */
+    MixpanelUtil.listen(ResourceActions, ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, token) {
+        _.each(invitationHashes, function(invitation) {
+            var params = MixpanelUtil.getBasicParameters(ctx);
+            params.inviteToken = token;
+
+            // The tenant from which the inviter invited the user
+            params.tenantFrom = inviterUsersById[invitation.inviterUserId].tenant.alias;
+
+            // The tenant to which the user was invited
+            params.tenantTo = TenantsAPI.getTenantByEmail(invitation.email).alias;
+
+            // The user who invited this guest
+            params.invitedBy = invitation.inviterUserId;
+
+            // The email domain of the invited guest
+            params.emailDomain = invitation.email.split('@').pop();
+
+            client.track(ResourceConstants.events.ACCEPTED_INVITATION, params);
+            client.people.increment(params.distinct_id, ResourceConstants.events.ACCEPTED_INVITATION);
+        });
+    });
+};

--- a/node_modules/oae-principals/lib/invitations.js
+++ b/node_modules/oae-principals/lib/invitations.js
@@ -33,7 +33,7 @@ var log = require('oae-logger').logger('oae-principals-invitations');
  * When an invitation is accepted, pass on the events to update group members and then feed back the
  * group resources into the event emitter
  */
-ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, callback) {
+ResourceActions.when(ResourceConstants.events.ACCEPTED_INVITATION, function(ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, token, callback) {
     // Filter the invitations and changes down to only group invitations
     var groupIds = _.chain(memberChangeInfosByResourceId)
         .keys()

--- a/node_modules/oae-resource/lib/actions.js
+++ b/node_modules/oae-resource/lib/actions.js
@@ -359,7 +359,7 @@ var acceptInvitation = module.exports.acceptInvitation = function(ctx, token, ca
                 // Fire the event for accepting an invitation. This allows resource modules to
                 // update search, activity, libraries, etc... regarding the changes that have been
                 // made
-                ResourceActions.emit(ResourceConstants.events.ACCEPTED_INVITATION, ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, function(errs, results) {
+                ResourceActions.emit(ResourceConstants.events.ACCEPTED_INVITATION, ctx, invitationHashes, memberChangeInfosByResourceId, inviterUsersById, token, function(errs, results) {
                     if (errs) {
                         _.each(errs, function(err) {
                             log().warn({'err': err}, 'An error occurred while handling an "accept invitation" event');


### PR DESCRIPTION
We should have a Mixpanel invite event that tracks at least:

- The inviter id
- The invite token
- The tenant from which the invite is sent
- The tenant to which the user will be invited
- The email domain that's been used for the invite
- The action type for which the invite was sent (group, content, etc.)

We should also have a Mixpanel event for accepting an invitation:

- The invite token
- The tenant to which the user was invited
- The tenant at which the invitation was accepted