### PR TITLE
Allow multiple email domains per tenant

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function(grunt) {
         'jslint': {
             'files': [
                 'Gruntfile.js',
+                'etc/**/*.js',
                 'node_modules/oae-*/lib/**/*.js',
                 'node_modules/oae-*/tests/**/*.js',
                 'node_modules/oae-*/config/**/*.js'

--- a/etc/migration/12.1-to-12.2/1.addEmailDomains.cql
+++ b/etc/migration/12.1-to-12.2/1.addEmailDomains.cql
@@ -1,0 +1,1 @@
+ALTER TABLE "Tenant" add "emailDomains" text;

--- a/etc/migration/12.1-to-12.2/1.addEmailDomains.cql
+++ b/etc/migration/12.1-to-12.2/1.addEmailDomains.cql
@@ -1,1 +1,1 @@
-ALTER TABLE "Tenant" add "emailDomains" text;
+ALTER TABLE "Tenant" ADD "emailDomains" text;

--- a/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
+++ b/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
@@ -79,7 +79,7 @@ OAE.init(config, function(err) {
         var tenantsToUpdate = _.chain(rows)
             .map(Cassandra.rowToHash)
             .filter(function(hash) {
-                return (hash.emailDomain)
+                return (hash.emailDomain);
             })
             .value();
 
@@ -110,7 +110,8 @@ function _updateTenants(tenants, callback) {
     }
 
     // Update tenants in batches
-    var tenantsToUpdate = tenants.splice(0, 250);
+    var numberOfTenants = 250;
+    var tenantsToUpdate = tenants.splice(0, numberOfTenants);
     var queries = _.map(tenantsToUpdate, function(tenant) {
         return Cassandra.constructUpsertCQL('Tenant', 'alias', tenant.alias, {'emailDomains': tenant.emailDomain});
     });
@@ -119,6 +120,7 @@ function _updateTenants(tenants, callback) {
             return callback(err);
         }
 
+        log.info('Updated %d tenants their email domains', numberOfTenants);
         return _updateTenants(tenants, callback);
     });
-};
+}

--- a/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
+++ b/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
@@ -120,7 +120,7 @@ function _updateTenants(tenants, callback) {
             return callback(err);
         }
 
-        log.info('Updated %d tenants their email domains', numberOfTenants);
+        log().info('Updated %d tenants their email domains', tenantsToUpdate.length);
         return _updateTenants(tenants, callback);
     });
 }

--- a/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
+++ b/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
@@ -14,10 +14,7 @@
  */
 
 /*
- * This migration script will:
- *  - Add an `emailDomains` column to the `Tenant` column family
- *  - Copy each row's `emailDomain` value to `emailDomains`
- *  - Drop the `emailDomain` value
+ * This migration script will copy each row's `emailDomain` value to `emailDomains`
  */
 
 var _ = require('underscore');
@@ -107,7 +104,7 @@ OAE.init(config, function(err) {
  * @param  {Object}     callback.err    An error that occurred, if any
  * @api private
  */
-var _updateTenants = function(tenants, callback) {
+function _updateTenants(tenants, callback) {
     if (_.isEmpty(tenants)) {
         return callback();
     }
@@ -122,6 +119,6 @@ var _updateTenants = function(tenants, callback) {
             return callback(err);
         }
 
-        _updateTenants(tenants, callback);
+        return _updateTenants(tenants, callback);
     });
 };

--- a/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
+++ b/etc/migration/12.1-to-12.2/2.tenantEmailDomains.js
@@ -1,0 +1,127 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * This migration script will:
+ *  - Add an `emailDomains` column to the `Tenant` column family
+ *  - Copy each row's `emailDomain` value to `emailDomains`
+ *  - Drop the `emailDomain` value
+ */
+
+var _ = require('underscore');
+var optimist = require('optimist');
+var path = require('path');
+
+var Cassandra = require('oae-util/lib/cassandra');
+var log = require('oae-logger').logger('tenants-email-domains-migrator');
+var OAE = require('oae-util/lib/oae');
+var TenantsAPI = require('oae-tenants');
+
+var argv = optimist.usage('$0 [--config <path/to/config.js>] [--warnings <path/to/warnings.csv>]')
+    .alias('c', 'config')
+    .describe('c', 'Specify an alternate config file')
+    .default('c', 'config.js')
+
+    .alias('w', 'warnings')
+    .describe('w', 'Specify the path to the file where unmappable users should be dumped to')
+    .default('w', 'email-migration.csv')
+
+    .alias('h', 'help')
+    .describe('h', 'Show usage information')
+    .argv;
+
+if (argv.help) {
+    optimist.showHelp();
+    process.exit(0);
+}
+
+// Get the config
+var configPath = path.resolve(process.cwd(), argv.config);
+var config = require(configPath).config;
+
+// Ensure that this application server does NOT start processing any preview images
+config.previews.enabled = false;
+
+// Ensure that we're logging to standard out/err
+config.log = {
+    'streams': [
+        {
+            'level': 'info',
+            'stream': process.stdout
+        }
+    ]
+};
+
+// Spin up the application container. This will allow us to re-use existing APIs
+OAE.init(config, function(err) {
+    if (err) {
+        log().error({'err': err}, 'Unable to spin up the application server');
+        return process.exit(err.code);
+    }
+
+    // Get all the tenants
+    Cassandra.runQuery('SELECT "alias", "emailDomain" FROM "Tenant"', [], function(err, rows) {
+        if (err) {
+            log().error({'err': err}, 'Unable to get all the tenants from the database');
+            return process.exit(err.code);
+        }
+
+        // Iterate through all the tenants and copy the emailDomain
+        var tenantsToUpdate = _.chain(rows)
+            .map(Cassandra.rowToHash)
+            .filter(function(hash) {
+                return (hash.emailDomain)
+            })
+            .value();
+
+        // Update all the tenants
+        _updateTenants(tenantsToUpdate, function(err) {
+            if (err) {
+                log().error({'err': err}, 'Unable to copy the emailDomain value');
+                return process.exit(err.code);
+            }
+
+            log().info('Updated all tenants');
+            process.exit(0);
+        });
+    });
+});
+
+/**
+ * Update a set of tenants their email domains
+ *
+ * @param  {Object[]}   tenants         Each object represent a tenant that needs to be updated. The `alias` and `emailDomain` keys should be present
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error that occurred, if any
+ * @api private
+ */
+var _updateTenants = function(tenants, callback) {
+    if (_.isEmpty(tenants)) {
+        return callback();
+    }
+
+    // Update tenants in batches
+    var tenantsToUpdate = tenants.splice(0, 250);
+    var queries = _.map(tenantsToUpdate, function(tenant) {
+        return Cassandra.constructUpsertCQL('Tenant', 'alias', tenant.alias, {'emailDomains': tenant.emailDomain});
+    });
+    Cassandra.runBatchQuery(queries, function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        _updateTenants(tenants, callback);
+    });
+};

--- a/etc/migration/12.1-to-12.2/3.dropEmailDomain.cql
+++ b/etc/migration/12.1-to-12.2/3.dropEmailDomain.cql
@@ -1,0 +1,1 @@
+ALTER TABLE "Tenant" drop "emailDomain" text;

--- a/etc/migration/12.1-to-12.2/3.dropEmailDomain.cql
+++ b/etc/migration/12.1-to-12.2/3.dropEmailDomain.cql
@@ -1,1 +1,1 @@
-ALTER TABLE "Tenant" drop "emailDomain" text;
+ALTER TABLE "Tenant" DROP "emailDomain";

--- a/etc/migration/8.0-to-9.0/groupcreated.js
+++ b/etc/migration/8.0-to-9.0/groupcreated.js
@@ -39,7 +39,7 @@ var _done = function(err) {
     }
     console.log('Migration complete');
     process.exit();
-}
+};
 
 /**
  * Migrate a set of rows by adding a `created` timestamp to each (the timestamp will be when the row was
@@ -60,7 +60,7 @@ var _migrateRows = function(rows, callback) {
 
     // Add the created timestamp and move on to the next page
     return Cassandra.runBatchQuery(queries, callback);
-}
+};
 
 /**
  * Start the migration

--- a/etc/migration/9.2-to-9.3/revisions-html.js
+++ b/etc/migration/9.2-to-9.3/revisions-html.js
@@ -52,7 +52,7 @@ OAE.init(config, function(err) {
 
         log().info('Migration completed, migrated %d revisions, it took %d milliseconds', total, (Date.now() - start));
         process.exit();
-    })
+    });
 });
 
 

--- a/etc/scripts/analysis/user-activity.js
+++ b/etc/scripts/analysis/user-activity.js
@@ -330,7 +330,7 @@ function _findLatestActedActivityMillis(userHash, callback, _nextToken) {
         }
 
         var activity = _.find(activities, function(activity) {
-            return (JSON.stringify(activity.actor).indexOf(userId) !== -1)
+            return (JSON.stringify(activity.actor).indexOf(userId) !== -1);
         });
 
         if (activity) {

--- a/node_modules/oae-authentication/lib/api.js
+++ b/node_modules/oae-authentication/lib/api.js
@@ -313,7 +313,7 @@ var _getOrCreateUser = function(ctx, loginId, displayName, opts, callback) {
                 // If an email address was provided by a non authoritative source (Facebook, Twitter,
                 // Google, Local authentication) by a user that is not an administrator we should
                 // check whether the email address matches the tenant's configured email domain
-                var shouldCheckEmail = (ctx.tenant().emailDomain && !isAdmin && !opts.authoritative);
+                var shouldCheckEmail = (!_.isEmpty(ctx.tenant().emailDomains) && !isAdmin && !opts.authoritative);
 
                 // However, if a user followed a link from an invitation email we do not check whether
                 // the email belongs to the configured tenant's email domain. This is to allow for the

--- a/node_modules/oae-authentication/tests/test-auth-local.js
+++ b/node_modules/oae-authentication/tests/test-auth-local.js
@@ -148,8 +148,8 @@ describe('Authentication', function() {
 
             // Create a test user
             var userId = TestsUtil.generateTestUserId();
-            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
-            var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
+            var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, userId, 'password', 'Test User', email1, {}, function(err, createdUser) {
                 err1 = err;
                 checkComplete();
@@ -413,7 +413,7 @@ describe('Authentication', function() {
 
                             // Try changing passwords for a user with no local strategy
                             var twitterTestUserId = TestsUtil.generateTestUserId();
-                            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                             var ctx = new Context(global.oaeTests.tenants.cam);
                             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.TWITTER, twitterTestUserId);
                             AuthenticationAPI.createUser(ctx, loginId, 'Twitter User', {'email': email}, function(err, userObj) {
@@ -503,7 +503,7 @@ describe('Authentication', function() {
                 assert.equal(err.code, 404);
 
                 // Create a user with this login id
-                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                     assert.ok(!err);
                     assert.ok(createdUser);
@@ -532,7 +532,7 @@ describe('Authentication', function() {
                                         assert.equal(err.code, 404);
 
                                         // Create a user with this login id
-                                        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                                        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                                         RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, username, 'password', 'Test User', email, {'visibility': 'public'}, function(err, createdUser) {
                                             assert.ok(!err);
                                             assert.ok(createdUser);
@@ -599,7 +599,7 @@ describe('Authentication', function() {
         it('verify getOrCreateUser', function(callback) {
             var externalId = TestsUtil.generateTestUserId();
             var ctx = new Context(global.oaeTests.tenants.cam);
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
 
             AuthenticationAPI.getOrCreateUser(ctx, AuthenticationConstants.providers.TWITTER, externalId, null, 'Nicolaas Matthijs', {'email': email}, function(err, userObj, loginId, created) {
                 assert.ok(!err);
@@ -625,7 +625,7 @@ describe('Authentication', function() {
          */
         it('verify create without login id', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             AuthenticationAPI.createUser(ctx, undefined, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
                 assert.equal(err.code, 400);
@@ -639,7 +639,7 @@ describe('Authentication', function() {
         it('verify create without tenant alias', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var loginId = new LoginId(undefined, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
             AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
@@ -654,7 +654,7 @@ describe('Authentication', function() {
         it('verify create without provider', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var loginId = new LoginId(ctx.tenant().alias, undefined, username, {'password': 'password'});
             AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
@@ -668,7 +668,7 @@ describe('Authentication', function() {
          */
         it('verify create without external id', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, undefined, {'password': 'password'});
             AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
@@ -684,7 +684,7 @@ describe('Authentication', function() {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
 
             // Test with `undefined` display name
             AuthenticationAPI.createUser(ctx, loginId, undefined, {'email': email}, function(err, userObj) {
@@ -728,7 +728,7 @@ describe('Authentication', function() {
         it('verify create local without password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username);
             AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
@@ -743,7 +743,7 @@ describe('Authentication', function() {
         it('verify create local with short password', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': '12345'});
             AuthenticationAPI.createUser(ctx, loginId, 'Branden Visser', {'email': email}, function(err, userObj) {
                 assert.ok(err);
@@ -757,7 +757,7 @@ describe('Authentication', function() {
          */
         it('verify create user with local loginId', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var username = TestsUtil.generateTestUserId();
             var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
             var loginId = new LoginId(ctx.tenant().alias, AuthenticationConstants.providers.LOCAL, username, {'password': 'password'});
@@ -786,7 +786,7 @@ describe('Authentication', function() {
         it('verify create user with non-local loginId', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, {
                 'username': username,
                 'userPassword': 'password'
@@ -811,7 +811,7 @@ describe('Authentication', function() {
         it('verify creating a user fails if the local login id is already taken', function(callback) {
             var ctx = new Context(global.oaeTests.tenants.cam);
             var username = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var userRestContext = new RestContext(global.oaeTests.tenants.cam.baseUrl, {
                 'username': username,
                 'userPassword': 'password'

--- a/node_modules/oae-authentication/tests/test-auth.js
+++ b/node_modules/oae-authentication/tests/test-auth.js
@@ -51,7 +51,7 @@ describe('Authentication', function() {
     it('verify that only authorized admins can request a user\'s login ids', function(callback) {
         // Generate a user id
         var username = TestsUtil.generateTestUserId();
-        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
 
         // Verify that an error is thrown when a malformed id was specified
         RestAPI.Authentication.getUserLoginIds(globalAdminRestContext, 'not an id', function(err, loginIds) {
@@ -115,7 +115,7 @@ describe('Authentication', function() {
     it('verify that a user\'s login ids can be successfully returned', function(callback) {
         // Generate a user id
         var username = TestsUtil.generateTestUserId();
-        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
 
         // Create a test user
         RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, null, function(err, createdUser) {

--- a/node_modules/oae-authentication/tests/test-cookies.js
+++ b/node_modules/oae-authentication/tests/test-cookies.js
@@ -153,7 +153,7 @@ describe('Authentication', function() {
 
             // Create a test user
             var username = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                 assert.ok(!err);
                 var userRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, username, 'password');

--- a/node_modules/oae-authentication/tests/test-external-strategies.js
+++ b/node_modules/oae-authentication/tests/test-external-strategies.js
@@ -384,7 +384,7 @@ describe('Authentication', function() {
 
                             // Signing in with an email address that does belong to the configured
                             // email domain should succeed
-                            email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomain).toLowerCase();
+                            email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomains[0]).toLowerCase();
                             AuthenticationTestUtil.assertFacebookLoginSucceeds(tenant.host, {'email': email}, function(restCtx, me) {
                                 assert.strictEqual(me.email, email);
 
@@ -395,7 +395,7 @@ describe('Authentication', function() {
 
                                     // Signing in with an email address that does belong to the configured
                                     // email domain should succeed
-                                    email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomain).toLowerCase();
+                                    email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomains[0]).toLowerCase();
                                     AuthenticationTestUtil.assertGoogleLoginSucceeds(tenant.host, email, function(restCtx, me) {
 
                                         return callback();
@@ -480,7 +480,7 @@ describe('Authentication', function() {
                 AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
 
                     // Clear the email domain
-                    TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomain': ''}, function(err) {
+                    TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomains': ''}, function(err) {
                         assert.ok(!err);
                         return callback();
                     });
@@ -695,7 +695,7 @@ describe('Authentication', function() {
 
                 // Configure an email domain
                 var emailDomain = TenantsTestUtil.generateTestTenantHost();
-                TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomain': emailDomain}, function(err) {
+                TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomains': [emailDomain]}, function(err) {
                     assert.ok(!err);
 
                     // Log in through CAS with an email address that definitely does not belong to
@@ -753,7 +753,7 @@ describe('Authentication', function() {
 
             AuthenticationAPI.once(AuthenticationConstants.events.REFRESHED_STRATEGIES, function(tenant) {
                 // Clear the email domain
-                TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomain': ''}, function(err) {
+                TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomains': ''}, function(err) {
                     assert.ok(!err);
                     return callback();
                 });
@@ -1371,7 +1371,7 @@ describe('Authentication', function() {
 
                 // Configure an email domain
                 var emailDomain = TenantsTestUtil.generateTestTenantHost();
-                TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomain': emailDomain}, function(err) {
+                TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, global.oaeTests.tenants.localhost.alias, {'emailDomains': emailDomain}, function(err) {
                     assert.ok(!err);
 
                     // Log in through Shibboleth with an email address that definitely does not

--- a/node_modules/oae-authz/tests/test-invitations.js
+++ b/node_modules/oae-authz/tests/test-invitations.js
@@ -2573,7 +2573,7 @@ describe('Invitations', function() {
      * @return {String}                 The created email
      */
     var _emailForTenant = function(tenant, username) {
-        return _emailForDomain(tenant.emailDomain, username);
+        return _emailForDomain(tenant.emailDomains[0], username);
     };
 
     /*!

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -108,7 +108,7 @@ describe('Content', function() {
         var contexts = {};
         var createUser = function(identifier, visibility, displayName) {
             var userId = TestsUtil.generateTestUserId(identifier);
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, userId, 'password', displayName, email, {'visibility' : visibility}, function(err, createdUser) {
                 if (err) {
                     assert.fail('Could not create test user');

--- a/node_modules/oae-principals/tests/test-emails.js
+++ b/node_modules/oae-principals/tests/test-emails.js
@@ -68,7 +68,7 @@ describe('User emails', function() {
          */
         it('verify validation when verifying an email address', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -106,7 +106,7 @@ describe('User emails', function() {
          */
         it('verify authorization when verifying an email address', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -149,7 +149,7 @@ describe('User emails', function() {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
                 'displayName': TestsUtil.generateRandomText(1),
-                'email': TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain)
+                'email': TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0])
             };
             var restContextUser1 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
             PrincipalsTestUtil.assertCreateUserSucceeds(restContextUser1, paramsUser1, function(user1, tokenUser1) {
@@ -158,7 +158,7 @@ describe('User emails', function() {
                         'username': TestsUtil.generateTestUserId(),
                         'password': 'password',
                         'displayName': TestsUtil.generateRandomText(1),
-                        'email': TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain)
+                        'email': TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0])
                     };
                     var restContextUser2 = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
                     PrincipalsTestUtil.assertCreateUserSucceeds(restContextUser2, paramsUser2, function(user2, tokenUser2) {
@@ -240,7 +240,7 @@ describe('User emails', function() {
          */
         it('verify local user accounts need to verify their email address', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -278,7 +278,7 @@ describe('User emails', function() {
          */
         it('verify activity emails are not sent to unverified email addresses', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -311,7 +311,7 @@ describe('User emails', function() {
          */
         it('verify local user accounts created by a tenant administrator do not need to verify their email address', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -348,7 +348,7 @@ describe('User emails', function() {
                 AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(tenantAdminRestContext, null, {'oae-authentication/facebook/enabled': true}, function() {
 
                     // Remove the tenant's email domain so we can sign in through Facebook
-                    TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, tenant.alias, {'emailDomain': ''}, function() {
+                    TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, tenant.alias, {'emailDomains': ''}, function() {
 
                         // First make sure authenticating without email and no
                         // invitation results in a user without an email
@@ -356,7 +356,7 @@ describe('User emails', function() {
                             assert.ok(!me.email);
 
                             // Create an invitation
-                            var email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomain);
+                            var email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomains[0]);
                             PrincipalsTestUtil.assertCreateGroupSucceeds(tenantAdminRestContext, 'My Group', 'My description', 'public', 'yes', [email], null, function(group) {
                                 email = email.toLowerCase();
 
@@ -391,7 +391,7 @@ describe('User emails', function() {
                 AuthenticationTestUtil.assertUpdateAuthConfigSucceeds(tenantAdminRestContext, null, {'oae-authentication/google/enabled': true}, function() {
 
                     // Sign in through google
-                    var email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomain);
+                    var email = TestsUtil.generateTestEmailAddress(null, tenant.emailDomains[0]);
                     AuthenticationTestUtil.assertGoogleLoginSucceeds(tenant.host, email, function(restContext, response) {
 
                         // As google is considered an authoritative source, the user shouldn't have
@@ -424,8 +424,8 @@ describe('User emails', function() {
                 EmailTestsUtil.collectAndFetchAllEmails(function() {
 
                     // Create 2 email addresses that have tokens associated to them
-                    var email1 = TestsUtil.generateTestEmailAddress(null, tenant.emailDomain);
-                    var email2 = TestsUtil.generateTestEmailAddress(null, tenant.emailDomain);
+                    var email1 = TestsUtil.generateTestEmailAddress(null, tenant.emailDomains[0]);
+                    var email2 = TestsUtil.generateTestEmailAddress(null, tenant.emailDomains[0]);
                     AuthzInvitationsDAO.getOrCreateTokensByEmails([email1, email2], function(err, emailTokens) {
                         assert.ok(!err);
 
@@ -544,7 +544,7 @@ describe('User emails', function() {
                     PrincipalsTestUtil.assertUserEmailMappingEquals(me.email, [me.id], function() {
 
                         // Update the email address
-                        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                        var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                         PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function(user, token) {
 
                             // Assert the old mapping is still in place
@@ -594,7 +594,7 @@ describe('User emails', function() {
                 var oldEmailAddress = simong.user.email;
 
                 // Let an administrator update the email address
-                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 PrincipalsTestUtil.assertUpdateUserSucceeds(camAdminRestContext, simong.user.id, {'email': email}, function(user, token) {
 
                     // The email address still has to be verified
@@ -613,11 +613,11 @@ describe('User emails', function() {
                 var oldEmailAddress = simong.user.email;
 
                 // Update the email address for the first time
-                var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email1}, function(user, token1) {
 
                     // Update the email address again (with a second email address)
-                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email2}, function(user, token2) {
 
                         // Using the first token to verify the email address should fail
@@ -659,7 +659,7 @@ describe('User emails', function() {
          */
         it('verify an email verification token can be resent', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -690,7 +690,7 @@ describe('User emails', function() {
          */
         it('verify validation when resending an email verification token', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -715,7 +715,7 @@ describe('User emails', function() {
          */
         it('verify authorization when resending an email verification token', function(callback) {
             // We can't use TestsUtil.generateTestUsers as that would do the verification process for us
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var params = {
                 'username': TestsUtil.generateTestUserId(),
                 'password': 'password',
@@ -766,7 +766,7 @@ describe('User emails', function() {
                 PrincipalsTestUtil.assertResendEmailTokenFails(simong.restContext, simong.user.id, 404, function() {
 
                     // Update the email address so we get a token
-                    var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function(user, token) {
 
                         // Resending a token now should be OK
@@ -801,7 +801,7 @@ describe('User emails', function() {
                     assert.ok(!email);
 
                     // Update the user's email address
-                    email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
 
                         // Verify the user as a token
@@ -839,7 +839,7 @@ describe('User emails', function() {
                 assert.ok(!err);
 
                 // Update simon's email address so he has a verification token
-                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
 
                     // Anonymous users cannot check anything
@@ -877,7 +877,7 @@ describe('User emails', function() {
                 assert.ok(!err);
 
                 // Update the email address
-                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
 
                     // Delete the token
@@ -920,7 +920,7 @@ describe('User emails', function() {
                 assert.ok(!err);
 
                 // Update simon's email address so he has a verification token
-                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
 
                     // Anonymous users cannot delete anything
@@ -935,7 +935,7 @@ describe('User emails', function() {
                                 // A user can delete his own pending email verification token
                                 PrincipalsTestUtil.assertDeleteEmailTokenSucceeds(simong.restContext, simong.user.id, function(emailForToken) {
 
-                                    email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                                    email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                                     PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function() {
                                         // A tenant admin can delete the pending email verification token for users of their tenant
                                         PrincipalsTestUtil.assertDeleteEmailTokenSucceeds(camAdminRestContext, simong.user.id, function(emailForToken) {

--- a/node_modules/oae-principals/tests/test-terms-and-conditions.js
+++ b/node_modules/oae-principals/tests/test-terms-and-conditions.js
@@ -93,7 +93,7 @@ describe('Terms and Conditions', function() {
 
                 // Not passing in acceptedTC: true should result in a 400
                 var username = TestsUtil.generateRandomText(5);
-                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {}, function(err, userObj) {
                     assert.equal(err.code, 400);
                     RestAPI.User.createUser(anonymousCamRestContext, username, 'password', 'Test User', email, {'acceptedTC': false}, function(err, userObj) {

--- a/node_modules/oae-principals/tests/test-users.js
+++ b/node_modules/oae-principals/tests/test-users.js
@@ -168,7 +168,7 @@ describe('Users', function() {
                 ConfigTestUtil.updateConfigAndWait(tenant.adminRestContext, null, {'oae-principals/recaptcha/enabled': true}, function(err) {
                     assert.ok(!err);
                     EmailTestUtil.collectAndFetchAllEmails(function() {
-                        var email = TestsUtil.generateTestEmailAddress(null, tenant.tenant.emailDomain);
+                        var email = TestsUtil.generateTestEmailAddress(null, tenant.tenant.emailDomains[0]);
                         var profile = {
                             'username': TestsUtil.generateTestUserId(),
                             'password': 'password',
@@ -235,7 +235,7 @@ describe('Users', function() {
 
                     var params = {
                         'username': TestsUtil.generateTestUserId(),
-                        'email': TestsUtil.generateTestEmailAddress(null, recaptchaTenant.emailDomain),
+                        'email': TestsUtil.generateTestEmailAddress(null, recaptchaTenant.emailDomains[0]),
                         'password': 'password',
                         'displayName': 'Test User',
                         'visibility': 'public'
@@ -243,7 +243,7 @@ describe('Users', function() {
                     var recaptchaAnonymousRestContext = TestsUtil.createTenantRestContext(recaptchaTenantAlias);
                     PrincipalsTestUtil.assertCreateUserFails(recaptchaAnonymousRestContext, params, 400, function() {
 
-                        params.email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                        params.email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                         PrincipalsTestUtil.assertCreateUserSucceeds(camAdminRestContext, params, function(createdUser) {
                             assert.ok(createdUser);
                             assert.equal(createdUser.displayName, 'Test User');
@@ -256,12 +256,12 @@ describe('Users', function() {
 
 
                             // Try creating a user with the same username, which should fail
-                            params.email = TestsUtil.generateTestEmailAddress(null, recaptchaTenant.emailDomain);
+                            params.email = TestsUtil.generateTestEmailAddress(null, recaptchaTenant.emailDomains[0]);
                             PrincipalsTestUtil.assertCreateUserFails(recaptchaAnonymousRestContext, params, 400, function() {
 
                                 // Try creating a new user as the created user
                                 params.username = TestsUtil.generateTestUserId();
-                                params.email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                                params.email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                                 PrincipalsTestUtil.assertCreateUserFails(userRestContext, params, 401, function() {
 
                                     // We promote the created user to be a tenant admin
@@ -273,7 +273,7 @@ describe('Users', function() {
 
                                             // Create a user on a tenant as the global administrator
                                             var newUsername = TestsUtil.generateTestUserId();
-                                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                                             RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email3, {'visibility': 'public'}, function(err, userObj) {
                                                 assert.ok(!err);
                                                 assert.ok(userObj);
@@ -285,7 +285,7 @@ describe('Users', function() {
 
                                                 // Create a user on the global tenant as the global administrator
                                                 newUsername = TestsUtil.generateTestUserId();
-                                                var email4 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                                                var email4 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                                                 RestAPI.User.createUserOnTenant(globalAdminRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email4, {'visibility': 'public'}, function(err, userObj) {
                                                     assert.ok(!err);
                                                     assert.ok(userObj);
@@ -298,7 +298,7 @@ describe('Users', function() {
                                                         assert.equal(err.code, 401);
 
                                                         // Verify we cannot create a user on another tenant as global admin anonymous user
-                                                        var email6 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                                                        var email6 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                                                         RestAPI.User.createUserOnTenant(anonymousGlobalRestContext, global.oaeTests.tenants.cam.alias, newUsername, 'password', 'Test User', email6, {}, function(err, userObj) {
                                                             assert.ok(err);
                                                             assert.equal(err.code, 401);
@@ -306,7 +306,7 @@ describe('Users', function() {
                                                             // Verify we cannot create a user on another tenant as a tenant admin. We check for a 404 because at the moment there is no
                                                             // such endpoint bound to the user tenant
                                                             newUsername = TestsUtil.generateTestUserId();
-                                                            var email7 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomain);
+                                                            var email7 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomains[0]);
                                                             RestAPI.User.createUserOnTenant(camAdminRestContext, global.oaeTests.tenants.gt.alias, newUsername, 'password', 'Test User', email7, {'visibility': 'public'}, function(err, userObj) {
                                                                 assert.ok(err);
                                                                 assert.strictEqual(err.code, 404);
@@ -348,7 +348,7 @@ describe('Users', function() {
                         _verifyCreateUserWithEmailDomain(tenantHost, emailDomain2, function() {
 
                             // Configure the tenant with an email domain
-                            RestAPI.Tenants.updateTenant(globalAdminRestContext, tenantAlias, {'emailDomain': emailDomain1}, function(err) {
+                            RestAPI.Tenants.updateTenant(globalAdminRestContext, tenantAlias, {'emailDomains': [emailDomain1]}, function(err) {
                                 assert.ok(!err);
 
                                 // Only user accounts with an email that belongs to the configured email domain can be created
@@ -447,7 +447,7 @@ describe('Users', function() {
             var camTenantAlias = global.oaeTests.tenants.cam.alias;
 
             // Create a user to ensure the default user visibility of the tenant starts as public
-            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bart', email1, {}, function(err, createdUser) {
                 assert.ok(!err);
                 assert.equal(createdUser.visibility, 'public');
@@ -457,7 +457,7 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create a user to ensure its visibility defaults to loggedin
-                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', email2, {}, function(err, createdUser) {
                         assert.ok(!err);
                         assert.equal(createdUser.visibility, 'loggedin');
@@ -467,7 +467,7 @@ describe('Users', function() {
                             assert.ok(!err);
 
                             // Ensure a user's visibility can be overridden when they are created
-                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                             RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', email3, {'visibility': 'private'}, function(err, createdUser) {
                                 assert.ok(!err);
                                 assert.equal(createdUser.visibility, 'private');
@@ -486,7 +486,7 @@ describe('Users', function() {
             var camTenantAlias = global.oaeTests.tenants.cam.alias;
 
             // Create a user to ensure the default user email preference of the tenant starts as immediate
-            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Bert', email1, {}, function(err, createdUser) {
                 assert.ok(!err);
                 assert.equal(createdUser.emailPreference, 'immediate');
@@ -496,7 +496,7 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create a user to ensure its email preference defaults to weekly
-                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Lisa', email2, {}, function(err, createdUser) {
                         assert.ok(!err);
                         assert.equal(createdUser.emailPreference, 'weekly');
@@ -506,7 +506,7 @@ describe('Users', function() {
                             assert.ok(!err);
 
                             // Ensure a user's email preference can be overridden when they are created
-                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                             RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateTestUserId(), 'password', 'Homer', email3, {'emailPreference': 'daily'}, function(err, createdUser) {
                                 assert.ok(!err);
                                 assert.equal(createdUser.emailPreference, 'daily');
@@ -527,12 +527,12 @@ describe('Users', function() {
             var lowerCasedUsername = username.toLowerCase();
             var upperCasedUsername = username.toUpperCase();
 
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, username, 'password', 'Test User', email, {}, function(err, createdUser) {
                 assert.ok(!err);
 
                 // Verify we cannot create another user account where the username only differs in the casing
-                var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 RestAPI.User.createUser(camAdminRestContext, lowerCasedUsername, 'password', 'Test User', email2, {}, function(err) {
                     assert.equal(err.code, 400);
                     RestAPI.User.createUser(camAdminRestContext, upperCasedUsername, 'password', 'Test User', email2, {}, function(err) {
@@ -572,7 +572,7 @@ describe('Users', function() {
             var userId3 = TestsUtil.generateTestUserId();
 
             // Create user without locale
-            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User 1', email1, {}, function(err, createdUser1) {
                 assert.ok(!err);
                 assert.ok(createdUser1);
@@ -584,7 +584,7 @@ describe('Users', function() {
                     assert.ok(!err);
 
                     // Create user without locale
-                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Test User 2', email2, {}, function(err, createdUser2) {
                         assert.ok(!err);
                         assert.ok(createdUser2);
@@ -599,7 +599,7 @@ describe('Users', function() {
                         ConfigTestUtil.updateConfigAndWait(camAdminRestContext, null, {'oae-principals/recaptcha/enabled': false}, function(err) {
                             assert.ok(!err);
 
-                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                            var email3 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                             RestAPI.User.createUser(acceptLanguageRestContext, userId3, 'password', 'Test User 3', email3, {}, function(err, createdUser3) {
                                 assert.ok(!err);
                                 assert.ok(createdUser3);
@@ -715,7 +715,7 @@ describe('Users', function() {
          */
         it('verify validation', function(callback) {
             var userId = TestsUtil.generateTestUserId();
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
 
             // Create user with no user id
             RestAPI.User.createUser(camAdminRestContext, null, 'password', 'Test User', email, {}, function(err, userObj) {
@@ -1491,7 +1491,7 @@ describe('Users', function() {
                     assert.strictEqual(meData.tenant.displayName, publicTenant1.tenant.displayName);
                     assert.strictEqual(meData.tenant.alias, publicTenant1.tenant.alias);
                     assert.strictEqual(meData.tenant.isPrivate, false);
-                    assert.strictEqual(meData.tenant.emailDomain, publicTenant1.tenant.emailDomain);
+                    assert.deepEqual(meData.tenant.emailDomains, publicTenant1.tenant.emailDomains);
 
                     // Verify it for an anonymous user
                     RestAPI.User.getMe(publicTenant1.anonymousRestContext, function(err, meData) {
@@ -1502,7 +1502,7 @@ describe('Users', function() {
                         assert.strictEqual(meData.tenant.displayName, publicTenant1.tenant.displayName);
                         assert.strictEqual(meData.tenant.alias, publicTenant1.tenant.alias);
                         assert.strictEqual(meData.tenant.isPrivate, false);
-                        assert.strictEqual(meData.tenant.emailDomain, publicTenant1.tenant.emailDomain);
+                        assert.deepEqual(meData.tenant.emailDomains, publicTenant1.tenant.emailDomains);
 
                         // Verify it for a user on a private tenant
                         RestAPI.User.getMe(privateTenant1.publicUser.restContext, function(err, meData) {
@@ -1513,7 +1513,7 @@ describe('Users', function() {
                             assert.strictEqual(meData.tenant.displayName, privateTenant1.tenant.displayName);
                             assert.strictEqual(meData.tenant.alias, privateTenant1.tenant.alias);
                             assert.strictEqual(meData.tenant.isPrivate, true);
-                            assert.strictEqual(meData.tenant.emailDomain, privateTenant1.tenant.emailDomain);
+                            assert.deepEqual(meData.tenant.emailDomains, privateTenant1.tenant.emailDomains);
 
                             // Verify it for an anonymous user on a private tenant
                             RestAPI.User.getMe(privateTenant1.anonymousRestContext, function(err, meData) {
@@ -1524,7 +1524,7 @@ describe('Users', function() {
                                 assert.strictEqual(meData.tenant.displayName, privateTenant1.tenant.displayName);
                                 assert.strictEqual(meData.tenant.alias, privateTenant1.tenant.alias);
                                 assert.strictEqual(meData.tenant.isPrivate, true);
-                                assert.strictEqual(meData.tenant.emailDomain, privateTenant1.tenant.emailDomain);
+                                assert.deepEqual(meData.tenant.emailDomains, privateTenant1.tenant.emailDomains);
 
                                 return callback();
                             });
@@ -1765,7 +1765,7 @@ describe('Users', function() {
         it('verify get user by ugly username', function(callback) {
             // Create a test user with an ugly user name
             var userId1 = TestsUtil.generateTestUserId('some.weird@`user\\name');
-            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email1 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, userId1, 'password', 'Test User', email1, {'visibility': 'public'},  function(err, userObj1) {
                 assert.ok(!err);
                 assert.ok(userObj1);
@@ -1781,7 +1781,7 @@ describe('Users', function() {
 
                     // Create a test user with a UTF-8 username
                     var userId2 = TestsUtil.generateTestUserId('стремился');
-                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    var email2 = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     RestAPI.User.createUser(camAdminRestContext, userId2, 'password', 'Кругом шумел', email2, {'visibility': 'public'}, function(err, userObj2) {
                         assert.ok(!err);
                         assert.ok(userObj2);
@@ -2139,7 +2139,7 @@ describe('Users', function() {
         it('verify user permissions', function(callback) {
             // Create 2 public test users
             var jackUserId = TestsUtil.generateTestUserId();
-            var jackEmail = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var jackEmail = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             var jackOpts = {
                 'visibility': 'public',
                 'publicAlias': 'Jack'
@@ -2151,7 +2151,7 @@ describe('Users', function() {
                 var jackRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, jackUserId, 'password');
 
                 var janeUserId = TestsUtil.generateTestUserId();
-                var janeEmail = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                var janeEmail = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                 RestAPI.User.createUser(camAdminRestContext, janeUserId, 'password', 'Jane Doe', janeEmail, {'visibility': 'public'}, function(err, jane) {
                     assert.ok(!err);
                     assert.ok(jane);
@@ -2235,14 +2235,14 @@ describe('Users', function() {
                 'visibility': 'loggedin',
                 'publicAlias': 'A user.'
             };
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
 
             RestAPI.User.createUser(camAdminRestContext, usernameA, 'password', 'LoggedIn User', email, loggedInUserOpts, function(err, userA) {
                 assert.ok(!err);
                 var restCtxA = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host, usernameA, 'password');
 
                 // Create user B in GT tenant
-                email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomain);
+                email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomains[0]);
                 RestAPI.User.createUser(gtAdminRestContext, usernameB, 'password', 'Private User', email, {}, function(err, userB) {
                     assert.ok(!err);
                     var restCtxB = TestsUtil.createTenantRestContext(global.oaeTests.tenants.gt.host, usernameB, 'password');

--- a/node_modules/oae-principals/tests/test-util.js
+++ b/node_modules/oae-principals/tests/test-util.js
@@ -73,7 +73,7 @@ describe('Principals', function() {
                         }
                     });
                 } else {
-                    var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+                    var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
                     RestAPI.User.createUser(camAdminRestContext, principalId, 'password', metadata, email, {}, function(err, userObj) {
                         assert.ok(!err);
                         var userContext = new Context(global.oaeTests.tenants.cam, userObj);

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -2368,10 +2368,10 @@ describe('General Search', function() {
          * Test that verifies that displayName matches are boosted correctly, even across spaces in the displayName
          */
         it('verify displayName matches are boosted across spaces', function(callback) {
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon Gaeremynck', email, {}, function(err, simonGaeremynck) {
                 assert.ok(!err);
-                email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomain);
+                email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomains[0]);
                 RestAPI.User.createUser(gtAdminRestContext, TestsUtil.generateRandomText(1), 'password', 'Simon The Great', email, {}, function(err, simonTheGreat) {
                     assert.ok(!err);
 
@@ -2397,10 +2397,10 @@ describe('General Search', function() {
             // Generate 2 identical users on 2 tenants
             var username = TestsUtil.generateRandomText(1);
             var displayName = TestsUtil.generateRandomText(2);
-            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomain);
+            var email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.cam.emailDomains[0]);
             RestAPI.User.createUser(camAdminRestContext, username, 'password', displayName, email, {}, function(err, camUser) {
                 assert.ok(!err);
-                email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomain);
+                email = TestsUtil.generateTestEmailAddress(null, global.oaeTests.tenants.gt.emailDomains[0]);
                 RestAPI.User.createUser(gtAdminRestContext, username, 'password', displayName, email, {}, function(err, gtUser) {
                     assert.ok(!err);
 

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -828,7 +828,7 @@ var _validateEmailDomains = function(validator, emailDomains, updateTenantAlias)
             'code': 400,
             'msg': util.format('The email domain "%s" conflicts with existing email domains: %s', emailDomain, matchingEmailDomains)
         };
-        validator.check(matchingEmailDomains, err).isNull();
+        validator.check(matchingTenant, err).isNull();
     });
 };
 

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -509,6 +509,7 @@ var _createTenant = function(alias, displayName, host, opts, callback) {
     validator.check(alias, {'code': 400, 'msg': 'The tenant alias should not contain a colon'}).notContains(':');
     validator.check(displayName, {'code': 400, 'msg': 'Missing tenant displayName'}).notEmpty();
     validator.check(host, {'code': 400, 'msg': 'Missing tenant host'}).notEmpty();
+    validator.check(host, {'code': 400, 'msg': 'Invalid hostname'}).isHost();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
@@ -617,6 +618,7 @@ var updateTenant = module.exports.updateTenant = function(ctx, alias, tenantUpda
             tenantUpdates[updateField] = updateValue;
 
             // Validate the lower-cased version
+            validator.check(updateValue, {'code': 400, 'msg': 'Invalid host'}).isHost();
             validator.check(updateValue, {'code': 400, 'msg': 'A hostname cannot be empty'}).notEmpty();
             validator.check(getTenantByHost(updateValue), {'code': 400, 'msg': 'The hostname has already been taken'}).isNull();
             validator.check(updateValue, {'code': 400, 'msg': 'This hostname is reserved'}).not(serverConfig.shibbolethSPHost.toLowerCase());
@@ -820,6 +822,9 @@ var _setLandingPageBlockAttribute = function(ctx, block, blockName, attributeNam
  */
 var _validateEmailDomains = function(validator, emailDomains, updateTenantAlias) {
     _.each(emailDomains, function(emailDomain) {
+        // Check whether it's a valid domain
+        validator.check(emailDomain, {'code': 400, 'msg': 'Invalid email domain'}).isHost();
+
         var matchingTenantAlias = tenantEmailDomainIndex.conflict(updateTenantAlias, emailDomain);
         var matchingTenant = tenants[matchingTenantAlias];
         var matchingEmailDomains = (matchingTenant && matchingTenant.emailDomains);

--- a/node_modules/oae-tenants/lib/api.js
+++ b/node_modules/oae-tenants/lib/api.js
@@ -347,7 +347,9 @@ var _cacheTenants = function(callback) {
                 tenantsByHost[tenant.host] = tenant;
 
                 // Insert the tenant into the email domain index
-                tenantEmailDomainIndex.update(tenant.alias, tenant.emailDomain);
+                _.each(tenant.emailDomains, function(emailDomain) {
+                    tenantEmailDomainIndex.update(tenant.alias, emailDomain);
+                });
 
                 // Keep a cache of all tenants that are private and disabled so we know which ones
                 // cannot be interacted with
@@ -402,6 +404,11 @@ var _updateCachedTenant = function(tenantAlias, callback) {
         var oldTenant = tenants[tenantAlias];
         if (oldTenant) {
             delete tenantsByHost[oldTenant.host];
+
+            // Remove the old email domains
+            _.each(oldTenant.emailDomains, function(emailDomain) {
+                tenantEmailDomainIndex.delete(emailDomain);
+            });
         }
 
         // Re-cache the tenant we pulled from storage
@@ -409,14 +416,16 @@ var _updateCachedTenant = function(tenantAlias, callback) {
         tenantsByHost[tenant.host] = tenant;
 
         // Update the tenant in the email domain index
-        var conflictingTenantAlias = tenantEmailDomainIndex.update(tenantAlias, tenant.emailDomain, (oldTenant && oldTenant.emailDomain));
-        if (conflictingTenantAlias) {
-            log().warn({
-                'tenant': tenant,
-                'oldTenant': oldTenant,
-                'conflictingTenantAlias': conflictingTenantAlias
-            }, 'Failed to update tenant in the email domain index due to a conflicting domain');
-        }
+        _.each(tenant.emailDomains, function(emailDomain) {
+            var conflictingTenantAlias = tenantEmailDomainIndex.update(tenantAlias, emailDomain);
+            if (conflictingTenantAlias) {
+                log().warn({
+                    'tenant': tenant,
+                    'oldTenant': oldTenant,
+                    'conflictingTenantAlias': conflictingTenantAlias
+                }, 'Failed to update tenant in the email domain index due to a conflicting domain');
+            }
+        });
 
         // Synchronize the cache of all tenants that are private and disabled so we know which ones
         // cannot be interacted with
@@ -455,7 +464,7 @@ var _updateCachedTenant = function(tenantAlias, callback) {
  * @param  {String}     displayName             A descriptive short name for the tenant
  * @param  {String}     host                    The host on which this tenant will be proxying (e.g. oae.cam.ac.uk or oae.gatech.edu)
  * @param  {Object}     [opts]                  Optional arguments
- * @param  {String}     [opts.emailDomain]      The email domain for this tenant
+ * @param  {String}     [opts.emailDomains]     The email domains for this tenant
  * @param  {String}     [opts.countryCode]      The ISO-3166-1 country code of the country that represents the tenant
  * @param  {Function}   callback                Standard callback function
  * @param  {Object}     callback.err            An error that occurred, if any
@@ -484,7 +493,7 @@ var createTenant = module.exports.createTenant = function(ctx, alias, displayNam
  * @param  {String}     displayName             A descriptive short name for the tenant
  * @param  {String}     host                    The host on which this tenant will be proxying (e.g. oae.cam.ac.uk or oae.gatech.edu)
  * @param  {Object}     [opts]                  Optional arguments
- * @param  {String}     [opts.emailDomain]      The email domain for this tenant
+ * @param  {String}     [opts.emailDomains]     The email domains for this tenant
  * @param  {String}     [opts.countryCode]      The ISO-3166-1 country code of the country that represents the tenant
  * @param  {Function}   callback                Standard callback function
  * @param  {Object}     callback.err            An error that occurred, if any
@@ -515,13 +524,15 @@ var _createTenant = function(alias, displayName, host, opts, callback) {
 
     // Ensure only valid optional fields are set
     _.each(opts, function(val, key) {
-        validator.check(key, {'code': 400, 'msg': util.format('Invalid field: %s', key)}).isIn(['emailDomain', 'countryCode']);
-        if (key === 'emailDomain') {
-            validator.check(null, {'code': 400, 'msg': 'An email domain was passed in, but was not a string'}).isString(val);
+        validator.check(key, {'code': 400, 'msg': util.format('Invalid field: %s', key)}).isIn(['emailDomains', 'countryCode']);
+        if (key === 'emailDomains') {
+            validator.check(null, {'code': 400, 'msg': 'One or more email domains were passed in, but not as an array'}).isArray(val);
             if (!validator.hasErrors()) {
-                // Only continue if we know the email domain value was a string
-                opts[key] = opts[key].toLowerCase().trim();
-                _validateEmailDomain(validator, opts[key]);
+                // Ensure the tenant email domains are all lower case
+                opts[key] = _.map(opts[key], function(emailDomain) {
+                    return emailDomain.trim().toLowerCase();
+                });
+                _validateEmailDomains(validator, opts[key]);
             }
         } else if (key === 'countryCode' && opts[key]) {
             // Ensure the country code is upper case
@@ -574,8 +585,8 @@ var _createTenant = function(alias, displayName, host, opts, callback) {
  * @param  {Object}     tenantUpdates                   Object where the keys represents the metadata identifiers and the values represent the new metadata values
  * @param  {String}     [tenantUpdates.displayName]     Updated tenant display name
  * @param  {String}     [tenantUpdates.host]            Updated tenant host name
- * @param  {String}     [tenantUpdates.emailDomain]     Updated tenant email domain
- * @param  {String}     [opts.countryCode]              The ISO-3166-1 country code of the country that represents the tenant
+ * @param  {String}     [tenantUpdates.emailDomains]    Updated tenant email domains
+ * @param  {String}     [tenantUpdates.countryCode]     Updated tenant ISO-3166-1 country code
  * @param  {Function}   callback                        Standard callback function
  * @param  {Object}     callback.err                    An error that occurred, if any
  */
@@ -597,7 +608,7 @@ var updateTenant = module.exports.updateTenant = function(ctx, alias, tenantUpda
     var updateFields = tenantUpdates ? _.keys(tenantUpdates) : [];
     validator.check(updateFields.length, {'code': 400, 'msg': 'You should at least specify a new displayName or hostname'}).min(1);
     _.each(tenantUpdates, function(updateValue, updateField) {
-        validator.check(updateField, {'code': 400, 'msg': util.format('"%s" is not a recognized tenant update field', updateField)}).isIn(['displayName', 'host', 'emailDomain', 'countryCode']);
+        validator.check(updateField, {'code': 400, 'msg': util.format('"%s" is not a recognized tenant update field', updateField)}).isIn(['displayName', 'host', 'emailDomains', 'countryCode']);
         if (updateField === 'displayName') {
             validator.check(updateValue, {'code': 400, 'msg': 'A displayName cannot be empty'}).notEmpty();
         } else if (updateField === 'host') {
@@ -609,16 +620,19 @@ var updateTenant = module.exports.updateTenant = function(ctx, alias, tenantUpda
             validator.check(updateValue, {'code': 400, 'msg': 'A hostname cannot be empty'}).notEmpty();
             validator.check(getTenantByHost(updateValue), {'code': 400, 'msg': 'The hostname has already been taken'}).isNull();
             validator.check(updateValue, {'code': 400, 'msg': 'This hostname is reserved'}).not(serverConfig.shibbolethSPHost.toLowerCase());
-        } else if (updateField === 'emailDomain') {
-            // Ensure the tenant email domain is all lower case
-            updateValue = updateValue.toLowerCase();
-            tenantUpdates[updateField] = updateValue;
+        } else if (updateField === 'emailDomains') {
+            // Ensure the tenant email domains are all lower case
+            updateValue = _.map(updateValue, function(emailDomain) {
+                return emailDomain.trim().toLowerCase();
+            });
+
+            tenantUpdates[updateField] = updateValue.join(',');
 
             // Only a global admin can update the email domain
             validator.check(null, {'code': 401, 'msg': 'Only a global administrator can update the email domain'}).isGlobalAdministratorUser(ctx);
 
             // Validate the lower-cased version
-            _validateEmailDomain(validator, updateValue, alias);
+            _validateEmailDomains(validator, updateValue, alias);
         } else if (updateField === 'countryCode' && tenantUpdates[updateField]) {
             // Ensure the country code is upper case
             tenantUpdates[updateField] = tenantUpdates[updateField].toUpperCase();
@@ -800,20 +814,22 @@ var _setLandingPageBlockAttribute = function(ctx, block, blockName, attributeNam
  * `throw` anything.
  *
  * @param  {Validator}  validator               The Validator object
- * @param  {String}     emailDomain             The email domain expression to verify
+ * @param  {String[]}   emailDomains            The email domain expressions to verify
  * @param  {String}     [updateTenantAlias]     The alias of the tenant being updated, if any
  * @api private
  */
-var _validateEmailDomain = function(validator, emailDomain, updateTenantAlias) {
-    var matchingTenantAlias = tenantEmailDomainIndex.conflict(updateTenantAlias, emailDomain);
-    var matchingTenant = tenants[matchingTenantAlias];
-    var matchingEmailDomain = (matchingTenant && matchingTenant.emailDomain);
+var _validateEmailDomains = function(validator, emailDomains, updateTenantAlias) {
+    _.each(emailDomains, function(emailDomain) {
+        var matchingTenantAlias = tenantEmailDomainIndex.conflict(updateTenantAlias, emailDomain);
+        var matchingTenant = tenants[matchingTenantAlias];
+        var matchingEmailDomains = (matchingTenant && matchingTenant.emailDomains);
 
-    var err = {
-        'code': 400,
-        'msg': util.format('The email domain "%s" conflicts with existing email domain: %s', emailDomain, matchingEmailDomain)
-    };
-    validator.check(matchingEmailDomain, err).isNull();
+        var err = {
+            'code': 400,
+            'msg': util.format('The email domain "%s" conflicts with existing email domains: %s', emailDomain, matchingEmailDomains)
+        };
+        validator.check(matchingEmailDomains, err).isNull();
+    });
 };
 
 /**
@@ -844,8 +860,15 @@ var _copyTenant = function(tenant) {
  * @api private
  */
 var _storageHashToTenant = function(alias, hash) {
+    var emailDomains = [];
+    if (hash.emailDomains) {
+        emailDomains = _.map(hash.emailDomains.split(','), function(emailDomain) {
+            return emailDomain.trim().toLowerCase();
+        });
+    }
+
     return new Tenant(alias, hash.displayName, hash.host.toLowerCase(), {
-        'emailDomain': (hash.emailDomain && hash.emailDomain.toLowerCase()),
+        'emailDomains': emailDomains,
         'countryCode': hash.countryCode,
         'active': hash.active,
         'isGuestTenant': (alias === serverConfig.guestTenantAlias)
@@ -862,11 +885,15 @@ var _storageHashToTenant = function(alias, hash) {
  * @api private
  */
 var _tenantToStorageHash = function(tenant) {
-    return _.pick(tenant,
+    var hash = _.pick(tenant,
         'displayName',
         'host',
-        'emailDomain',
+        'emailDomains',
         'countryCode',
         'active'
     );
+    if (hash.emailDomains) {
+        hash.emailDomains = hash.emailDomains.join(',');
+    }
+    return hash;
 };

--- a/node_modules/oae-tenants/lib/init.js
+++ b/node_modules/oae-tenants/lib/init.js
@@ -38,7 +38,7 @@ module.exports = function(config, callback) {
  */
 var ensureSchema = function(callback) {
     Cassandra.createColumnFamilies({
-        'Tenant': 'CREATE TABLE "Tenant" ("alias" text PRIMARY KEY, "displayName" text, "host" text, "emailDomain" text, "countryCode" text, "active" boolean)',
+        'Tenant': 'CREATE TABLE "Tenant" ("alias" text PRIMARY KEY, "displayName" text, "host" text, "emailDomains" text, "countryCode" text, "active" boolean)',
         'TenantNetwork': 'CREATE TABLE "TenantNetwork" ("id" text PRIMARY KEY, "displayName" text);',
         'TenantNetworkTenants': 'CREATE TABLE "TenantNetworkTenants" ("tenantNetworkId" text, "tenantAlias" text, "value" text, PRIMARY KEY ("tenantNetworkId", "tenantAlias")) WITH COMPACT STORAGE;'
     }, callback);

--- a/node_modules/oae-tenants/lib/internal/emailDomainIndex.js
+++ b/node_modules/oae-tenants/lib/internal/emailDomainIndex.js
@@ -211,6 +211,15 @@ var EmailDomainIndex = module.exports = function() {
         },
 
         /**
+         * Delete a domain from the index
+         *
+         * @param  {String}     emailDomain  The email domain to remove from the index
+         */
+        'delete': function(emailDomain) {
+            _delete(emailDomain);
+        },
+
+        /**
          * Update given alias in the email domain index. This will remove the specified email domain
          * (if any) and set the current email domain. If the final state of the index would result
          * in conflicting domains as described in the index summary documentation, then this method

--- a/node_modules/oae-tenants/lib/model.js
+++ b/node_modules/oae-tenants/lib/model.js
@@ -21,7 +21,7 @@
  * @param  {String}     host                        The host on which this tenant is proxying (ie: oae.cam.ac.uk or oae.gatech.edu)
  * @param  {Object}     [opts]                      Optional parameters
  * @param  {Boolean}    [opts.active]               Whether or not the tenant is active. Default: `true`
- * @param  {String}     [opts.emailDomain]          The tenant's registered email domain
+ * @param  {String[]}   [opts.emailDomains]         The tenant's registered email domains
  * @param  {String}     [opts.countryCode]          The ISO-3166-1 country code of the country that represents the tenant
  * @param  {Boolean}    [opts.isGlobalAdminServer]  Whether or not the tenant is the global admin tenant. Default: `false`
  * @param  {Boolean}    [opts.isGuestTenant]        Whether or not the tenant is the tenant configured as the "guest" tenant. Default: `false`
@@ -34,7 +34,7 @@ var Tenant = module.exports.Tenant = function(alias, displayName, host, opts) {
     that.alias = alias;
     that.displayName = displayName;
     that.host = host;
-    that.emailDomain = opts.emailDomain;
+    that.emailDomains = opts.emailDomains || [];
     that.countryCode = opts.countryCode;
     that.active = (opts.active !== false);
     that.isGlobalAdminServer = (opts.isGlobalAdminServer === true);
@@ -49,7 +49,7 @@ var Tenant = module.exports.Tenant = function(alias, displayName, host, opts) {
         var compact = {
             'alias': that.alias,
             'displayName': that.displayName,
-            'emailDomain': that.emailDomain
+            'emailDomains': that.emailDomains
         };
 
         if (that.isGuestTenant) {

--- a/node_modules/oae-tenants/lib/rest.js
+++ b/node_modules/oae-tenants/lib/rest.js
@@ -193,13 +193,13 @@ OAE.globalAdminRouter.on('post', '/api/tenantNetwork/:id/removeTenants', functio
  * @FormParam   {string}            alias           The unique alias for the tenant
  * @FormParam   {string}            displayName     A descriptive short name for the tenant
  * @FormParam   {string}            host            The host on which this tenant will be proxying
- * @FormParam   {string}            [emailDomain]   The email domain expression (e.g., *.cam.ac.uk, gmail.com) for users of this tenant (Supports multiple)
+ * @FormParam   {string[]}          [emailDomains]  The email domain expressions (e.g., *.cam.ac.uk, gmail.com) for users of this tenant (Supports multiple)
  * @FormParam   {string}            [countryCode]   The ISO-3166-1 country code of the country that represents the tenant
  * @Return      {Tenant}                            The created tenant
  * @HttpResponse                    200             Tenant created
  * @HttpResponse                    400             A tenant with the alias already exists
  * @HttpResponse                    400             A tenant with the host already exists
- * @HttpResponse                    400             The email domain expression conflicts with an existing tenant email domain
+ * @HttpResponse                    400             The email domain expressions conflict with an existing tenant email domain expression
  * @HttpResponse                    400             Missing alias
  * @HttpResponse                    400             Missing tenant displayName
  * @HttpResponse                    400             Missing tenant host
@@ -208,7 +208,7 @@ OAE.globalAdminRouter.on('post', '/api/tenantNetwork/:id/removeTenants', functio
  */
 OAE.globalAdminRouter.on('post', '/api/tenant/create', function(req, res) {
     var opts = _.oaeExtendDefined({}, _.pick(req.body, 'countryCode'));
-    opts.emailDomains = OaeUtil.toArray(req.body.emailDomain);
+    opts.emailDomains = OaeUtil.toArray(req.body.emailDomains);
     TenantsAPI.createTenant(req.ctx, req.body.alias, req.body.displayName, req.body.host, opts, function(err, tenant) {
         if (err) {
             return res.send(err.code, err.msg);
@@ -281,7 +281,7 @@ OAE.globalAdminRouter.on('get', '/api/tenant/:alias', function(req, res) {
  * @Path        /tenant
  * @FormParam   {string}            [displayName]   Updated tenant display name
  * @FormParam   {string}            [host]          Updated tenant host name
- * @FormParam   {string}            [emailDomain]   Updated tenant email domain expression
+ * @FormParam   {string}            [emailDomains]  Updated tenant email domain expressions
  * @FormParam   {string}            [countryCode]   Updated tenant ISO-3166-1 country code
  * @Return      {void}
  * @HttpResponse                    200             Tenant updated
@@ -296,8 +296,8 @@ OAE.globalAdminRouter.on('get', '/api/tenant/:alias', function(req, res) {
  */
 OAE.tenantRouter.on('post', '/api/tenant', function(req, res) {
     var update = _.oaeExtendDefined({}, _.pick(req.body, 'displayName', 'host', 'countryCode'));
-    if (_.has(req.body, 'emailDomain')) {
-        update.emailDomains = OaeUtil.toArray(req.body.emailDomain);
+    if (_.has(req.body, 'emailDomains')) {
+        update.emailDomains = OaeUtil.toArray(req.body.emailDomains);
     }
     TenantsAPI.updateTenant(req.ctx, req.ctx.tenant().alias, update, function(err) {
         if (err) {
@@ -368,7 +368,7 @@ OAE.globalAdminRouter.on('post', '/api/tenant/stop', function(req, res) {
  * @PathParam   {string}            alias           The alias of the tenant to update
  * @FormParam   {string}            [displayName]   Updated tenant display name
  * @FormParam   {string}            [host]          Updated tenant host name
- * @FormParam   {string}            [emailDomain]   Updated tenant email domain expression
+ * @FormParam   {string[]}          [emailDomains]  Updated tenant email domain expression
  * @FormParam   {string}            [countryCode]   Updated tenant ISO-3166-1 country code
  * @Return      {void}
  * @HttpResponse                    200             Tenant updated
@@ -383,8 +383,8 @@ OAE.globalAdminRouter.on('post', '/api/tenant/stop', function(req, res) {
  */
 OAE.globalAdminRouter.on('post', '/api/tenant/:alias', function(req, res) {
     var update = _.oaeExtendDefined({}, _.pick(req.body, 'displayName', 'host', 'countryCode'));
-    if (_.has(req.body, 'emailDomain')) {
-        update.emailDomains = OaeUtil.toArray(req.body.emailDomain);
+    if (_.has(req.body, 'emailDomains')) {
+        update.emailDomains = OaeUtil.toArray(req.body.emailDomains);
     }
     TenantsAPI.updateTenant(req.ctx, req.params.alias, update, function(err) {
         if (err) {

--- a/node_modules/oae-tenants/lib/rest.js
+++ b/node_modules/oae-tenants/lib/rest.js
@@ -193,7 +193,8 @@ OAE.globalAdminRouter.on('post', '/api/tenantNetwork/:id/removeTenants', functio
  * @FormParam   {string}            alias           The unique alias for the tenant
  * @FormParam   {string}            displayName     A descriptive short name for the tenant
  * @FormParam   {string}            host            The host on which this tenant will be proxying
- * @FormParam   {string}            emailDomain     The email domain expression (e.g., *.cam.ac.uk, gmail.com) for users of this tenant
+ * @FormParam   {string}            [emailDomain]   The email domain expression (e.g., *.cam.ac.uk, gmail.com) for users of this tenant (Supports multiple)
+ * @FormParam   {string}            [countryCode]   The ISO-3166-1 country code of the country that represents the tenant
  * @Return      {Tenant}                            The created tenant
  * @HttpResponse                    200             Tenant created
  * @HttpResponse                    400             A tenant with the alias already exists
@@ -206,7 +207,8 @@ OAE.globalAdminRouter.on('post', '/api/tenantNetwork/:id/removeTenants', functio
  * @HttpResponse                    400             The tenant alias should not contain a space
  */
 OAE.globalAdminRouter.on('post', '/api/tenant/create', function(req, res) {
-    var opts = _.oaeExtendDefined({}, _.pick(req.body, 'emailDomain', 'countryCode'));
+    var opts = _.oaeExtendDefined({}, _.pick(req.body, 'countryCode'));
+    opts.emailDomains = OaeUtil.toArray(req.body.emailDomain);
     TenantsAPI.createTenant(req.ctx, req.body.alias, req.body.displayName, req.body.host, opts, function(err, tenant) {
         if (err) {
             return res.send(err.code, err.msg);
@@ -279,6 +281,8 @@ OAE.globalAdminRouter.on('get', '/api/tenant/:alias', function(req, res) {
  * @Path        /tenant
  * @FormParam   {string}            [displayName]   Updated tenant display name
  * @FormParam   {string}            [host]          Updated tenant host name
+ * @FormParam   {string}            [emailDomain]   Updated tenant email domain expression
+ * @FormParam   {string}            [countryCode]   Updated tenant ISO-3166-1 country code
  * @Return      {void}
  * @HttpResponse                    200             Tenant updated
  * @HttpResponse                    400             ... is not a recognized tenant update field'
@@ -291,7 +295,11 @@ OAE.globalAdminRouter.on('get', '/api/tenant/:alias', function(req, res) {
  * @HttpResponse                    404             Tenant with alias ... does not exist and cannot be updated
  */
 OAE.tenantRouter.on('post', '/api/tenant', function(req, res) {
-    TenantsAPI.updateTenant(req.ctx, req.ctx.tenant().alias, req.body, function(err) {
+    var update = _.oaeExtendDefined({}, _.pick(req.body, 'displayName', 'host', 'countryCode'));
+    if (_.has(req.body, 'emailDomain')) {
+        update.emailDomains = OaeUtil.toArray(req.body.emailDomain);
+    }
+    TenantsAPI.updateTenant(req.ctx, req.ctx.tenant().alias, update, function(err) {
         if (err) {
             return res.send(err.code, err.msg);
         }
@@ -360,6 +368,8 @@ OAE.globalAdminRouter.on('post', '/api/tenant/stop', function(req, res) {
  * @PathParam   {string}            alias           The alias of the tenant to update
  * @FormParam   {string}            [displayName]   Updated tenant display name
  * @FormParam   {string}            [host]          Updated tenant host name
+ * @FormParam   {string}            [emailDomain]   Updated tenant email domain expression
+ * @FormParam   {string}            [countryCode]   Updated tenant ISO-3166-1 country code
  * @Return      {void}
  * @HttpResponse                    200             Tenant updated
  * @HttpResponse                    400             ... is not a recognized tenant update field'
@@ -372,7 +382,11 @@ OAE.globalAdminRouter.on('post', '/api/tenant/stop', function(req, res) {
  * @HttpResponse                    404             Tenant with alias ... does not exist and cannot be updated
  */
 OAE.globalAdminRouter.on('post', '/api/tenant/:alias', function(req, res) {
-    TenantsAPI.updateTenant(req.ctx, req.params.alias, req.body, function(err) {
+    var update = _.oaeExtendDefined({}, _.pick(req.body, 'displayName', 'host', 'countryCode'));
+    if (_.has(req.body, 'emailDomain')) {
+        update.emailDomains = OaeUtil.toArray(req.body.emailDomain);
+    }
+    TenantsAPI.updateTenant(req.ctx, req.params.alias, update, function(err) {
         if (err) {
             return res.send(err.code, err.msg);
         }

--- a/node_modules/oae-tenants/lib/test/util.js
+++ b/node_modules/oae-tenants/lib/test/util.js
@@ -65,7 +65,7 @@ var generateTestTenants = module.exports.generateTestTenants = function(globalAd
     var alias = generateTestTenantAlias();
     var description = TestsUtil.generateRandomText();
     var host = generateTestTenantHost();
-    createTenantAndWait(globalAdminRestCtx, alias, description, host, {'emailDomain': host}, function(err, tenant) {
+    createTenantAndWait(globalAdminRestCtx, alias, description, host, {'emailDomains': host}, function(err, tenant) {
         assert.ok(!err);
         _created.push(tenant);
         return generateTestTenants(globalAdminRestCtx, numToCreate, callback, _created);

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -325,6 +325,21 @@ describe('Tenants', function() {
 
             callback();
         });
+
+        /**
+         * Test that verifies that the email domain index can map multiple email domains to an alias
+         */
+        it('verify it supports multiple tenants', function(callback) {
+            var index = _createIndex();
+
+            index.update('sussex', 'sussex.ac.uk');
+            index.update('sussex', 'susx.ac.uk');
+
+            assert.strictEqual(index.match('sussex.ac.uk'), 'sussex');
+            assert.strictEqual(index.match('susx.ac.uk'), 'sussex');
+
+            callback();
+        });
     });
 
     describe('Guest tenant', function() {
@@ -341,7 +356,7 @@ describe('Tenants', function() {
                 assert.ok(guestTenant0);
                 assert.strictEqual(guestTenant0.displayName, 'Guest tenant');
                 assert.strictEqual(guestTenant0.host, 'guest.oae.com');
-                assert.ok(!guestTenant0.emailDomain);
+                assert.ok(_.isEmpty(guestTenant0.emailDomains));
                 assert.strictEqual(guestTenant0.active, true);
                 assert.strictEqual(guestTenant0.isGlobalAdminServer, false);
                 assert.strictEqual(guestTenant0.isGuestTenant, true);
@@ -414,7 +429,7 @@ describe('Tenants', function() {
                 var numTenants = _.keys(tenants).length;
 
                 // Create a new tenant
-                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, {'emailDomain': tenantEmailDomain}, function(err) {
+                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, {'emailDomains': [tenantEmailDomain]}, function(err) {
                     assert.ok(!err);
 
                     // Get all tenants, check that there is one more
@@ -426,7 +441,7 @@ describe('Tenants', function() {
                         assert.strictEqual(tenants['camtest'].host, 'cambridge.oae.com');
                         assert.ok(tenants[tenantAlias]);
                         assert.strictEqual(tenants[tenantAlias].host, tenantHost.toLowerCase());
-                        assert.strictEqual(tenants[tenantAlias].emailDomain, tenantEmailDomain.toLowerCase());
+                        assert.strictEqual(tenants[tenantAlias].emailDomains[0], tenantEmailDomain.toLowerCase());
                         assert.strictEqual(_.keys(tenants).length, numTenants + 1);
 
                         // Verify that the global admin tenant is not included
@@ -447,33 +462,33 @@ describe('Tenants', function() {
             var tenantHost = TenantsTestUtil.generateTestTenantHost();
             var tenantEmailDomain = TenantsTestUtil.generateTestTenantHost();
 
-            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, {'emailDomain': tenantEmailDomain}, function(err, createdTenant) {
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, {'emailDomains': [tenantEmailDomain]}, function(err, createdTenant) {
                 var anonymousRestContext = TestsUtil.createTenantRestContext(tenantHost);
 
                 RestAPI.Tenants.getTenant(anonymousRestContext, null, function(err, tenant) {
                     assert.ok(!err);
                     assert.strictEqual(tenant.alias, tenantAlias);
                     assert.strictEqual(tenant.host, tenantHost.toLowerCase());
-                    assert.strictEqual(tenant.emailDomain, tenantEmailDomain.toLowerCase());
+                    assert.strictEqual(tenant.emailDomains[0], tenantEmailDomain.toLowerCase());
 
                     // Verify that the tenant information is available through the global tenant
                     RestAPI.Tenants.getTenant(globalAdminRestContext, tenantAlias, function(err, tenant) {
                         assert.ok(!err);
                         assert.strictEqual(tenant.alias, tenantAlias);
                         assert.strictEqual(tenant.host, tenantHost.toLowerCase());
-                        assert.strictEqual(tenant.emailDomain, tenantEmailDomain.toLowerCase());
+                        assert.strictEqual(tenant.emailDomains[0], tenantEmailDomain.toLowerCase());
 
                         // Get the tenant by host name
                         var tenantByHost = TenantsAPI.getTenantByHost(tenantHost);
                         assert.strictEqual(tenantByHost.alias, tenantAlias);
                         assert.strictEqual(tenantByHost.host, tenantHost.toLowerCase());
-                        assert.strictEqual(tenantByHost.emailDomain, tenantEmailDomain.toLowerCase());
+                        assert.strictEqual(tenantByHost.emailDomains[0], tenantEmailDomain.toLowerCase());
 
                         // Get the tenant by email domain
                         var tenantByEmailDomain = TenantsAPI.getTenantByEmail(tenantEmailDomain);
                         assert.strictEqual(tenantByEmailDomain.alias, tenantAlias);
                         assert.strictEqual(tenantByEmailDomain.host, tenantHost.toLowerCase());
-                        assert.strictEqual(tenantByEmailDomain.emailDomain, tenantEmailDomain.toLowerCase());
+                        assert.strictEqual(tenantByEmailDomain.emailDomains[0], tenantEmailDomain.toLowerCase());
 
                         return callback();
                     });
@@ -590,14 +605,14 @@ describe('Tenants', function() {
             var tenant1Alias = TenantsTestUtil.generateTestTenantAlias();
             var tenant1Description = TestsUtil.generateRandomText();
             var tenant1Host = util.format('a.%s', commonTld);
-            var tenant1Opts = {'emailDomain': tenant1Host};
+            var tenant1Opts = {'emailDomains': [tenant1Host]};
 
             // Initialize tenant information for a tenant whose email domain suffix is "aa" followed
             // by the same host
             var tenant2Alias = TenantsTestUtil.generateTestTenantAlias();
             var tenant2Description = TestsUtil.generateRandomText();
             var tenant2Host = util.format('aa.%s', commonTld);
-            var tenant2Opts = {'emailDomain': tenant2Host};
+            var tenant2Opts = {'emailDomains': [tenant2Host]};
 
             TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenant1Alias, tenant1Description, tenant1Host, tenant1Opts, function(err, tenant1) {
                 assert.ok(!err);
@@ -605,60 +620,60 @@ describe('Tenants', function() {
                     assert.ok(!err);
 
                     // Ensure we can get tenant 1 by an exact match
-                    var gotTenant1 = TenantsAPI.getTenantByEmail(tenant1Opts.emailDomain);
+                    var gotTenant1 = TenantsAPI.getTenantByEmail(tenant1Opts.emailDomains[0]);
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
                     assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomains[0], tenant1Opts.emailDomains[0].toLowerCase());
 
                     // Ensure we can get tenant 1 with an email address by an exact match
-                    gotTenant1 = TenantsAPI.getTenantByEmail(util.format('mrvisser@%s', tenant1Opts.emailDomain));
+                    gotTenant1 = TenantsAPI.getTenantByEmail(util.format('mrvisser@%s', tenant1Opts.emailDomains));
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
                     assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomains[0], tenant1Opts.emailDomains[0].toLowerCase());
 
                     // Ensure we can get tenant 1 by a valid host suffix
-                    gotTenant1 = TenantsAPI.getTenantByEmail(util.format('prefix.%s', tenant1Opts.emailDomain));
+                    gotTenant1 = TenantsAPI.getTenantByEmail(util.format('prefix.%s', tenant1Opts.emailDomains));
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
                     assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomains[0], tenant1Opts.emailDomains[0].toLowerCase());
 
                     // Ensure we can get tenant 1 by a valid host suffix in an email address
-                    gotTenant1 = TenantsAPI.getTenantByEmail(util.format('mrvisser@prefix.%s', tenant1Opts.emailDomain));
+                    gotTenant1 = TenantsAPI.getTenantByEmail(util.format('mrvisser@prefix.%s', tenant1Opts.emailDomains));
                     assert.ok(gotTenant1);
                     assert.strictEqual(gotTenant1.alias, tenant1Alias);
                     assert.strictEqual(gotTenant1.host, tenant1Host.toLowerCase());
-                    assert.strictEqual(gotTenant1.emailDomain, tenant1Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant1.emailDomains[0], tenant1Opts.emailDomains[0].toLowerCase());
 
                     // Ensure we can get tenant 2 by an exact match
-                    var gotTenant2 = TenantsAPI.getTenantByEmail(tenant2Opts.emailDomain);
+                    var gotTenant2 = TenantsAPI.getTenantByEmail(tenant2Opts.emailDomains[0]);
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
                     assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomains[0], tenant2Opts.emailDomains[0].toLowerCase());
 
                     // Ensure we can get tenant 2 by an email address domain exact match
-                    gotTenant2 = TenantsAPI.getTenantByEmail(util.format('mrvisser@%s', tenant2Opts.emailDomain));
+                    gotTenant2 = TenantsAPI.getTenantByEmail(util.format('mrvisser@%s', tenant2Opts.emailDomains[0]));
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
                     assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomains[0], tenant2Opts.emailDomains[0].toLowerCase());
 
                     // Ensure we can get tenant 2 by a valid host suffix
-                    gotTenant2 = TenantsAPI.getTenantByEmail(util.format('prefix.%s', tenant2Opts.emailDomain));
+                    gotTenant2 = TenantsAPI.getTenantByEmail(util.format('prefix.%s', tenant2Opts.emailDomains[0]));
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
                     assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomains[0], tenant2Opts.emailDomains[0].toLowerCase());
 
                     // Ensure we can get tenant 2 by an email address with a valid host suffix
-                    gotTenant2 = TenantsAPI.getTenantByEmail(util.format('mrvisser@prefix.%s', tenant2Opts.emailDomain));
+                    gotTenant2 = TenantsAPI.getTenantByEmail(util.format('mrvisser@prefix.%s', tenant2Opts.emailDomains[0]));
                     assert.ok(tenant2);
                     assert.strictEqual(gotTenant2.alias, tenant2Alias);
                     assert.strictEqual(gotTenant2.host, tenant2Host.toLowerCase());
-                    assert.strictEqual(gotTenant2.emailDomain, tenant2Opts.emailDomain.toLowerCase());
+                    assert.strictEqual(gotTenant2.emailDomains[0], tenant2Opts.emailDomains[0].toLowerCase());
 
                     // Some subtle things that should fall back to the guest tenant:
                     var shouldBeGuest = [
@@ -670,7 +685,7 @@ describe('Tenants', function() {
                         commonTld,
 
                         // Ensure missing the last character doesn't match (e.g., "cam.ac.u")
-                        tenant1Opts.emailDomain.slice(0, -1),
+                        tenant1Opts.emailDomains[0].slice(0, -1),
 
                         // Ensure missing the last character with the triple-"a" domain doesn't
                         // match either (i.e., same length as a valid match, but subtle difference)
@@ -838,7 +853,7 @@ describe('Tenants', function() {
                 assert.ok(tenant);
                 assert.strictEqual(tenant.alias, tenantAlias);
                 assert.strictEqual(tenant.host, tenantHost.toLowerCase());
-                assert.ok(!tenant.emailDomain);
+                assert.ok(_.isEmpty(tenant.emailDomains));
                 assert.strictEqual(tenant.countryCode, 'CA');
 
                 // Get the tenant
@@ -848,7 +863,7 @@ describe('Tenants', function() {
                     assert.ok(tenant);
                     assert.strictEqual(tenant.alias, tenantAlias);
                     assert.strictEqual(tenant.host, tenantHost.toLowerCase());
-                    assert.ok(!tenant.emailDomain);
+                    assert.ok(_.isEmpty(tenant.emailDomains));
                     assert.strictEqual(tenant.countryCode, 'CA');
 
                     // Get the tenant by host
@@ -856,7 +871,7 @@ describe('Tenants', function() {
                     assert.ok(tenant);
                     assert.strictEqual(tenant.alias, tenantAlias);
                     assert.strictEqual(tenant.host, tenantHost.toLowerCase());
-                    assert.ok(!tenant.emailDomain);
+                    assert.ok(_.isEmpty(tenant.emailDomains));
                     assert.strictEqual(tenant.countryCode, 'CA');
                     return callback();
                 });
@@ -946,7 +961,7 @@ describe('Tenants', function() {
             var uniqueString1 = TenantsTestUtil.generateTestTenantAlias();
             var commonTld = TenantsTestUtil.generateTestTenantHost();
             var emailDomain1 = util.format('third.second.%s', commonTld);
-            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString1, uniqueString1, uniqueString1, {'emailDomain': emailDomain1}, function(err) {
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString1, uniqueString1, uniqueString1, {'emailDomains': [emailDomain1]}, function(err) {
                 assert.ok(!err);
 
                 // Conflicting domain that exactly matches an existing email domain
@@ -960,18 +975,18 @@ describe('Tenants', function() {
 
                 // Ensure exact match domain can't fall under the scope of the suffix
                 var uniqueString2 = TenantsTestUtil.generateTestTenantAlias();
-                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomain': emailDomain1ExactConflict}, function(err) {
+                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [emailDomain1ExactConflict]}, function(err) {
                     assert.ok(err);
                     assert.strictEqual(err.code, 400);
-                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomain': emailDomain1SuffixConflict1}, function(err) {
+                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
                         assert.ok(err);
                         assert.strictEqual(err.code, 400);
-                        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomain': emailDomain1SuffixConflict2}, function(err) {
+                        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict2]}, function(err) {
                             assert.ok(err);
                             assert.strictEqual(err.code, 400);
 
                             // Sanity check we can create a tenant with these values
-                            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomain': uniqueString2}, function(err) {
+                            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [uniqueString2]}, function(err) {
                                 assert.ok(!err);
 
                                 return callback();
@@ -993,7 +1008,7 @@ describe('Tenants', function() {
             var tenantHost = TestsUtil.generateRandomText().toUpperCase();
             var tenantHost2 = TestsUtil.generateRandomText().toUpperCase();
 
-            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, {'emailDomain': tenantHost}, function(err) {
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, tenantDescription, tenantHost, {'emailDomains': [tenantHost]}, function(err) {
                 assert.ok(!err);
 
                 // Verify that the existing tenant is still running
@@ -1003,18 +1018,18 @@ describe('Tenants', function() {
                     assert.ok(tenant);
                     assert.strictEqual(tenant.alias, tenantAlias);
                     assert.strictEqual(tenant.host, tenantHost.toLowerCase());
-                    assert.strictEqual(tenant.emailDomain, tenantHost.toLowerCase());
+                    assert.strictEqual(tenant.emailDomains[0], tenantHost.toLowerCase());
 
                     // Verify we can get the tenant by email match
                     var tenantByEmailMatch = TenantsAPI.getTenantByEmail(tenantHost);
                     assert.ok(tenantByEmailMatch);
                     assert.strictEqual(tenantByEmailMatch.alias, tenantAlias);
                     assert.strictEqual(tenantByEmailMatch.host, tenantHost.toLowerCase());
-                    assert.strictEqual(tenantByEmailMatch.emailDomain, tenantHost.toLowerCase());
+                    assert.strictEqual(tenantByEmailMatch.emailDomains[0], tenantHost.toLowerCase());
 
                     // Update the tenant, ensuring that the host and email
                     // domain remain lower case
-                    RestAPI.Tenants.updateTenant(globalAdminRestContext, tenantAlias, {'host': tenantHost2, 'emailDomain': tenantHost2}, function(err, updatedTenant) {
+                    RestAPI.Tenants.updateTenant(globalAdminRestContext, tenantAlias, {'host': tenantHost2, 'emailDomains': [tenantHost2]}, function(err, updatedTenant) {
                         assert.ok(!err);
 
                         uppercaseRestContext = TestsUtil.createTenantRestContext(tenantHost2);
@@ -1023,7 +1038,7 @@ describe('Tenants', function() {
                             assert.ok(tenant2);
                             assert.strictEqual(tenant2.alias, tenantAlias);
                             assert.strictEqual(tenant2.host, tenantHost2.toLowerCase());
-                            assert.strictEqual(tenant2.emailDomain, tenantHost2.toLowerCase());
+                            assert.strictEqual(tenant2.emailDomains[0], tenantHost2.toLowerCase());
 
 
                             // Verify we can still get the tenant by email domain
@@ -1032,13 +1047,13 @@ describe('Tenants', function() {
                             assert.ok(tenantByEmailMatch);
                             assert.strictEqual(tenantByEmailMatch.alias, tenantAlias);
                             assert.strictEqual(tenantByEmailMatch.host, tenantHost2.toLowerCase());
-                            assert.strictEqual(tenantByEmailMatch.emailDomain, tenantHost2.toLowerCase());
+                            assert.strictEqual(tenantByEmailMatch.emailDomains[0], tenantHost2.toLowerCase());
 
                             tenantByEmailMatch = TenantsAPI.getTenantByEmail(tenantHost2.toLowerCase());
                             assert.ok(tenantByEmailMatch);
                             assert.strictEqual(tenantByEmailMatch.alias, tenantAlias);
                             assert.strictEqual(tenantByEmailMatch.host, tenantHost2.toLowerCase());
-                            assert.strictEqual(tenantByEmailMatch.emailDomain, tenantHost2.toLowerCase());
+                            assert.strictEqual(tenantByEmailMatch.emailDomains[0], tenantHost2.toLowerCase());
 
                             return callback();
                         });
@@ -1406,52 +1421,32 @@ describe('Tenants', function() {
                 RestAPI.Tenants.updateTenant(globalAdminRestContext, 'camtest', {'alias': 'foobar'}, function(err) {
                     assert.ok(err);
                     assert.equal(err.code, 400);
-                    // Verify update with a valid and an invalid property
-                    RestAPI.Tenants.updateTenant(globalAdminRestContext, 'camtest', {'alias': 'foobar', 'displayName': 'Anglia Ruskin University'}, function(err) {
+
+                    // Verify through a user tenant
+                    RestAPI.Tenants.updateTenant(camAdminRestContext, null, null, function(err) {
                         assert.ok(err);
                         assert.equal(err.code, 400);
-                        // Verify update a non-existing property
-                        RestAPI.Tenants.updateTenant(globalAdminRestContext, 'camtest', {'noneexisting': 'foobar'}, function(err) {
+                        // Verify update with an invalid property
+                        RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'alias': 'foobar'}, function(err) {
                             assert.ok(err);
                             assert.equal(err.code, 400);
 
-                            // Verify through a user tenant
-                            RestAPI.Tenants.updateTenant(camAdminRestContext, null, null, function(err) {
+                            // Verify updating to host that's already used
+                            RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'host': 'caMBriDGe.oae.com'}, function(err) {
                                 assert.ok(err);
                                 assert.equal(err.code, 400);
-                                // Verify update with an invalid property
-                                RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'alias': 'foobar'}, function(err) {
+
+                                // Verify updating a non-existing tenant fails
+                                RestAPI.Tenants.updateTenant(globalAdminRestContext, TestsUtil.generateRandomText(), {'displayName': 'I\'m totally legit...'}, function(err) {
                                     assert.ok(err);
-                                    assert.equal(err.code, 400);
-                                    // Verify update with a valid and an invalid property
-                                    RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'alias': 'foobar', 'displayName': 'Anglia Ruskin University'}, function(err) {
+                                    assert.equal(err.code, 404);
+
+                                    // Verify updating country code to an invalid value
+                                    RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'countryCode': 'ZZ'}, function(err) {
                                         assert.ok(err);
                                         assert.equal(err.code, 400);
-                                        // Verify update a non-existing property
-                                        RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'noneexisting': 'foobar'}, function(err) {
-                                            assert.ok(err);
-                                            assert.equal(err.code, 400);
 
-                                            // Verify updating to host that's already used
-                                            RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'host': 'caMBriDGe.oae.com'}, function(err) {
-                                                assert.ok(err);
-                                                assert.equal(err.code, 400);
-
-                                                // Verify updating a non-existing tenant fails
-                                                RestAPI.Tenants.updateTenant(globalAdminRestContext, TestsUtil.generateRandomText(), {'displayName': 'I\'m totally legit...'}, function(err) {
-                                                    assert.ok(err);
-                                                    assert.equal(err.code, 404);
-
-                                                    // Verify updating country code to an invalid value
-                                                    RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'countryCode': 'ZZ'}, function(err) {
-                                                        assert.ok(err);
-                                                        assert.equal(err.code, 400);
-
-                                                        return callback();
-                                                    });
-                                                });
-                                            });
-                                        });
+                                        return callback();
                                     });
                                 });
                             });
@@ -1494,46 +1489,46 @@ describe('Tenants', function() {
                     var emailDomain2SuffixConflict2 = util.format('a.%s', emailDomain2);
 
                     // Ensure only global admin can update email domain
-                    RestAPI.Tenants.updateTenant(tenantAdminRestContext, null, {'emailDomain': emailDomain1}, function(err) {
+                    RestAPI.Tenants.updateTenant(tenantAdminRestContext, null, {'emailDomains': [emailDomain1]}, function(err) {
                         assert.ok(err);
                         assert.strictEqual(err.code, 401);
-                        RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomain': emailDomain1}, function(err) {
+                        RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain1]}, function(err) {
                             assert.ok(!err);
 
                             // Ensure we can't set an email domain for tenant 2 that conflicts with tenant1
-                            RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomain': emailDomain1ExactConflict}, function(err) {
+                            RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain1ExactConflict]}, function(err) {
                                 assert.ok(err);
                                 assert.strictEqual(err.code, 400);
-                                RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomain': emailDomain1SuffixConflict1}, function(err) {
+                                RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
                                     assert.ok(err);
                                     assert.strictEqual(err.code, 400);
-                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomain': emailDomain1SuffixConflict2}, function(err) {
+                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict2]}, function(err) {
                                         assert.ok(err);
                                         assert.strictEqual(err.code, 400);
 
                                         // Update tenant 2 to an email domain that doesn't conflict
-                                        RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomain': emailDomain2}, function(err) {
+                                        RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain2]}, function(err) {
                                             assert.ok(!err);
 
                                             // Ensure we can update tenant 1's email domain to conflict with itself
-                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomain': emailDomain1SuffixConflict1}, function(err) {
+                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Ensure we can't update tenant1's email domain to conflict with tenant 2's
-                                                RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomain': emailDomain2SuffixConflict1}, function(err) {
+                                                RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain2SuffixConflict1]}, function(err) {
                                                     assert.ok(err);
                                                     assert.strictEqual(err.code, 400);
-                                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomain': emailDomain2SuffixConflict2}, function(err) {
+                                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain2SuffixConflict2]}, function(err) {
                                                         assert.ok(err);
                                                         assert.strictEqual(err.code, 400);
 
                                                         // Sanity check that the email domains are now set to what we would expect
                                                         RestAPI.Tenants.getTenant(tenantAdminRestContext, null, function(err, tenant) {
                                                             assert.ok(!err);
-                                                            assert.strictEqual(tenant.emailDomain, emailDomain1SuffixConflict1.toLowerCase());
+                                                            assert.strictEqual(tenant.emailDomains[0], emailDomain1SuffixConflict1.toLowerCase());
                                                             RestAPI.Tenants.getTenant(globalAdminRestContext, uniqueString2, function(err, tenant) {
                                                                 assert.ok(!err);
-                                                                assert.strictEqual(tenant.emailDomain, emailDomain2.toLowerCase());
+                                                                assert.strictEqual(tenant.emailDomains[0], emailDomain2.toLowerCase());
 
                                                                 return callback();
                                                             });

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -958,10 +958,11 @@ describe('Tenants', function() {
          * conflicts with an existing email domain
          */
         it('verify cannot create tenant with conflicting email domain', function(callback) {
-            var uniqueString1 = TenantsTestUtil.generateTestTenantAlias();
+            var alias1 = TenantsTestUtil.generateTestTenantAlias();
+            var host1 = TenantsTestUtil.generateTestTenantHost();
             var commonTld = TenantsTestUtil.generateTestTenantHost();
             var emailDomain1 = util.format('third.second.%s', commonTld);
-            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString1, uniqueString1, uniqueString1, {'emailDomains': [emailDomain1]}, function(err) {
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias1, alias1, host1, {'emailDomains': [emailDomain1]}, function(err) {
                 assert.ok(!err);
 
                 // Conflicting domain that exactly matches an existing email domain
@@ -974,23 +975,76 @@ describe('Tenants', function() {
                 var emailDomain1SuffixConflict2 = util.format('a.%s', emailDomain1);
 
                 // Ensure exact match domain can't fall under the scope of the suffix
-                var uniqueString2 = TenantsTestUtil.generateTestTenantAlias();
-                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [emailDomain1ExactConflict]}, function(err) {
+                var alias2 = TenantsTestUtil.generateTestTenantAlias();
+                var host2 = TenantsTestUtil.generateTestTenantHost();
+                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, {'emailDomains': [emailDomain1ExactConflict]}, function(err) {
                     assert.ok(err);
                     assert.strictEqual(err.code, 400);
-                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
+                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
                         assert.ok(err);
                         assert.strictEqual(err.code, 400);
-                        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict2]}, function(err) {
+                        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, {'emailDomains': [emailDomain1SuffixConflict2]}, function(err) {
                             assert.ok(err);
                             assert.strictEqual(err.code, 400);
 
                             // Sanity check we can create a tenant with these values
-                            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, uniqueString2, uniqueString2, uniqueString2, {'emailDomains': [uniqueString2]}, function(err) {
+                            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, {'emailDomains': [host2]}, function(err) {
                                 assert.ok(!err);
 
                                 return callback();
                             });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies a tenant cannot be created with one or more email domain expressions
+         * that conflict with another tenant's existing email domain expressions
+         */
+        it('verify cannot create tenant with one or more conflicting email domains', function(callback) {
+            var alias1 = TenantsTestUtil.generateTestTenantAlias();
+            var host1 = TenantsTestUtil.generateTestTenantHost();
+            var commonTld = TenantsTestUtil.generateTestTenantHost();
+            var emailDomain1 = util.format('one.%s', commonTld);
+            var emailDomain2 = util.format('two.%s', commonTld);
+            var emailDomain3 = util.format('three.%s', commonTld);
+            var emailDomain4 = util.format('four.%s', commonTld);
+            var emailDomain5 = util.format('five.%s', commonTld);
+            var opts = {
+                'emailDomains': [emailDomain1, emailDomain2, emailDomain3]
+            };
+            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias1, alias1, host1, opts, function(err) {
+                assert.ok(!err);
+
+                // Creating a tenant where 1 email domain conflicts should fail
+                var alias2 = TenantsTestUtil.generateTestTenantAlias();
+                var host2 = TenantsTestUtil.generateTestTenantHost();
+                opts = {
+                    'emailDomains': [emailDomain3, emailDomain4, emailDomain5]
+                };
+                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, opts, function(err) {
+                    assert.ok(err);
+                    assert.strictEqual(err.code, 400);
+
+                    // Creating a tenant where multiple email domains conflict should fail
+                    opts = {
+                        'emailDomains': [emailDomain2, emailDomain3, emailDomain5]
+                    };
+                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, opts, function(err) {
+                        assert.ok(err);
+                        assert.strictEqual(err.code, 400);
+
+                        // Creating a tenant where 1 email domain suffix conflicts should fail
+                        opts = {
+                            'emailDomains': [emailDomain4, emailDomain5, commonTld]
+                        };
+                        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, opts, function(err) {
+                            assert.ok(err);
+                            assert.strictEqual(err.code, 400);
+
+                            return callback();
                         });
                     });
                 });
@@ -1457,6 +1511,86 @@ describe('Tenants', function() {
         });
 
         /**
+         * Test that verifies that updating a tenant's email domain updates the email domain index accordingly
+         */
+        it('verify updating email domains', function(callback) {
+            var commonTld = TenantsTestUtil.generateTestTenantHost();
+            var emailDomain1 = util.format('one.%s', commonTld).toLowerCase();
+            var emailDomain2 = util.format('two.%s', commonTld).toLowerCase();
+            var emailDomain3 = util.format('three.%s', commonTld).toLowerCase();
+            var emailDomain4 = util.format('four.%s', commonTld).toLowerCase();
+            var emailDomain5 = util.format('five.%s', commonTld).toLowerCase();
+
+            var alias1 = TenantsTestUtil.generateTestTenantAlias();
+            var host1 = TenantsTestUtil.generateTestTenantHost();
+
+            // Create a tenant
+            TestsUtil.createTenantWithAdmin(alias1, host1, function(err, tenant, tenantAdminRestContext) {
+                assert.ok(!err);
+
+                // Set multiple email domains
+                var update = {
+                    'emailDomains': [emailDomain1, emailDomain2, emailDomain3].sort()
+                };
+                RestAPI.Tenants.updateTenant(globalAdminRestContext, tenant.alias, update, function(err) {
+                    assert.ok(!err);
+                    RestAPI.Tenants.getTenant(globalAdminRestContext, tenant.alias, function(err, tenant) {
+                        assert.ok(!err);
+                        assert.deepEqual(tenant.emailDomains.sort(), update.emailDomains);
+
+                        // Set 1 email domain
+                        update = {
+                            'emailDomains': [emailDomain1]
+                        };
+                        RestAPI.Tenants.updateTenant(globalAdminRestContext, tenant.alias, update, function(err) {
+                            assert.ok(!err);
+                            RestAPI.Tenants.getTenant(globalAdminRestContext, tenant.alias, function(err, tenant) {
+                                assert.ok(!err);
+                                assert.deepEqual(tenant.emailDomains, update.emailDomains);
+
+                                // Ensure the other email domains can now be used to create a second tenant
+                                var alias2 = TenantsTestUtil.generateTestTenantAlias();
+                                var host2 = TenantsTestUtil.generateTestTenantHost();
+                                var opts = {
+                                    'emailDomains': [emailDomain2, emailDomain3].sort()
+                                };
+                                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, alias2, alias2, host2, opts, function(err, secondTenant) {
+                                    assert.ok(!err);
+                                    assert.deepEqual(secondTenant.emailDomains.sort(), opts.emailDomains);
+
+                                    // Unset the email domains
+                                    update = {
+                                        'emailDomains': ''
+                                    };
+                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, tenant.alias, update, function(err) {
+                                        assert.ok(!err);
+                                        RestAPI.Tenants.getTenant(globalAdminRestContext, tenant.alias, function(err, tenant) {
+                                            assert.ok(!err);
+                                            assert.strictEqual(tenant.emailDomains.length, 0);
+
+                                            // The unset email domain can now be added to another tenant
+                                            update = {
+                                                'emailDomains': [emailDomain1, emailDomain2, emailDomain3].sort()
+                                            };
+                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, secondTenant.alias, update, function(err) {
+                                                assert.ok(!err);
+                                                RestAPI.Tenants.getTenant(globalAdminRestContext, secondTenant.alias, function(err, secondTenant) {
+                                                    assert.ok(!err);
+                                                    assert.deepEqual(secondTenant.emailDomains.sort(), update.emailDomains);
+                                                    return callback();
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies updating email domains associated to a tenant
          */
         it('verify update email domains validation', function(callback) {
@@ -1464,14 +1598,15 @@ describe('Tenants', function() {
             var emailDomain1 = util.format('third.second.%s', commonTld);
             var emailDomain2 = util.format('anotherthird.anothersecond.%s', commonTld);
 
-            var uniqueString1 = TenantsTestUtil.generateTestTenantAlias();
-            var uniqueString2 = TenantsTestUtil.generateTestTenantAlias();
+            var alias1 = TenantsTestUtil.generateTestTenantAlias();
+            var host1 = TenantsTestUtil.generateTestTenantHost();
+            var alias2 = TenantsTestUtil.generateTestTenantAlias();
+            var host2 = TenantsTestUtil.generateTestTenantHost();
 
             // Create 2 tenants that we can use to conflict with one another's email domains
-            TestsUtil.createTenantWithAdmin(uniqueString1, uniqueString1, function(err, tenant, tenantAdminRestContext) {
+            TestsUtil.createTenantWithAdmin(alias1, host1, function(err, tenant, tenantAdminRestContext) {
                 assert.ok(!err);
-                var uniqueString2 = TenantsTestUtil.generateTestTenantAlias();
-                TestsUtil.createTenantWithAdmin(uniqueString2, uniqueString2, function(err) {
+                TestsUtil.createTenantWithAdmin(alias2, host2, function(err) {
 
                     // Conflicting email domain where the exact match equals existing emailDomain1
                     var emailDomain1ExactConflict = emailDomain1;
@@ -1492,33 +1627,33 @@ describe('Tenants', function() {
                     RestAPI.Tenants.updateTenant(tenantAdminRestContext, null, {'emailDomains': [emailDomain1]}, function(err) {
                         assert.ok(err);
                         assert.strictEqual(err.code, 401);
-                        RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain1]}, function(err) {
+                        RestAPI.Tenants.updateTenant(globalAdminRestContext, alias1, {'emailDomains': [emailDomain1]}, function(err) {
                             assert.ok(!err);
 
                             // Ensure we can't set an email domain for tenant 2 that conflicts with tenant1
-                            RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain1ExactConflict]}, function(err) {
+                            RestAPI.Tenants.updateTenant(globalAdminRestContext, alias2, {'emailDomains': [emailDomain1ExactConflict]}, function(err) {
                                 assert.ok(err);
                                 assert.strictEqual(err.code, 400);
-                                RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
+                                RestAPI.Tenants.updateTenant(globalAdminRestContext, alias2, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
                                     assert.ok(err);
                                     assert.strictEqual(err.code, 400);
-                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain1SuffixConflict2]}, function(err) {
+                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, alias2, {'emailDomains': [emailDomain1SuffixConflict2]}, function(err) {
                                         assert.ok(err);
                                         assert.strictEqual(err.code, 400);
 
                                         // Update tenant 2 to an email domain that doesn't conflict
-                                        RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString2, {'emailDomains': [emailDomain2]}, function(err) {
+                                        RestAPI.Tenants.updateTenant(globalAdminRestContext, alias2, {'emailDomains': [emailDomain2]}, function(err) {
                                             assert.ok(!err);
 
                                             // Ensure we can update tenant 1's email domain to conflict with itself
-                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
+                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, alias1, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Ensure we can't update tenant1's email domain to conflict with tenant 2's
-                                                RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain2SuffixConflict1]}, function(err) {
+                                                RestAPI.Tenants.updateTenant(globalAdminRestContext, alias1, {'emailDomains': [emailDomain2SuffixConflict1]}, function(err) {
                                                     assert.ok(err);
                                                     assert.strictEqual(err.code, 400);
-                                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, uniqueString1, {'emailDomains': [emailDomain2SuffixConflict2]}, function(err) {
+                                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, alias1, {'emailDomains': [emailDomain2SuffixConflict2]}, function(err) {
                                                         assert.ok(err);
                                                         assert.strictEqual(err.code, 400);
 
@@ -1526,7 +1661,7 @@ describe('Tenants', function() {
                                                         RestAPI.Tenants.getTenant(tenantAdminRestContext, null, function(err, tenant) {
                                                             assert.ok(!err);
                                                             assert.strictEqual(tenant.emailDomains[0], emailDomain1SuffixConflict1.toLowerCase());
-                                                            RestAPI.Tenants.getTenant(globalAdminRestContext, uniqueString2, function(err, tenant) {
+                                                            RestAPI.Tenants.getTenant(globalAdminRestContext, alias2, function(err, tenant) {
                                                                 assert.ok(!err);
                                                                 assert.strictEqual(tenant.emailDomains[0], emailDomain2.toLowerCase());
 

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -915,31 +915,37 @@ describe('Tenants', function() {
                                     assert.ok(err);
                                     assert.equal(err.code, 400);
 
-                                    // Try creating a tenant with a host name that's already taken
-                                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, 'Cambridge University', 'cambridge.oae.com', null, function(err) {
+                                    // Try creating a tenant with an invalid hostname
+                                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, 'Cambridge University', 'not a valid hostname', null, function(err) {
                                         assert.ok(err);
                                         assert.equal(err.code, 400);
 
-                                        // Try creating a tenant with an invalid country code
-                                        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, 'Cambridge University', tenantHost, {'countryCode': 'ZZ'}, function(err) {
+                                        // Try creating a tenant with a host name that's already taken
+                                        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, 'Cambridge University', 'cambridge.oae.com', null, function(err) {
                                             assert.ok(err);
                                             assert.equal(err.code, 400);
 
-                                            // Verify that the tenant does not exist
-                                            var tenantRestContext = TestsUtil.createTenantRestContext(tenantHost);
-                                            RestAPI.Tenants.getTenant(tenantRestContext, null, function(err, tenant) {
+                                            // Try creating a tenant with an invalid country code
+                                            TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, 'Cambridge University', tenantHost, {'countryCode': 'ZZ'}, function(err) {
                                                 assert.ok(err);
-                                                assert.equal(err.code, 418);
-                                                assert.ok(!tenant);
+                                                assert.equal(err.code, 400);
 
-                                                // Sanity check creating the tenant with our generated values and ensure the tenant exists after
-                                                TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, 'Cambridge University', tenantHost, {'countryCode': 'CA'}, function(err) {
-                                                    assert.ok(!err);
-                                                    RestAPI.Tenants.getTenant(tenantRestContext, null, function(err, tenant) {
+                                                // Verify that the tenant does not exist
+                                                var tenantRestContext = TestsUtil.createTenantRestContext(tenantHost);
+                                                RestAPI.Tenants.getTenant(tenantRestContext, null, function(err, tenant) {
+                                                    assert.ok(err);
+                                                    assert.equal(err.code, 418);
+                                                    assert.ok(!tenant);
+
+                                                    // Sanity check creating the tenant with our generated values and ensure the tenant exists after
+                                                    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, tenantAlias, 'Cambridge University', tenantHost, {'countryCode': 'CA'}, function(err) {
                                                         assert.ok(!err);
-                                                        assert.ok(tenant);
+                                                        RestAPI.Tenants.getTenant(tenantRestContext, null, function(err, tenant) {
+                                                            assert.ok(!err);
+                                                            assert.ok(tenant);
 
-                                                        return callback();
+                                                            return callback();
+                                                        });
                                                     });
                                                 });
                                             });
@@ -1490,17 +1496,35 @@ describe('Tenants', function() {
                                 assert.ok(err);
                                 assert.equal(err.code, 400);
 
-                                // Verify updating a non-existing tenant fails
-                                RestAPI.Tenants.updateTenant(globalAdminRestContext, TestsUtil.generateRandomText(), {'displayName': 'I\'m totally legit...'}, function(err) {
+                                // Verify updating with an invalid host
+                                RestAPI.Tenants.updateTenant(globalAdminRestContext, 'camtest', {'host': 'an invalid hostname'}, function(err) {
                                     assert.ok(err);
-                                    assert.equal(err.code, 404);
+                                    assert.equal(err.code, 400);
 
-                                    // Verify updating country code to an invalid value
-                                    RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'countryCode': 'ZZ'}, function(err) {
+                                    // Verify updating with an invalid email domains
+                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, 'camtest', {'emailDomains': ['an invalid email domain']}, function(err) {
                                         assert.ok(err);
                                         assert.equal(err.code, 400);
 
-                                        return callback();
+                                        // Verify updating with a set of badly serialized email domains
+                                        RestAPI.Tenants.updateTenant(globalAdminRestContext, 'camtest', {'emailDomains': ['foo.test.com,bar.test.com']}, function(err) {
+                                            assert.ok(err);
+                                            assert.equal(err.code, 400);
+
+                                            // Verify updating a non-existing tenant fails
+                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, TestsUtil.generateRandomText(), {'displayName': 'I\'m totally legit...'}, function(err) {
+                                                assert.ok(err);
+                                                assert.equal(err.code, 404);
+
+                                                // Verify updating country code to an invalid value
+                                                RestAPI.Tenants.updateTenant(camAdminRestContext, null, {'countryCode': 'ZZ'}, function(err) {
+                                                    assert.ok(err);
+                                                    assert.equal(err.code, 400);
+
+                                                    return callback();
+                                                });
+                                            });
+                                        });
                                     });
                                 });
                             });

--- a/node_modules/oae-tenants/tests/test-tenants.js
+++ b/node_modules/oae-tenants/tests/test-tenants.js
@@ -368,7 +368,7 @@ describe('Tenants', function() {
 
                     // Update the display name of the guest tenant
                     var newDisplayName = TestsUtil.generateRandomText(1);
-                    RestAPI.Tenants.updateTenant(globalAdminRestContext, 'guest', {'displayName': newDisplayName}, function(err) {
+                    TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, 'guest', {'displayName': newDisplayName}, function(err) {
                         assert.ok(!err);
 
                         // Get the guest tenant again and ensure it has the updates
@@ -1083,7 +1083,7 @@ describe('Tenants', function() {
 
                     // Update the tenant, ensuring that the host and email
                     // domain remain lower case
-                    RestAPI.Tenants.updateTenant(globalAdminRestContext, tenantAlias, {'host': tenantHost2, 'emailDomains': [tenantHost2]}, function(err, updatedTenant) {
+                    TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, tenantAlias, {'host': tenantHost2, 'emailDomains': [tenantHost2]}, function(err, updatedTenant) {
                         assert.ok(!err);
 
                         uppercaseRestContext = TestsUtil.createTenantRestContext(tenantHost2);
@@ -1532,7 +1532,7 @@ describe('Tenants', function() {
                 var update = {
                     'emailDomains': [emailDomain1, emailDomain2, emailDomain3].sort()
                 };
-                RestAPI.Tenants.updateTenant(globalAdminRestContext, tenant.alias, update, function(err) {
+                TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, tenant.alias, update, function(err) {
                     assert.ok(!err);
                     RestAPI.Tenants.getTenant(globalAdminRestContext, tenant.alias, function(err, tenant) {
                         assert.ok(!err);
@@ -1542,7 +1542,7 @@ describe('Tenants', function() {
                         update = {
                             'emailDomains': [emailDomain1]
                         };
-                        RestAPI.Tenants.updateTenant(globalAdminRestContext, tenant.alias, update, function(err) {
+                        TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, tenant.alias, update, function(err) {
                             assert.ok(!err);
                             RestAPI.Tenants.getTenant(globalAdminRestContext, tenant.alias, function(err, tenant) {
                                 assert.ok(!err);
@@ -1562,7 +1562,7 @@ describe('Tenants', function() {
                                     update = {
                                         'emailDomains': ''
                                     };
-                                    RestAPI.Tenants.updateTenant(globalAdminRestContext, tenant.alias, update, function(err) {
+                                    TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, tenant.alias, update, function(err) {
                                         assert.ok(!err);
                                         RestAPI.Tenants.getTenant(globalAdminRestContext, tenant.alias, function(err, tenant) {
                                             assert.ok(!err);
@@ -1572,7 +1572,7 @@ describe('Tenants', function() {
                                             update = {
                                                 'emailDomains': [emailDomain1, emailDomain2, emailDomain3].sort()
                                             };
-                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, secondTenant.alias, update, function(err) {
+                                            TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, secondTenant.alias, update, function(err) {
                                                 assert.ok(!err);
                                                 RestAPI.Tenants.getTenant(globalAdminRestContext, secondTenant.alias, function(err, secondTenant) {
                                                     assert.ok(!err);
@@ -1607,6 +1607,7 @@ describe('Tenants', function() {
             TestsUtil.createTenantWithAdmin(alias1, host1, function(err, tenant, tenantAdminRestContext) {
                 assert.ok(!err);
                 TestsUtil.createTenantWithAdmin(alias2, host2, function(err) {
+                    assert.ok(!err);
 
                     // Conflicting email domain where the exact match equals existing emailDomain1
                     var emailDomain1ExactConflict = emailDomain1;
@@ -1627,7 +1628,7 @@ describe('Tenants', function() {
                     RestAPI.Tenants.updateTenant(tenantAdminRestContext, null, {'emailDomains': [emailDomain1]}, function(err) {
                         assert.ok(err);
                         assert.strictEqual(err.code, 401);
-                        RestAPI.Tenants.updateTenant(globalAdminRestContext, alias1, {'emailDomains': [emailDomain1]}, function(err) {
+                        TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, alias1, {'emailDomains': [emailDomain1]}, function(err) {
                             assert.ok(!err);
 
                             // Ensure we can't set an email domain for tenant 2 that conflicts with tenant1
@@ -1642,11 +1643,11 @@ describe('Tenants', function() {
                                         assert.strictEqual(err.code, 400);
 
                                         // Update tenant 2 to an email domain that doesn't conflict
-                                        RestAPI.Tenants.updateTenant(globalAdminRestContext, alias2, {'emailDomains': [emailDomain2]}, function(err) {
+                                        TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, alias2, {'emailDomains': [emailDomain2]}, function(err) {
                                             assert.ok(!err);
 
                                             // Ensure we can update tenant 1's email domain to conflict with itself
-                                            RestAPI.Tenants.updateTenant(globalAdminRestContext, alias1, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
+                                            TenantsTestUtil.updateTenantAndWait(globalAdminRestContext, alias1, {'emailDomains': [emailDomain1SuffixConflict1]}, function(err) {
                                                 assert.ok(!err);
 
                                                 // Ensure we can't update tenant1's email domain to conflict with tenant 2's

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -159,12 +159,12 @@ var setUpTenants = module.exports.setUpTenants = function(callback) {
     var globalAdminRestContext = createGlobalAdminRestContext();
 
     // Create the Cambridge tenant
-    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'camtest', 'Cambridge University Test', 'cambridge.oae.com', {'emailDomain': 'cam.ac.uk'}, function(err, tenant) {
+    TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'camtest', 'Cambridge University Test', 'cambridge.oae.com', {'emailDomains': 'cam.ac.uk'}, function(err, tenant) {
         assert.ok(!err);
         global.oaeTests.tenants.cam = tenant;
 
         // Create the Georgia Tech tenant
-        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'gttest', 'Georgia Tech Test', 'gt.oae.com', {'emailDomain': 'gatech.edu'}, function(err, tenant) {
+        TenantsTestUtil.createTenantAndWait(globalAdminRestContext, 'gttest', 'Georgia Tech Test', 'gt.oae.com', {'emailDomains': 'gatech.edu'}, function(err, tenant) {
             assert.ok(!err);
             global.oaeTests.tenants.gt = tenant;
 
@@ -220,7 +220,7 @@ var _setUpTenantAdmins = function(callback) {
 var _setupTenantAdmin = function(tenant, callback) {
     var adminLoginId = new LoginId(tenant.alias, AuthenticationConstants.providers.LOCAL, 'administrator', { 'password': 'administrator' });
     var displayName = generateRandomText(2);
-    var email = generateTestEmailAddress(null, tenant.emailDomain);
+    var email = generateTestEmailAddress(null, tenant.emailDomains[0]);
 
     var ctx = createTenantAdminContext(tenant);
     AuthenticationAPI.createUser(ctx, adminLoginId, displayName, {'email': email}, function(err, createdUser) {
@@ -272,7 +272,7 @@ var generateTestUsers = module.exports.generateTestUsers = function(restCtx, tot
 
             var username = generateTestUserId('random-user');
             var displayName = generateTestGroupId('random-user');
-            var email = generateTestEmailAddress(username, tenant.emailDomain);
+            var email = generateTestEmailAddress(username, tenant.emailDomains[0]);
             RestAPI.User.createUser(restCtx, username, 'password', displayName, email, {}, function(err, user) {
                 if (err) {
                     return callback(err);
@@ -346,7 +346,7 @@ var generateTestGroups = module.exports.generateTestGroups = function(restContex
  */
 var createTenantWithAdmin = module.exports.createTenantWithAdmin = function(tenantAlias, tenantHost, callback) {
     var adminCtx = createGlobalAdminRestContext();
-    TenantsTestUtil.createTenantAndWait(adminCtx, tenantAlias, tenantAlias, tenantHost, {'emailDomain': tenantHost}, function(err, tenant) {
+    TenantsTestUtil.createTenantAndWait(adminCtx, tenantAlias, tenantAlias, tenantHost, {'emailDomains': tenantHost}, function(err, tenant) {
         if (err) {
             return callback(err);
         }
@@ -842,7 +842,7 @@ var _createUserWithVisibility = function(tenant, visibility, callback) {
     var password = 'password-' + randomId;
     var displayName = 'displayName-' + randomId;
     var publicAlias = 'publicAlias-' + randomId;
-    var email = generateTestEmailAddress(null, tenant.tenant.emailDomain);
+    var email = generateTestEmailAddress(null, tenant.tenant.emailDomains[0]);
     RestAPI.User.createUser(tenant.adminRestContext, username, password, displayName, email, {'visibility': visibility, 'publicAlias': publicAlias}, function(err, user) {
         assert.ok(!err);
         return callback({'user': user, 'restContext': createTenantRestContext(tenant.adminRestContext.hostHeader, username, password)});

--- a/node_modules/oae-util/lib/validator.js
+++ b/node_modules/oae-util/lib/validator.js
@@ -18,6 +18,8 @@ var tz = require('oae-util/lib/tz');
 
 var Validator = module.exports.Validator = require('validator').Validator;
 
+var HOST_REGEX = /^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?(:\d+)?$/i;
+
 var countriesByCode = null;
 
 /*!
@@ -313,6 +315,20 @@ Validator.prototype.isMediumString = function() {
  */
 Validator.prototype.isLongString = function() {
     this.len(1, 100000);
+};
+
+/**
+ * Checks whether the string is a valid host
+ *
+ * Usage:
+ * ```
+ * var validator = new Validator();
+ * validator.check(aString, error).istHost();
+ * ```
+ */
+Validator.prototype.isHost = function() {
+    this.isShortString()
+    this.regex(HOST_REGEX);
 };
 
 /**

--- a/node_modules/oae-util/tests/test-validator.js
+++ b/node_modules/oae-util/tests/test-validator.js
@@ -520,5 +520,29 @@ describe('Utilities', function() {
             return callback();
         });
 
+        /**
+         * Test that verifies the isHost validation properly verifies a value is a host
+         */
+        it('verify isHost validation', function(callback) {
+            var err = {'code': 400, 'msg': 'Funny error object, LOL'};
+
+            var validator = new Validator();
+            // A set of invalid hosts
+            validator.check('not a valid host', err).isHost();
+            validator.check('invalid,character.com', err).isHost();
+            validator.check('almost.but.not.quite com', err).isHost();
+            validator.check('localhost:', err).isHost();
+            validator.check('localhost:2000:', err).isHost();
+            assert.strictEqual(validator.getErrorCount(), 5);
+
+            // A set of valid hosts
+            validator.check('www.google.com', err).isHost();
+            validator.check('unity.ac', err).isHost();
+            validator.check('localhost:2000', err).isHost();
+            validator.check('trailing.dots.are.valid.too.', err).isHost();
+            assert.strictEqual(validator.getErrorCount(), 5);
+            return callback();
+        });
+
     });
 });


### PR DESCRIPTION
This is something that has come up during development and bringing together the list of 20k tenancies. We also received feedback from ESUP that some of their institutions have multiple email domains, which is currently impacting their ability to use the invitations feature.