### PR TITLE
Missing email case-sensitivity migration for user profiles and email mappings

### DIFF
--- a/etc/migration/12.3-to-12.4/1.lowerCaseEmails.js
+++ b/etc/migration/12.3-to-12.4/1.lowerCaseEmails.js
@@ -1,0 +1,65 @@
+/*!
+ * Copyright 2016 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*!
+ * This migration script will make all existing emails in the database lower-
+ * case.
+ */
+
+var _ = require('underscore');
+var optimist = require('optimist');
+var path = require('path');
+
+var Cassandra = require('oae-util/lib/cassandra');
+var log = require('oae-logger').logger('tenants-email-domains-migrator');
+var LowerCaseEmailsMigrator = require('./lib/lowerCaseEmails');
+var OAE = require('oae-util/lib/oae');
+var TenantsAPI = require('oae-tenants');
+
+var argv = optimist.usage('$0 [--config <path/to/config.js>]')
+    .alias('c', 'config')
+    .describe('c', 'Specify an alternate config file')
+    .default('c', 'config.js')
+
+    .alias('h', 'help')
+    .describe('h', 'Show usage information')
+    .argv;
+
+if (argv.help) {
+    optimist.showHelp();
+    process.exit(0);
+}
+
+// Get the config
+var configPath = path.resolve(process.cwd(), argv.config);
+var config = require(configPath).config;
+
+// Start the application container. This will allow us to re-use existing APIs
+OAE.init(config, function(err) {
+    if (err) {
+        log().error({'err': err}, 'Unable to spin up the application server');
+        return process.exit(err.code);
+    }
+
+    LowerCaseEmailsMigrator.doMigration(function(err, stats) {
+        if (err) {
+            log().error({'err': err}, 'An error occurred while migrating emails to lower case');
+        } else {
+            log().info({'stats': stats}, 'Migration complete');
+        }
+
+        return process.exit(0);
+    });
+});

--- a/etc/migration/12.3-to-12.4/lib/lowerCaseEmails.js
+++ b/etc/migration/12.3-to-12.4/lib/lowerCaseEmails.js
@@ -1,0 +1,116 @@
+/*!
+ * Copyright 2016 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+
+var OaeUtil = require('oae-util/lib/util');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
+
+var log = require('oae-logger').logger('lowerCaseEmails-migrator');
+
+// The batch size of principals to migrate
+var BATCH_SIZE = 30;
+
+/**
+ * Migrate email addresses that are mixed case to be lower case
+ *
+ * @param  {Function}   callback                    Standard callback function
+ * @param  {Object}     callback.err                An error that occurred, if any
+ * @param  {Object}     callback.stats              The migration stats
+ * @param  {Number}     callback.stats.nSkipped     The number of principals that were skipped (groups, no mixed-case email)
+ * @param  {Number}     callback.stats.nUpdated     The number of users whose emails were updated
+ * @param  {Number}     callback.stats.nFailed      The number of users that attempted to be migrated but failed
+ */
+var doMigration = module.exports.doMigration = function(callback) {
+    var stats = {'nSkipped': 0, 'nUpdated': 0, 'nFailed': 0};
+    PrincipalsDAO.iterateAll(['principalId', 'displayName', 'email'], BATCH_SIZE, _lowerCaseEmails(stats), function(err) {
+        if (err) {
+            return callback(err);
+        }
+
+        return callback(null, stats);
+    });
+};
+
+/**
+ * Perform the lower-casing migration
+ *
+ * @param  {Object}     stats   The stats object whose stats to update as the migration occurrs. This object is updated in place
+ * @api private
+ */
+var _lowerCaseEmails = function(stats) {
+    // The function to pass into iterateAll that proesses all batches of
+    // principals
+    return function(principals, callback) {
+        _lowerCaseEmailsRecursive(principals, function(err, nSkipped, nUpdated, nFailed) {
+            if (err) {
+                return callback(err);
+            }
+
+            // Update the stats from this iteration
+            stats.nSkipped += nSkipped;
+            stats.nUpdated += nUpdated;
+            stats.nFailed += nFailed;
+
+            log().info({
+                'nSkipped': nSkipped,
+                'nUpdated': nUpdated,
+                'nFailed': nFailed,
+                'total': stats
+            }, 'Finished migrating a batch of %s principals', BATCH_SIZE);
+            return callback();
+        });
+    };
+};
+
+/**
+ * Lower-case the emails in this set of principals
+ *
+ * @param  {Principal[]}    principals          The principals whose emails to make lower case
+ * @param  {Function}       callback            Standard callback function
+ * @param  {Object}         callback.err        An error that occurred, if any
+ * @param  {Number}         callback.nSkipped   The number of principals that were skipped (groups, no mixed-case email)
+ * @param  {Number}         callback.nUpdated   The number of users whose emails were updated
+ * @param  {Number}         callback.nFailed    The number of users that attempted to be migrated but failed
+ * @api private
+ */
+var _lowerCaseEmailsRecursive = function(principals, callback, _nSkipped, _nUpdated, _nFailed) {
+    principals = principals.slice();
+    _nSkipped = _nSkipped || 0;
+    _nUpdated = _nUpdated || 0;
+    _nFailed = _nFailed || 0;
+    if (_.isEmpty(principals)) {
+        return callback(null, _nSkipped, _nUpdated, _nFailed);
+    }
+
+    // Check if the principal is all lower case. If not, we persist and update
+    // for it
+    var principal = principals.shift();
+    var newEmail = (_.isString(principal.email)) ? principal.email.toLowerCase() : principal.email;
+    var shouldUpdate = (principal.email !== newEmail);
+    OaeUtil.invokeIfNecessary(shouldUpdate, PrincipalsDAO.updatePrincipal, principal.principalId, {'email': newEmail}, function(err) {
+        if (err) {
+            log().warn({'err': err, 'principal': principal}, 'Failed to migrate a user email');
+            _nFailed++;
+        } else if (shouldUpdate) {
+            log().info({'before': principal.email, 'after': newEmail}, 'Email migrated for user "%s"', principal.displayName);
+            _nUpdated++;
+        } else {
+            _nSkipped++;
+        }
+
+        return _lowerCaseEmailsRecursive(principals, callback, _nSkipped, _nUpdated, _nFailed);
+    });
+};

--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -562,7 +562,6 @@ var _updatePrincipal = function(principalId, profileFields, callback) {
         return callback(validator.getFirstError());
     }
 
-
     // If a change is being made to the email address, we need to update the mapping
     _isEmailAddressUpdate(principalId, profileFields, function(err, isEmailAddressUpdate, oldEmail) {
         if (err) {
@@ -576,7 +575,7 @@ var _updatePrincipal = function(principalId, profileFields, callback) {
 
         // If the user's email address needs to be updated, we remove the old one from the mapping
         if (isEmailAddressUpdate) {
-            queries.push({'query': 'DELETE FROM "PrincipalsByEmail" WHERE "email" = ?', 'parameters': [oldEmail]});
+            queries.push({'query': 'DELETE FROM "PrincipalsByEmail" WHERE "email" = ? AND "principalId" = ?', 'parameters': [oldEmail, principalId]});
             queries.push({'query': 'INSERT INTO "PrincipalsByEmail" ("email", "principalId") VALUES (?, ?)', 'parameters': [profileFields.email, principalId]});
         }
 
@@ -651,9 +650,7 @@ var _isEmailAddressUpdate = function(principalId, profileFields, callback) {
     getPrincipal(principalId, function(err, user) {
         if (err) {
             return callback(err);
-        }
-
-        if (user.email !== profileFields.email) {
+        } else if (user.email !== profileFields.email) {
             return callback(null, true, user.email);
         }
 

--- a/node_modules/oae-principals/tests/test-dao.js
+++ b/node_modules/oae-principals/tests/test-dao.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var assert = require('assert');
 
 var PrincipalsDAO = require('oae-principals/lib/internal/dao');
+var PrincipalsTestUtil = require('oae-principals/lib/test/util');
 var RestAPI = require('oae-rest');
 var TestsUtil = require('oae-tests');
 
@@ -35,65 +36,53 @@ describe('Principals DAO', function() {
         return callback();
     });
 
-
-    describe('#iterateAll', function() {
+    describe('#updatePrincipal', function() {
 
         /**
-         * Test that verifies created user appears in PrincipalsDAO.iterateAll
+         * Test that verifies that updating an email address only removes the
+         * email mapping for the user whose email address is being updated
          */
-        it('verify newly created principals are returned in iterateAll', function(callback) {
-            // Create a user to test with
-            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, user) {
+        it('verify updating email address retains duplicate email mappings', function(callback) {
+            // Create 2 users whose email address will be the same
+            TestsUtil.generateTestUsers(camAdminRestContext, 2, function(err, users, mrvisser, simong) {
                 assert.ok(!err);
-                user = _.values(user)[0];
+                var email = mrvisser.user.email;
 
-                var testUsername = TestsUtil.generateTestUserId();
+                // Change Simon's email to be the same as mrvisser
+                PrincipalsTestUtil.assertUpdateUserSucceeds(simong.restContext, simong.user.id, {'email': email}, function(simong1, emailToken) {
+                    PrincipalsTestUtil.assertVerifyEmailSucceeds(simong.restContext, simong.user.id, emailToken, function() {
 
-                // Stores how many principals were in the database before we created a new one
-                var numPrincipalsOrig = 0;
-
-                // Count how many principals we currently have in the database
-                PrincipalsDAO.iterateAll(null, 1000, function(principalRows, done) {
-                    if (principalRows) {
-                        numPrincipalsOrig += principalRows.length;
-                    }
-
-                    return done();
-                }, function(err) {
-                    assert.ok(!err);
-
-                    // Create one new one, and ensure the new number of principals is numPrincipalsOrig + 1
-                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, createdUser) {
-                        assert.ok(!err);
-
-                        var numPrincipalsAfter = 0;
-                        var hasNewPrincipal = false;
-
-                        // Count the principals we have now, and ensure we iterate over the new user
-                        PrincipalsDAO.iterateAll(null, 1000, function(principalRows, done) {
-                            if (principalRows) {
-                                numPrincipalsAfter += principalRows.length;
-                                _.each(principalRows, function(principalRow) {
-                                    if (principalRow.principalId === createdUser.user.id) {
-                                        hasNewPrincipal = true;
-                                    }
-                                });
-                            }
-
-                            return done();
-                        }, function(err) {
+                        // Ensure both users are represented in the user email mapping for the email
+                        PrincipalsDAO.getUserIdsByEmails([email], function(err, userIdsByEmail) {
                             assert.ok(!err);
-                            assert.strictEqual(numPrincipalsOrig + 1, numPrincipalsAfter);
-                            assert.ok(hasNewPrincipal);
-                            return callback();
+
+                            var ids = userIdsByEmail[email];
+                            assert.ok(_.isArray(ids));
+                            assert.strictEqual(_.size(ids), 2);
+                            assert.ok(_.contains(ids, mrvisser.user.id));
+                            assert.ok(_.contains(ids, simong.user.id));
+
+                            // Now change simong's email to something else using the DAO
+                            var email1 = TestsUtil.generateTestEmailAddress().toLowerCase();
+                            PrincipalsDAO.updatePrincipal(simong.user.id, {'email': email1}, function(err) {
+                                assert.ok(!err);
+
+                                // Ensure mrvisser's email entry still has him mapped
+                                PrincipalsDAO.getUserIdsByEmails([email], function(err, userIdsByEmail) {
+                                    assert.ok(!err);
+
+                                    var ids = userIdsByEmail[email];
+                                    assert.ok(_.isArray(ids));
+                                    assert.strictEqual(_.size(ids), 1);
+                                    assert.strictEqual(ids[0], mrvisser.user.id);
+                                    return callback();
+                                });
+                            });
                         });
                     });
                 });
             });
         });
-    });
-
-    describe('#updatePrincipal', function() {
 
         /**
          * Test that verifies that restricted fields (i.e., admin:global and admin:tenant) cannot be set through
@@ -224,6 +213,60 @@ describe('Principals DAO', function() {
                         assert.ok(!err, JSON.stringify(err, null, 4));
                         assert.ok(foundUser, 'Expected to find the user we just created');
                         callback();
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies created user appears in PrincipalsDAO.iterateAll
+         */
+        it('verify newly created principals are returned in iterateAll', function(callback) {
+            // Create a user to test with
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, user) {
+                assert.ok(!err);
+                user = _.values(user)[0];
+
+                var testUsername = TestsUtil.generateTestUserId();
+
+                // Stores how many principals were in the database before we created a new one
+                var numPrincipalsOrig = 0;
+
+                // Count how many principals we currently have in the database
+                PrincipalsDAO.iterateAll(null, 1000, function(principalRows, done) {
+                    if (principalRows) {
+                        numPrincipalsOrig += principalRows.length;
+                    }
+
+                    return done();
+                }, function(err) {
+                    assert.ok(!err);
+
+                    // Create one new one, and ensure the new number of principals is numPrincipalsOrig + 1
+                    TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, createdUser) {
+                        assert.ok(!err);
+
+                        var numPrincipalsAfter = 0;
+                        var hasNewPrincipal = false;
+
+                        // Count the principals we have now, and ensure we iterate over the new user
+                        PrincipalsDAO.iterateAll(null, 1000, function(principalRows, done) {
+                            if (principalRows) {
+                                numPrincipalsAfter += principalRows.length;
+                                _.each(principalRows, function(principalRow) {
+                                    if (principalRow.principalId === createdUser.user.id) {
+                                        hasNewPrincipal = true;
+                                    }
+                                });
+                            }
+
+                            return done();
+                        }, function(err) {
+                            assert.ok(!err);
+                            assert.strictEqual(numPrincipalsOrig + 1, numPrincipalsAfter);
+                            assert.ok(hasNewPrincipal);
+                            return callback();
+                        });
                     });
                 });
             });

--- a/node_modules/oae-principals/tests/test-migrations.js
+++ b/node_modules/oae-principals/tests/test-migrations.js
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2016 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+var assert = require('assert');
+var Chance = require('chance');
+
+var AuthzTestUtil = require('oae-authz/lib/test/util');
+var Cassandra = require('oae-util/lib/cassandra');
+var ContentTestUtil = require('oae-content/lib/test/util');
+var LowerCaseEmailsMigrator = require('../../../etc/migration/12.3-to-12.4/lib/lowerCaseEmails');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
+var Redis = require('oae-util/lib/redis');
+var RestAPI = require('oae-rest');
+var SearchTestUtil = require('oae-search/lib/test/util');
+var TestsUtil = require('oae-tests');
+
+var chance = new Chance();
+
+describe('Principals Migration', function() {
+    var globalAdminRestContext = null;
+    var camAdminRestContext = null;
+
+    before(function(callback) {
+        globalAdminRestContext = TestsUtil.createGlobalAdminRestContext();
+        camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+        return callback();
+    });
+
+    /*!
+     * Randomly mix the case of the given string
+     *
+     * @param  {String}     toMix   The string whose case to mix
+     * @return {String}             The string with its case mixed
+     */
+    var _mixCase = function(toMix) {
+        return _.map(toMix, function(c) {
+            if (chance.bool()) {
+                return c.toUpperCase();
+            } else {
+                return c.toLowerCase();
+            }
+        }).join('');
+    };
+
+
+    /*!
+     * Search for the email using email search, ensuring either their
+     * presence or absense, depending on the `shoudlContain` option
+     *
+     * @param  {String[]}       emails              The email addresses for which to search
+     * @param  {Object}         opts                Execution options
+     * @param  {Boolean}        opts.shouldContain  Whether or not the search results should contain an associated user
+     * @param  {Function}       callback            Invoked when assertions are complete
+     * @throws {AssertionError}                     Thrown if the assertions fail
+     */
+    var _assertAllEmailsSearch = function(emails, opts, callback) {
+        emails = emails.slice();
+        if (_.isEmpty(emails)) {
+            return callback();
+        }
+
+        var email = emails.shift();
+        SearchTestUtil.assertSearchSucceeds(camAdminRestContext, 'email', null, {'q': email}, function(result) {
+            if (opts.shouldContain) {
+                assert.strictEqual(result.results.length, 1);
+                assert.strictEqual(result.results[0].email, email.toLowerCase());
+            } else {
+                assert.strictEqual(result.results.length, 0);
+            }
+            return _assertAllEmailsSearch(emails, opts, callback);
+        });
+    };
+
+    /*!
+     * Add the given emails to a content item, ensuring they are either added as
+     * invitations or members, depending on if we expect the emails to be
+     * found in the PrincipalsByEmail index.
+     *
+     * @param  {RestContext}    restContext         The REST context with which to share
+     * @param  {String[]}       emails              The email addresses with which to share
+     * @param  {Object}         opts                Execution options
+     * @param  {Boolean}        opts.shouldInvite   Whether we should expect the share to result in email invitations
+     * @param  {Function}       callback            Standard callback function
+     * @throws {AssertionError}                     Thrown if the assertions fail
+     */
+    var _assertAllEmailsInvite = function(restContext, emails, opts, callback) {
+        ContentTestUtil.assertCreateLinkSucceeds(restContext, 'google', 'description', 'public', 'http://www.google.ca', null, null, null, function(link) {
+            // In this case, the share targets are the raw emails, so we should
+            // expect the share to happen with just the emails. If there are matches
+            // in the PrincipalsByEmail table, then they would be used as the target
+            // principal and this operation would fail
+            RestAPI.Content.shareContent(restContext, link.id, emails, function(err) {
+                assert.ok(!err);
+                AuthzTestUtil.assertGetInvitationsSucceeds(restContext, 'content', link.id, function(invitations) {
+                    ContentTestUtil.getAllContentMembers(restContext, link.id, null, function(members) {
+                        // Since invitations will be lower-cased, to compare
+                        // the arrays we should lower case our mixed-case local
+                        // copy
+                        var lowerCased = _.map(emails, function(email) {
+                            return email.toLowerCase();
+                        });
+
+                        if (opts.shouldInvite) {
+                            // If we expected to invite them, ensure they are
+                            // all present in the invitations list
+                            assert.deepEqual(_.pluck(invitations.results, 'email').sort(), lowerCased.sort());
+                            assert.strictEqual(members.length, 1);
+                        } else {
+                            // If we expected to add them (i.e., their emails
+                            // were found in the system), then verify they exist
+                            // as members
+                            assert.strictEqual(invitations.results.length, 0);
+                            assert.strictEqual(members.length, emails.length + 1);
+                        }
+
+                        return callback();
+                    });
+                });
+            });
+        });
+    };
+
+    /**
+     * Test that verifies emails are made case insensitive
+     */
+    it('verify emails are made case insensitive', function(callback) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 51, function(err, users) {
+            assert.ok(!err);
+
+            users = _.values(users);
+            var actor = _.first(users);
+            var targets = _.rest(users);
+
+            // Mix the case of all emails that were persisted in this group
+            var userIds = _.chain(targets).pluck('user').pluck('id').value();
+            var userIdEmails = _.chain(targets)
+                .map(function(user) {
+                    return [user.user.id, {
+                        'before': user.user.email,
+                        'after': _mixCase(user.user.email)
+                    }];
+                })
+                .object()
+                .value();
+            var queries = _.chain(userIdEmails)
+                .map(function(email, userId) {
+                    return [
+                        {
+                            'query': 'UPDATE "Principals" SET "email" = ? WHERE "principalId" = ?',
+                            'parameters': [email.after, userId]
+                        },
+                        {
+                            'query': 'DELETE FROM "PrincipalsByEmail" WHERE "email" = ?',
+                            'parameters': [email.before]
+                        },
+                        {
+                            'query': 'INSERT INTO "PrincipalsByEmail" ("email", "principalId") VALUES (?, ?)',
+                            'parameters': [email.after, userId]
+                        }
+                    ];
+                })
+                .flatten()
+                .value();
+
+            // Persist the mixed case emails outside the scope of the API to
+            // reproduce the migration test conditions (i.e., there were
+            // mixed-case emails in the database at time of ugprade)
+            Cassandra.runBatchQuery(queries, function(err) {
+                assert.ok(!err);
+                Cassandra.runQuery('SELECT "principalId", "email" FROM "Principals" WHERE "principalId" IN (?)', [userIds], function(err, rows) {
+                    assert.ok(!err);
+
+                    // Update redis and search since we updated outside the
+                    // scope of the API
+                    Redis.flush(function(err) {
+                        assert.ok(!err);
+                        SearchTestUtil.reindexAll(globalAdminRestContext, function() {
+                            // Determine which users we should not be able to find in search
+                            // because of mixed-cased emails
+                            var userIdEmailsWithUpperCase = _.chain(userIdEmails)
+                                .map(function(emailInfo, userId) {
+                                    return [userId, emailInfo];
+                                })
+                                .filter(function(entries) {
+                                    var userId = entries[0];
+                                    var emailInfo = entries[1];
+
+                                    // Retain all emails that contain an upper-case character
+                                    // (excluding things that don't have uppercase variants
+                                    // like '@')
+                                    return _.some(emailInfo.after, function(c) {
+                                        return c !== c.toLowerCase() && c === c.toUpperCase();
+                                    });
+                                })
+                                .object()
+                                .value();
+                            var emailsWithUpperCase = _.chain(userIdEmailsWithUpperCase)
+                                .values()
+                                .pluck('after')
+                                .value();
+
+                            // Ensure that none of the emails can be searched for or linked to when sharing a content
+                            // item. This is the basis for the migration
+                            _assertAllEmailsSearch(emailsWithUpperCase, {'shouldContain': false}, function() {
+                                _assertAllEmailsInvite(actor.restContext, emailsWithUpperCase, {'shouldInvite': true}, function() {
+
+                                    // Run the migration
+                                    LowerCaseEmailsMigrator.doMigration(function(err, stats) {
+                                        assert.ok(!err);
+                                        assert.strictEqual(stats.nUpdated, emailsWithUpperCase.length);
+                                        assert.strictEqual(stats.nFailed, 0);
+
+                                        // Refresh the search index
+                                        SearchTestUtil.reindexAll(globalAdminRestContext, function() {
+
+                                            // Ensure the emails are now all searchable and can be matched
+                                            // when sharing
+                                            _assertAllEmailsSearch(emailsWithUpperCase, {'shouldContain': true}, function() {
+                                                _assertAllEmailsInvite(actor.restContext, emailsWithUpperCase, {'shouldInvite': false}, function() {
+                                                    return callback();
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -364,7 +364,7 @@ var createTenantWithAdmin = module.exports.createTenantWithAdmin = function(tena
 
             // Create the user and make them a tenant administrator
             var anonymousCtx = createTenantRestContext(tenantHost);
-            var email = generateTestEmailAddress('administrator', 'domain.' + tenantHost);
+            var email = generateTestEmailAddress('administrator', 'domain.' + tenantHost).toLowerCase();
             RestAPI.User.createUser(anonymousCtx, 'administrator', 'administrator', 'Tenant Administrator', email, null, function(err, tenantAdmin) {
                 if (err) {
                     return callback(err);


### PR DESCRIPTION
Currently the `Principals` and `PrincipalsByEmail` tables for active deployments will likely have mixed case emails, depending on how they were before the 12.0 release.

There should be a migration to update it to be lower cased. This implies:

1. For all user profiles in Principals, update the email to be lower case
2. For all entries in PrincipalsByEmail, add a new row keyed by the lower-cased version with the same user id mappings, and delete the old mixed-case version
