### PR TITLE
Report tenant and user name in Mixpanel user profile

### DIFF
--- a/node_modules/oae-mixpanel/lib/eventlisteners/authentication.js
+++ b/node_modules/oae-mixpanel/lib/eventlisteners/authentication.js
@@ -36,6 +36,19 @@ module.exports = function(client, config) {
             return;
         }
 
+        // Create a user profile for this user in Mixpanel
+        client.people.set(user.id, {
+            // Because of FERPA/legal reasons we don't send the real name of the user
+            '$name': user.id,
+
+            // Pass along some of the user's data
+            'tenant': user.tenant.alias,
+            'strategy': strategyName,
+            'visibility': user.visibility,
+            'emailPreference': user.emailPreference
+        });
+
+        // Track the authentication event
         var params = {
             'distinct_id': user.id,
             'tenant': tenantAlias,


### PR DESCRIPTION
Currently, the Mixpanel user profiles don't appear to contain the user's name and tenant information.