### PR TITLE
Investigate whether Google Apps intermediary page can be avoided

### DIFF
--- a/node_modules/oae-authentication/lib/strategies/google/init.js
+++ b/node_modules/oae-authentication/lib/strategies/google/init.js
@@ -66,7 +66,8 @@ module.exports = function() {
         };
 
         // If there's only one allowed domain, add that to options as the hosted domain
-        if(domains.length === 1) {
+        // @see https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
+        if (domains.length === 1) {
             options.hd = domains[0];
         }
 

--- a/node_modules/oae-authentication/lib/strategies/google/init.js
+++ b/node_modules/oae-authentication/lib/strategies/google/init.js
@@ -53,7 +53,8 @@ module.exports = function() {
             .compact()
             .value();
 
-        var passportStrategy = new GoogleStrategy({
+        // Set passport options
+        var options = {
             'clientID': key,
             'clientSecret': secret,
             'passReqToCallback': true,
@@ -62,7 +63,14 @@ module.exports = function() {
                 'email'
             ],
             'callbackURL': AuthenticationUtil.constructCallbackUrl(tenant, AuthenticationConstants.providers.GOOGLE)
-        },  function(req, accessToken, refreshToken, profile, done) {
+        };
+
+        // If there's only one allowed domain, add that to options as the hosted domain
+        if(domains.length === 1) {
+            options.hd = domains[0];
+        }
+
+        var passportStrategy = new GoogleStrategy(options,  function(req, accessToken, refreshToken, profile, done) {
 
             log().trace({
                 'tenant': tenant,


### PR DESCRIPTION
Currently, clicking the "Sign In" button on a tenant that's configured with Google Apps authentication causes you to be sent off to the general Google Auth page.

<img width="1664" alt="screen shot 2015-12-28 at 18 10 56" src="https://cloud.githubusercontent.com/assets/109850/12028591/5f3751ae-ad8e-11e5-8403-7e0bc23cb95f.png">

The user is then expected to enter an email address for that Google Apps domain, without any indication of them having to do so. When signing in with a different Google address, no error message is provided either.

We should investigate if we can:

- Send them directly to the SSO page Google forwards them to (preferred)
- Provide indication of what address they should use