### PR TITLE
401 on user profile pictures in activity stream

### DIFF
--- a/node_modules/oae-content/tests/test-activity.js
+++ b/node_modules/oae-content/tests/test-activity.js
@@ -361,6 +361,52 @@ describe('Content Activity', function() {
         });
 
         /**
+         * Test that verifies that profile picture URLs in the comments in the activity stream are non-expiring.
+         */
+        it('verify a comment activity has a non-expiring profile picture URL', function(callback) {
+            TestsUtil.generateTestUsers(camAdminRestContext, 3, function(err, users, simong, mrvisser) {
+                assert.ok(!err);
+
+                /**
+                 * Return a profile picture stream
+                 *
+                 * @return {Stream}     A stream containing an profile picture
+                 */
+                var getPictureStream = function() {
+                    var file = __dirname + '/data/profilepic.jpg';
+                    return fs.createReadStream(file);
+                };
+
+                // Give one of the users a profile picture
+                var cropArea = {'x': 0, 'y': 0, 'width': 250, 'height': 250};
+                RestAPI.User.uploadPicture(mrvisser.restContext, mrvisser.user.id, getPictureStream, cropArea, function(err) {
+                    assert.ok(!err);
+
+                    // Create a content item to be commented on
+                    RestAPI.Content.createLink(simong.restContext, 'Google', 'Google', 'public', 'http://www.google.ca', [], [], [], function(err, link) {
+                        assert.ok(!err);
+
+                        // mrvisser is not a member, but he will comment on it
+                        RestAPI.Content.createComment(mrvisser.restContext, link.id, 'This link clearly goes to Google.', null, function(err, mrvisserComment) {
+                            assert.ok(!err);
+
+                            // mrvisser should have a notification and an activity about this because he was a recent commenter
+                            ActivityTestsUtil.collectAndGetActivityStream(mrvisser.restContext, mrvisser.user.id, null, function(err, activityStream) {
+                                assert.ok(!err);
+                                assert.equal(activityStream.items.length, 1);
+                                assert.equal(activityStream.items[0].object['oae:id'], mrvisserComment.id);
+                                assert.ok(activityStream.items[0].object.author.image);
+                                assert.ok(activityStream.items[0].object.author.image.url);
+                                assert.ok(activityStream.items[0].object.author.image.url.indexOf('expired') === -1);
+                                callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies that the "revision HTML" content of a content item
          * does not get persisted in activity streams
          */

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -634,11 +634,6 @@ describe('Content', function() {
                             assert.ok(comment.createdBy.picture.medium);
                             assert.ok(comment.createdBy.picture.large);
 
-                            // Assert that the picture URLs are non-expiring
-                            assert.ok(comment.createdBy.picture.small.indexOf('expires') === -1);
-                            assert.ok(comment.createdBy.picture.medium.indexOf('expires') === -1);
-                            assert.ok(comment.createdBy.picture.large.indexOf('expires') === -1);
-
                             // Assert that this works for replies as well
                             RestAPI.Content.createComment(bert.restContext, contentObj.id, 'Blah', comment.created, function(err, reply) {
                                 assert.ok(!err);
@@ -649,11 +644,6 @@ describe('Content', function() {
                                 assert.ok(reply.createdBy.picture.small);
                                 assert.ok(reply.createdBy.picture.medium);
                                 assert.ok(reply.createdBy.picture.large);
-
-                                // Assert that the picture URLs are non-expiring
-                                assert.ok(comment.createdBy.picture.small.indexOf('expires') === -1);
-                                assert.ok(comment.createdBy.picture.medium.indexOf('expires') === -1);
-                                assert.ok(comment.createdBy.picture.large.indexOf('expires') === -1);
 
                                 // Add a comment to the piece of content as a user with no profile picture
                                 RestAPI.Content.createComment(nicolaas.restContext, contentObj.id, 'Blih', null, function(err, comment) {
@@ -690,6 +680,7 @@ describe('Content', function() {
                                                     assert.ok(comment.createdBy.picture.small);
                                                     assert.ok(comment.createdBy.picture.medium);
                                                     assert.ok(comment.createdBy.picture.large);
+
                                                 // Verify that the comments don't have a picture for the user
                                                 // without a profile picture
                                                 } else if (comment.createdBy.id === nicolaas.user.id) {

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -635,9 +635,9 @@ describe('Content', function() {
                             assert.ok(comment.createdBy.picture.large);
 
                             // Assert that the picture URLs are non-expiring
-                            assert.ok(comment.createdBy.picture.small.indexOf('expires') !== -1);
-                            assert.ok(comment.createdBy.picture.medium.indexOf('expires') !== -1);
-                            assert.ok(comment.createdBy.picture.large.indexOf('expires') !== -1);
+                            assert.ok(comment.createdBy.picture.small.indexOf('expires') === -1);
+                            assert.ok(comment.createdBy.picture.medium.indexOf('expires') === -1);
+                            assert.ok(comment.createdBy.picture.large.indexOf('expires') === -1);
 
                             // Assert that this works for replies as well
                             RestAPI.Content.createComment(bert.restContext, contentObj.id, 'Blah', comment.created, function(err, reply) {
@@ -651,9 +651,9 @@ describe('Content', function() {
                                 assert.ok(reply.createdBy.picture.large);
 
                                 // Assert that the picture URLs are non-expiring
-                                assert.ok(comment.createdBy.picture.small.indexOf('expires') !== -1);
-                                assert.ok(comment.createdBy.picture.medium.indexOf('expires') !== -1);
-                                assert.ok(comment.createdBy.picture.large.indexOf('expires') !== -1);
+                                assert.ok(comment.createdBy.picture.small.indexOf('expires') === -1);
+                                assert.ok(comment.createdBy.picture.medium.indexOf('expires') === -1);
+                                assert.ok(comment.createdBy.picture.large.indexOf('expires') === -1);
 
                                 // Add a comment to the piece of content as a user with no profile picture
                                 RestAPI.Content.createComment(nicolaas.restContext, contentObj.id, 'Blih', null, function(err, comment) {

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -634,6 +634,11 @@ describe('Content', function() {
                             assert.ok(comment.createdBy.picture.medium);
                             assert.ok(comment.createdBy.picture.large);
 
+                            // Assert that the picture URLs are non-expiring
+                            assert.ok(comment.createdBy.picture.small.indexOf('expires') !== -1);
+                            assert.ok(comment.createdBy.picture.medium.indexOf('expires') !== -1);
+                            assert.ok(comment.createdBy.picture.large.indexOf('expires') !== -1);
+
                             // Assert that this works for replies as well
                             RestAPI.Content.createComment(bert.restContext, contentObj.id, 'Blah', comment.created, function(err, reply) {
                                 assert.ok(!err);
@@ -644,6 +649,11 @@ describe('Content', function() {
                                 assert.ok(reply.createdBy.picture.small);
                                 assert.ok(reply.createdBy.picture.medium);
                                 assert.ok(reply.createdBy.picture.large);
+
+                                // Assert that the picture URLs are non-expiring
+                                assert.ok(comment.createdBy.picture.small.indexOf('expires') !== -1);
+                                assert.ok(comment.createdBy.picture.medium.indexOf('expires') !== -1);
+                                assert.ok(comment.createdBy.picture.large.indexOf('expires') !== -1);
 
                                 // Add a comment to the piece of content as a user with no profile picture
                                 RestAPI.Content.createComment(nicolaas.restContext, contentObj.id, 'Blih', null, function(err, comment) {

--- a/node_modules/oae-content/tests/test-content.js
+++ b/node_modules/oae-content/tests/test-content.js
@@ -680,7 +680,6 @@ describe('Content', function() {
                                                     assert.ok(comment.createdBy.picture.small);
                                                     assert.ok(comment.createdBy.picture.medium);
                                                     assert.ok(comment.createdBy.picture.large);
-
                                                 // Verify that the comments don't have a picture for the user
                                                 // without a profile picture
                                                 } else if (comment.createdBy.id === nicolaas.user.id) {

--- a/node_modules/oae-messagebox/lib/util.js
+++ b/node_modules/oae-messagebox/lib/util.js
@@ -35,7 +35,7 @@ var MessageBoxConstants = require('./constants').MessageBoxConstants;
  * @param  {ActivityEntity} callback.entity     The bare message activity entity (note that this lacks an `objectType`).
  */
 var createPersistentMessageActivityEntity = module.exports.createPersistentMessageActivityEntity = function(message, callback) {
-    PrincipalsDAO.getPrincipal(message.createdBy, function(err, createdByUser) {
+    PrincipalsDAO.getPrincipal(message.createdBy.id, function(err, createdByUser) {
         if (err) {
             return callback(err);
         }

--- a/node_modules/oae-messagebox/lib/util.js
+++ b/node_modules/oae-messagebox/lib/util.js
@@ -77,6 +77,7 @@ var createPersistentMessageActivityEntity = module.exports.createPersistentMessa
  * @api private
  */
 var _createPersistentMessageActivityEntity = function(message, context) {
+    message.createdBy = PrincipalsDAO.getPrincipal(message.createdBy);
     var persistentEntity = {
         'message': message,
         'messageContext': context,

--- a/node_modules/oae-messagebox/lib/util.js
+++ b/node_modules/oae-messagebox/lib/util.js
@@ -35,37 +35,44 @@ var MessageBoxConstants = require('./constants').MessageBoxConstants;
  * @param  {ActivityEntity} callback.entity     The bare message activity entity (note that this lacks an `objectType`).
  */
 var createPersistentMessageActivityEntity = module.exports.createPersistentMessageActivityEntity = function(message, callback) {
-    var context = {};
-    if (message.replyTo) {
-        // Create the parent entity if the message is a reply
-        MessageBoxAPI.getMessages(message.messageBoxId, [message.replyTo], null, function(err, messages) {
-            if (err) {
-                return callback(err);
-            } else if (_.isEmpty(messages) || !messages[0]) {
-                return callback({'code': 404, 'msg': 'The message could not be found'});
-            }
+    PrincipalsDAO.getPrincipal(message.createdBy, function(err, createdByUser) {
+        if (err) {
+            return callback(err);
+        }
+        message.createdBy = createdByUser;
 
-            var parent = messages[0];
-            if (parent && !parent.deleted) {
-                context.parent = parent;
-                PrincipalsDAO.getPrincipal(parent.createdBy, function(err, parentUser) {
-                    if (err) {
-                        return callback(err);
-                    }
+        var context = {};
+        if (message.replyTo) {
+            // Create the parent entity if the message is a reply
+            MessageBoxAPI.getMessages(message.messageBoxId, [message.replyTo], null, function(err, messages) {
+                if (err) {
+                    return callback(err);
+                } else if (_.isEmpty(messages) || !messages[0]) {
+                    return callback({'code': 404, 'msg': 'The message could not be found'});
+                }
 
-                    context.parent.createdBy = parentUser;
+                var parent = messages[0];
+                if (parent && !parent.deleted) {
+                    context.parent = parent;
+                    PrincipalsDAO.getPrincipal(parent.createdBy, function(err, parentUser) {
+                        if (err) {
+                            return callback(err);
+                        }
 
+                        context.parent.createdBy = parentUser;
+
+                        return callback(null, _createPersistentMessageActivityEntity(message, context));
+                    });
+                } else {
+                    // The parent message has probably been deleted since this activity was triggered. Don't include it
+                    // as context to the activity
                     return callback(null, _createPersistentMessageActivityEntity(message, context));
-                });
-            } else {
-                // The parent message has probably been deleted since this activity was triggered. Don't include it
-                // as context to the activity
-                return callback(null, _createPersistentMessageActivityEntity(message, context));
-            }
-        });
-    } else {
-        return callback(null, _createPersistentMessageActivityEntity(message, context));
-    }
+                }
+            });
+        } else {
+            return callback(null, _createPersistentMessageActivityEntity(message, context));
+        }
+    });
 };
 
 /**
@@ -77,7 +84,6 @@ var createPersistentMessageActivityEntity = module.exports.createPersistentMessa
  * @api private
  */
 var _createPersistentMessageActivityEntity = function(message, context) {
-    message.createdBy = PrincipalsDAO.getPrincipal(message.createdBy);
     var persistentEntity = {
         'message': message,
         'messageContext': context,


### PR DESCRIPTION
The following was seen for a Georgia Tech user trying to load profiles pictures from different tenants in their activity feed (comment activity):

```
"NetworkError: 401 Unauthorized - https://oae.gatech.edu/api/download/signed?uri=local%3Au%2Fgatech%2FTT%2FSv%2FRL%2Fly%2FTTSvRLlyI5%2Fprofilepictures%2F1439504094885%2Fmedium.jpg&expires=1461801600000&signature=df502326421cdc625c00387570de1e0b96f53298"
```

This caused the profile pictures to not display as expected.

<img width="1503" alt="screen shot 2016-05-09 at 11 54 32" src="https://cloud.githubusercontent.com/assets/109850/15124415/d83458a2-15dc-11e6-9378-69d0b0e76594.png">
