### PR TITLE
Collabdoc revision HTML stored with activity

### DIFF
--- a/node_modules/oae-activity/lib/internal/dao.js
+++ b/node_modules/oae-activity/lib/internal/dao.js
@@ -99,6 +99,7 @@ var getActivitiesFromStreams = module.exports.getActivitiesFromStreams = functio
                 activitiesPerStream[activityStreamId] = activitiesPerStream[activityStreamId] || [];
                 activitiesPerStream[activityStreamId].push(activity);
             } catch (err) {
+                activityStr = activityStr.slice(0, 300);
                 log().warn({'err': err, 'activityId': activityId, 'value': activityStr}, 'Error parsing activity from Cassandra');
             }
         });
@@ -1026,6 +1027,7 @@ var _rowsToActivities = function(rows) {
         try {
             activities.push(JSON.parse(activityStr));
         } catch (err) {
+            activityStr = activityStr.slice(0, 300);
             log().warn({'err': err, 'activityId': activityId, 'value': activityStr}, 'Error parsing activity from Cassandra');
         }
     });

--- a/node_modules/oae-activity/lib/internal/transformer.js
+++ b/node_modules/oae-activity/lib/internal/transformer.js
@@ -46,14 +46,14 @@ var transformActivities = module.exports.transformActivities = function(ctx, act
             _getActivityEntitiesByObjectType(activityId, activity.target, activityEntitiesByObjectType);
         });
     } catch (err) {
-        var logActivities = [];
-        activities.forEach(function(activity) {
-            logActivities.push({
-                'activityActor': activity.actor.id,
-                'activityObject': activity.object.id,
-                'activityTarget': activity.target.id
-            });
+        var logActivities = _.map(activities, function(activity) {
+         return {
+                'actor': activity.actor.id,
+                'object': activity.object.id,
+                'target': activity.target.id
+            };
         });
+
         log().error({'err': err, 'activities': logActivities, 'user': ctx.user()}, 'Failed to get activity entities');
         throw err;
     }

--- a/node_modules/oae-activity/lib/internal/transformer.js
+++ b/node_modules/oae-activity/lib/internal/transformer.js
@@ -46,7 +46,15 @@ var transformActivities = module.exports.transformActivities = function(ctx, act
             _getActivityEntitiesByObjectType(activityId, activity.target, activityEntitiesByObjectType);
         });
     } catch (err) {
-        log().error({'err': err, 'activities': activities, 'user': ctx.user()}, 'Failed to get activity entities');
+        var logActivities = [];
+        activities.forEach(function(activity) {
+            logActivities.push({
+                'activityActor': activity.actor.id,
+                'activityObject': activity.object.id,
+                'activityTarget': activity.target.id
+            });
+        });
+        log().error({'err': err, 'activities': logActivities, 'user': ctx.user()}, 'Failed to get activity entities');
         throw err;
     }
     var objectTypes = _.keys(activityEntitiesByObjectType);


### PR DESCRIPTION
It looks like when a collaborative document is stored in the activity streams, it's reivison HTML might be stored with it. This is resulting in queries large enough to time out.

Additionally, when the error happens, the full activity information gets logged as well resulting in an extremely large log entry.

Additionally, it is possible that it gets retried a number of times, causing critical loss in disk space in the log volume.

The above should be analyzed and fixed.
