### PR TITLE
Inviting guests configurable per tenant

### DIFF
--- a/node_modules/oae-authz/lib/permissions.js
+++ b/node_modules/oae-authz/lib/permissions.js
@@ -530,19 +530,18 @@ var _validateRoleChanges = function(ctx, resource, targetRoles, opts, callback) 
     // addresses that match known tenant email domains should still get an
     // invitation. Email addresses that wind up on the guest tenant should
     // be disallowed however.
-    var guestEmails = !_.chain(emailTargetRoles)
+    var guestEmails = _.chain(emailTargetRoles)
         .pluck('email')
         .map(TenantsAPI.getTenantByEmail)
         .filter({'isGuestTenant': true})
         .value();
 
     if (!_.isEmpty(guestEmails) && !TenantsUtil.canInviteGuests(ctx.user().tenant.alias)) {
-        var err = {
+        return callback({
             'code': 401,
             'invalidPrincipals': guestEmails,
             'msg': 'Guests cannot be invited from this tenant'
-        };
-        return callback(err);
+        });
     }
 
     // Get the principal ids that were accompanied with a valid email assertion, thus bypassing

--- a/node_modules/oae-authz/lib/permissions.js
+++ b/node_modules/oae-authz/lib/permissions.js
@@ -525,6 +525,26 @@ var _validateRoleChanges = function(ctx, resource, targetRoles, opts, callback) 
     var principalTargetRoles = _.first(targetRoles);
     var emailTargetRoles = _.last(targetRoles);
 
+    // Ensure that no guests can get invited on a tenant that has disabled
+    // inviting guests. When a tenant disables inviting guests, email
+    // addresses that match known tenant email domains should still get an
+    // invitation. Email addresses that wind up on the guest tenant should
+    // be disallowed however.
+    var guestEmails = !_.chain(emailTargetRoles)
+        .pluck('email')
+        .map(TenantsAPI.getTenantByEmail)
+        .filter({'isGuestTenant': true})
+        .value();
+
+    if (!_.isEmpty(guestEmails) && !TenantsUtil.canInviteGuests(ctx.user().tenant.alias)) {
+        var err = {
+            'code': 401,
+            'invalidPrincipals': guestEmails,
+            'msg': 'Guests cannot be invited from this tenant'
+        };
+        return callback(err);
+    }
+
     // Get the principal ids that were accompanied with a valid email assertion, thus bypassing
     // target interaction checks for it
     var validatedPrincipalIds = {};

--- a/node_modules/oae-authz/tests/test-invitations.js
+++ b/node_modules/oae-authz/tests/test-invitations.js
@@ -21,6 +21,7 @@ var url = require('url');
 var util = require('util');
 
 var ActivityTestUtil = require('oae-activity/lib/test/util');
+var ConfigTestUtil = require('oae-config/lib/test/util');
 var ContentTestUtil = require('oae-content/lib/test/util');
 var DiscussionsTestUtil = require('oae-discussions/lib/test/util');
 var EmailTestUtil = require('oae-email/lib/test/util');
@@ -44,6 +45,7 @@ describe('Invitations', function() {
     // Initialize some rest contexts for anonymous and admin users
     var anonymousRestContext = null;
     var camAdminRestContext = null;
+    var globalAdminRestContext = null;
 
     var _randomString = function() {
         return TestsUtil.generateRandomText(1);
@@ -186,6 +188,7 @@ describe('Invitations', function() {
     before(function(callback) {
         anonymousRestContext = TestsUtil.createTenantRestContext(global.oaeTests.tenants.cam.host);
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+        globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
         return callback();
     });
 
@@ -1859,7 +1862,25 @@ describe('Invitations', function() {
                     fns.createSucceeds(privateTenant0.publicUser.restContext, 'public', [_emailForTenantInfo(privateTenant0)], [], function(resource) {
                         // Ensure a user can create a loggedin item and share it with an email of a user from another tenant
                         fns.createSucceeds(publicTenant0.publicUser.restContext, 'loggedin', [_emailForTenantInfo(publicTenant1)], [], function(resource) {
-                            return callback();
+                            // Ensure a user can create content and invite guests that end up on the guest tenant
+                            fns.createSucceeds(publicTenant0.publicUser.restContext, 'public', ['thisemail0@defaultstoguest.local'], [], function() {
+
+                                _disableInvitingGuests(publicTenant0.tenant.alias, function() {
+                                    // Invitations that end up on the guest tenant are disallowed
+                                    fns.createFails(publicTenant0.publicUser.restContext, 'public', ['thisemail0@defaultstoguest.local'], [], 401, function() {
+                                        // Sanity check all other invitations are still accepted
+                                        fns.createFails(privateTenant0.publicUser.restContext, 'public', [_emailForTenantInfo(publicTenant0)], [], 401, function(resource) {
+                                            fns.createFails(publicTenant0.publicUser.restContext, 'public', [_emailForTenantInfo(privateTenant0)], [], 401, function(resource) {
+                                                fns.createSucceeds(privateTenant0.publicUser.restContext, 'public', [_emailForTenantInfo(privateTenant0)], [], function(resource) {
+                                                    fns.createSucceeds(publicTenant0.publicUser.restContext, 'loggedin', [_emailForTenantInfo(publicTenant1)], [], function(resource) {
+                                                        return callback();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
                         });
                     });
                 });
@@ -1926,14 +1947,16 @@ describe('Invitations', function() {
         TestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant0, publicTenant1, privateTenant0) {
             _testInvitationsAuthorizationForPublicShare(fns, publicTenant0, publicTenant1, privateTenant0, function() {
                 _testInvitationsAuthorizationForLoggedinShare(fns, publicTenant0, publicTenant1, privateTenant0, function() {
-                    _testInvitationsAuthorizationForPrivateShare(fns, publicTenant0, publicTenant1, privateTenant0, callback);
+                    _testInvitationsAuthorizationForPrivateShare(fns, publicTenant0, publicTenant1, privateTenant0, function() {
+                        _testInvitationsAuthorizationForNoGuestsShare(fns, publicTenant0, publicTenant1, privateTenant0, callback);
+                    });
                 });
             });
         });
     };
 
     /*!
-     * Ensure the authorization contraints of sharing a public resource with emails from a variety
+     * Ensure the authorization constraints of sharing a resource with emails from a variety
      * of different types of tenants are as expected
      *
      * @param  {Object}         fns             The functions specification for the resource type to test, as given in `resourceFns`
@@ -1971,7 +1994,7 @@ describe('Invitations', function() {
     };
 
     /*!
-     * Ensure the authorization contraints of sharing a loggedin resource with emails from a variety
+     * Ensure the authorization constraints of sharing a loggedin resource with emails from a variety
      * of different types of tenants are as expected
      *
      * @param  {Object}         fns             The functions specification for the resource type to test, as given in `resourceFns`
@@ -2009,7 +2032,7 @@ describe('Invitations', function() {
     };
 
     /*!
-     * Ensure the authorization contraints of sharing a private resource with emails from a variety
+     * Ensure the authorization constraints of sharing a private resource with emails from a variety
      * of different types of tenants are as expected
      *
      * @param  {Object}         fns             The functions specification for the resource type to test, as given in `resourceFns`
@@ -2035,6 +2058,46 @@ describe('Invitations', function() {
                                     fns.shareFails(managerUser.restContext, viewerUser.restContext, resource.id, ['thisemail@defaultstoguest.local'], 401, function() {
                                         fns.shareFails(managerUser.restContext, viewerUser.restContext, resource.id, [_emailForTenantInfo(privateTenant0)], 401, function() {
                                             return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    };
+
+    /*!
+     * Ensure the authorization constraints of sharing a resource with guests on
+     * a tenant that has disabled inviting guests
+     *
+     * @param  {Object}         fns             The functions specification for the resource type to test, as given in `resourceFns`
+     * @param  {Object}         publicTenant0   The tenant info of a public tenant
+     * @param  {Object}         publicTenant1   The tenant info of another public tenant
+     * @param  {Object}         privateTenant0  The tenant info of a private tenant
+     * @param  {Function}       callback        Invoked when the test is complete
+     * @throws {AssertionError}                 Thrown if any of the assertions fail
+     */
+    var _testInvitationsAuthorizationForNoGuestsShare = function(fns, publicTenant0, publicTenant1, privateTenant0, callback) {
+        _disableInvitingGuests(publicTenant0.tenant.alias, function() {
+            var managerUser = publicTenant0.publicUser;
+            var viewerUser = publicTenant0.loggedinUser;
+            // Create public resource with a viewer
+            fns.createSucceeds(managerUser.restContext, 'public', [], [viewerUser.user.id], function(resource) {
+                // Ensure manager users cannot invite emails that end up on the guest tenant
+                fns.shareSucceeds(managerUser.restContext, managerUser.restContext, resource.id, [_emailForTenantInfo(publicTenant0)], function() {
+                    fns.shareSucceeds(managerUser.restContext, managerUser.restContext, resource.id, [_emailForTenantInfo(publicTenant1)], function() {
+                        fns.shareFails(managerUser.restContext, managerUser.restContext, resource.id, ['thisemail0@defaultstoguest.local'], 401, function() {
+                            fns.shareFails(managerUser.restContext, managerUser.restContext, resource.id, [_emailForTenantInfo(privateTenant0)], 401, function() {
+                                // Ensure viewer user cannot invite emails that end up on the guest tenant
+                                fns.shareSucceeds(managerUser.restContext, viewerUser.restContext, resource.id, [_emailForTenantInfo(publicTenant0)], function() {
+                                    fns.shareSucceeds(managerUser.restContext, viewerUser.restContext, resource.id, [_emailForTenantInfo(publicTenant1)], function() {
+                                        fns.shareFails(managerUser.restContext, viewerUser.restContext, resource.id, ['thisemail1@defaultstoguest.local'], 401, function() {
+                                            fns.shareFails(managerUser.restContext, viewerUser.restContext, resource.id, [_emailForTenantInfo(privateTenant0)], 401, function() {
+                                                return callback();
+                                            });
                                         });
                                     });
                                 });
@@ -2184,13 +2247,40 @@ describe('Invitations', function() {
                         fns.setRolesSucceeds(managerUser.restContext, managerUser.restContext, resource.id, rolesExternalPublicTenant, function() {
                             fns.setRolesSucceeds(managerUser.restContext, managerUser.restContext, resource.id, rolesGuestTenant, function() {
                                 fns.setRolesFails(managerUser.restContext, managerUser.restContext, resource.id, rolesExternalPrivateTenant, 401, function() {
-                                    return callback();
+
+                                    // Ensure a user on a tenant that has disabled inviting guests
+                                    // cannot invite guests that end up on the guest tenant
+                                    _disableInvitingGuests(publicTenant0.tenant.alias, function() {
+                                        fns.setRolesSucceeds(managerUser.restContext, managerUser.restContext, resource.id, rolesSameTenant, function() {
+                                            fns.setRolesSucceeds(managerUser.restContext, managerUser.restContext, resource.id, rolesExternalPublicTenant, function() {
+                                                fns.setRolesFails(managerUser.restContext, managerUser.restContext, resource.id, rolesGuestTenant, 401, function() {
+                                                    fns.setRolesFails(managerUser.restContext, managerUser.restContext, resource.id, rolesExternalPrivateTenant, 401, function() {
+                                                        return callback();
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
                                 });
                             });
                         });
                     });
                 });
             });
+        });
+    };
+
+    /*!
+     * Disable inviting guests for a given tenant
+     *
+     * @param  {String}         tenantAlias     The alias of the tenant to disable the inviting guests feature for
+     * @param  {Function}       callback        Invoked when the configuration has been updated
+     * @throws {AssertionError}                 Thrown if any of the assertions fail
+     */
+    var _disableInvitingGuests = function(tenantAlias, callback) {
+        ConfigTestUtil.updateConfigAndWait(globalAdminRestContext, tenantAlias, {'oae-tenants/guests/allow': false}, function(err) {
+            assert.ok(!err);
+            return callback();
         });
     };
 

--- a/node_modules/oae-authz/tests/test-invitations.js
+++ b/node_modules/oae-authz/tests/test-invitations.js
@@ -1868,7 +1868,7 @@ describe('Invitations', function() {
                                 _disableInvitingGuests(publicTenant0.tenant.alias, function() {
                                     // Invitations that end up on the guest tenant are disallowed
                                     fns.createFails(publicTenant0.publicUser.restContext, 'public', ['thisemail0@defaultstoguest.local'], [], 401, function() {
-                                        // Sanity check all other invitations are still accepted
+                                        // Sanity other invitations are still unchanged
                                         fns.createFails(privateTenant0.publicUser.restContext, 'public', [_emailForTenantInfo(publicTenant0)], [], 401, function(resource) {
                                             fns.createFails(publicTenant0.publicUser.restContext, 'public', [_emailForTenantInfo(privateTenant0)], [], 401, function(resource) {
                                                 fns.createSucceeds(privateTenant0.publicUser.restContext, 'public', [_emailForTenantInfo(privateTenant0)], [], function(resource) {

--- a/node_modules/oae-tenants/config/config.js
+++ b/node_modules/oae-tenants/config/config.js
@@ -91,5 +91,12 @@ module.exports = {
         'elements': {
             'timezone': new Fields.List('Tenant Timezone', 'Tenant timezone', 'Etc/UTC', timezoneConfigValues, {'suppress': true})
         }
+    },
+    'guests': {
+        'name': 'Tenant Guests',
+        'description': 'Allow guests to be invited from this tenant',
+        'elements': {
+            'allow': new Fields.Bool('Tenant Guests', 'Allow guests to be invited from this tenant', true, {'tenantOverride': true})
+        }
     }
 };

--- a/node_modules/oae-tenants/lib/util.js
+++ b/node_modules/oae-tenants/lib/util.js
@@ -73,6 +73,16 @@ var canInteract = module.exports.canInteract = function(tenantAliasOne, tenantAl
 };
 
 /**
+ * Determine whether or not guests can be invited from the tenant identified by the given tenant alias.
+ *
+ * @param  {String}    tenantAlias         The alias of the tenant to check
+ * @return {Boolean}                       `true` if guests can be invited from the tenant. `false` otherwise
+ */
+var canInviteGuests = module.exports.canInviteGuests = function(tenantAlias) {
+    return TenantsConfig.getValue(tenantAlias, 'guests', 'allow') !== false;
+};
+
+/**
  * Returns the base URL (including protocol) for the tenant
  *
  * @param  {Tenant}     tenant  The tenant for which to retrieve the base URL


### PR DESCRIPTION
Each tenant has an “allow guests” configuration flag that determines
whether guests can be invited from this tenant. If the flag is set to
disabled, email invitations that do not match any known tenant email
domain will cause 401’s.