### PR TITLE
version api does not report useful info

### DIFF
--- a/node_modules/oae-version/lib/api.js
+++ b/node_modules/oae-version/lib/api.js
@@ -287,7 +287,7 @@ function _getBuildInfoFile(directory, callback) {
             if (parent !== directory) {
                 return _getBuildInfoFile(parent, callback);
             } else {
-                return callback(null, null);
+                return callback();
             }
         }
     });

--- a/node_modules/oae-version/lib/api.js
+++ b/node_modules/oae-version/lib/api.js
@@ -108,11 +108,11 @@ function _getUIVersion(callback) {
  * @api private
  */
 function _getVersionInfo(directory, callback) {
-    _hasBuildInfoFile(directory, function(err, hasBuildInfoFile) {
+    _getBuildInfoFile(directory, function(err, buildInfoPath) {
         if (err) {
             return callback(err);
-        } else if (hasBuildInfoFile) {
-            return _getBuildVersion(directory, callback);
+        } else if (buildInfoPath) {
+            return _getBuildVersion(buildInfoPath, callback);
         } else {
             return _getGitVersion(directory, callback);
         }
@@ -123,14 +123,13 @@ function _getVersionInfo(directory, callback) {
  * Each generated build has a `build-info.json` file that contains information about the build.
  * Parse it and return the relevant version information
  *
- * @param  {String}     directory           The directory where the build info can be found
+ * @param  {String}     buildInfoPath       The path to the build info file
  * @param  {Function}   callback            Standard callback function
  * @param  {Object}     callback.err        An error that occurred, if any
  * @param  {String}     callback.version    The version information for the directory
  * @api private
  */
-function _getBuildVersion(directory, callback) {
-    var buildInfoPath = _getBuildInfoFilePath(directory);
+function _getBuildVersion(buildInfoPath, callback) {
     fs.readFile(buildInfoPath, function(err, buildInfo) {
         if (err) {
             return callback({'code': 500, 'msg': 'Unable to read the build info file'});
@@ -262,19 +261,36 @@ function _getGitDescribeVersion(repo, branchName, tagsByCommitId, callback, _nrO
         }
     });
 }
-
 /**
- * Check whether a directory has a build-info.json file
+ * Check whether a directory has a build-info.json file. This function
+ * will recursively check each parent directory as well.
  *
- * @param  {String}     directory           The directory to get the version information for
- * @param  {Function}   callback            Standard callback function
- * @param  {Object}     callback.err        An error that occurred, if any
- * @param  {Boolean}    callback.exists     Whether the build-info.json file exists
+ * @param  {String}     directory                       The directory to get the version information for
+ * @param  {Function}   callback                        Standard callback function
+ * @param  {Object}     callback.err                    An error that occurred, if any
+ * @param  {String}     [callback.buildInfoPath]        The path to the build-info.json file. `null` if no such file could be found
  * @api private
  */
-function _hasBuildInfoFile(directory, callback) {
+function _getBuildInfoFile(directory, callback) {
     var buildInfoPath = _getBuildInfoFilePath(directory);
-    IO.exists(buildInfoPath, callback);
+    IO.exists(buildInfoPath, function(err, exists) {
+        if (err) {
+            log.error({
+                'directory': directory,
+                'err': err
+            }, 'Unable to check if a build info file exists');
+            return callback(err);
+        } else if (exists) {
+            return callback(null, buildInfoPath);
+        } else {
+            var parent = path.dirname(directory);
+            if (parent !== directory) {
+                return _getBuildInfoFile(parent, callback);
+            } else {
+                return callback(null, null);
+            }
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
Calling /api/version (or /docs/rest#!/version/getVersion) produces "Could not get the branch information" in all environments I tested.
