### PR TITLE
Explicitly set session cookie name

### DIFF
--- a/config.js
+++ b/config.js
@@ -111,10 +111,16 @@ config.files = {
     'localStorageDirectory': '../files'
 };
 
-// The configuration that can be used to generate secure HTTP cookies.
-// It's strongly recommended that you change this value.
-// Make sure that this value is the same accross each app server.
+/**
+ * `config.cookie`
+ *
+ * Configuration namespace for cookies.
+ *
+ * @param  {String}     name        The name of the cookie in which to store the session information
+ * @param  {String}     secret      The key to securely sign the cookies with. It's strongly recommended that you change this value
+ */
 config.cookie = {
+    'name': 'session',
     'secret': 'this secret will be used to sign your cookies, change me!'
 };
 

--- a/node_modules/oae-authentication/lib/util.js
+++ b/node_modules/oae-authentication/lib/util.js
@@ -43,7 +43,10 @@ var setupAuthMiddleware  = module.exports.setupAuthMiddleware = function(config,
     // with encryption signed by the configured secret). That said, it needs to come before passport
     // authentication (`passport.session()`) because passport needs to know how to write the cookie
     server.use(function(req, res, next) {
-        var cookieOpts = {'secret': config.cookie.secret};
+        var cookieOpts = {
+            'name': config.cookie.name,
+            'secret': config.cookie.secret
+        };
 
         // Don't increase the expiry if we are accessing the global admin server
         if (!req.tenant.isGlobalAdminServer) {

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -53,6 +53,11 @@ var User = require('oae-principals/lib/model').User;
 var log = require('oae-logger').logger('before-tests');
 
 /**
+ * The name of the session cookie
+ */
+var CONFIG_COOKIE_NAME = module.exports.CONFIG_COOKIE_NAME = 'a-non-default-cookie-name';
+
+/**
  * Create a new express test server on some port between 2500 and 3500
  *
  * @param  {Function}   callback            Standard callback function
@@ -1016,6 +1021,9 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
 
     // Disable mixpanel tracking
     config.mixpanel.enabled = false;
+
+    // Explicitly use a different cookie
+    config.cookie.name = CONFIG_COOKIE_NAME;
 
     return config;
 };

--- a/node_modules/oae-util/tests/test-server.js
+++ b/node_modules/oae-util/tests/test-server.js
@@ -178,8 +178,12 @@ describe('OAE Server', function() {
                     var config = require('../../../config.js').config;
                     assert.ok(_.contains(cookieNames, config.cookie.name));
 
-                    // Remove the session cookie from the jar
-                    delete simong.restContext.cookieJar._jar.store.idx.localhost['/'][config.cookie.name];
+                    // Rename the cookie to something else
+                    _.each(cookies, function(cookie) {
+                        if (cookie.key === config.cookie.name) {
+                            cookie.key = 'somethingElse';
+                        }
+                    });
 
                     // Ensure the user is anonymous
                     PrincipalsTestUtil.assertGetMeSucceeds(simong.restContext, function(me) {

--- a/node_modules/oae-util/tests/test-server.js
+++ b/node_modules/oae-util/tests/test-server.js
@@ -174,13 +174,15 @@ describe('OAE Server', function() {
                     var cookies = simong.restContext.cookieJar.getCookies('http://localhost');
                     var cookieNames = _.pluck(cookies, 'key');
 
-                    // Verify the configured cookie names are being used
+                    // When setting up the tests, we configured the cookie name to a specific value.
+                    // Ensure that this value is used. This tests regressions in the cookie-session
+                    // middleware
                     var config = require('../../../config.js').config;
-                    assert.ok(_.contains(cookieNames, config.cookie.name));
+                    assert.ok(_.contains(cookieNames, TestsUtil.CONFIG_COOKIE_NAME));
 
                     // Rename the cookie to something else
                     _.each(cookies, function(cookie) {
-                        if (cookie.key === config.cookie.name) {
+                        if (cookie.key === TestsUtil.CONFIG_COOKIE_NAME) {
                             cookie.key = 'somethingElse';
                         }
                     });

--- a/node_modules/oae-util/tests/test-server.js
+++ b/node_modules/oae-util/tests/test-server.js
@@ -18,6 +18,7 @@ var assert = require('assert');
 var fs = require('fs');
 
 var OaeServer = require('oae-util/lib/server');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var RestUtil = require('oae-rest/lib/util');
 var TestsUtil = require('oae-tests');
@@ -152,6 +153,41 @@ describe('OAE Server', function() {
 
                 var opts = {'method': 'POST', 'url': 'http://localhost:' + port + '/testUploadFiles'};
                 RestUtil.request(opts, {'testFiles': [getFileStream, getFileStream]});
+            });
+        });
+    });
+
+    describe('Cookies', function() {
+
+        /**
+         * Verify that a fixed cookie name is used
+         */
+        it('verify a fixed cookie name is used', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, user, simong) {
+                assert.ok(!err);
+
+                // Ensure the user is authenticated
+                PrincipalsTestUtil.assertGetMeSucceeds(simong.restContext, function(me) {
+                    assert.ok(!me.anon)
+
+                    // Get the cookies from the cookie har
+                    var cookies = simong.restContext.cookieJar.getCookies('http://localhost');
+                    var cookieNames = _.pluck(cookies, 'key');
+
+                    // Verify the configured cookie names are being used
+                    var config = require('../../../config.js').config;
+                    assert.ok(_.contains(cookieNames, config.cookie.name));
+
+                    // Remove the session cookie from the jar
+                    delete simong.restContext.cookieJar._jar.store.idx.localhost['/'][config.cookie.name];
+
+                    // Ensure the user is anonymous
+                    PrincipalsTestUtil.assertGetMeSucceeds(simong.restContext, function(me) {
+                        assert.strictEqual(me.anon, true)
+
+                        return callback();
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
This change:

https://github.com/expressjs/cookie-session/commit/4c55ae4fb68377428c378f54515032220eed81e1#diff-168726dbe96b3ce427e7fedce31bb0bcL44

Has resulted in the session cookie to change name to `session` instead of `expess.sess`. We should fix this name to `session` in case it changes again in another version.