### PR TITLE
Create feed that lists recent groups visited

### DIFF
--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -86,7 +86,8 @@ var getFullGroupProfile = module.exports.getFullGroupProfile = function(ctx, gro
                 return callback({'code': 401, 'msg': 'You do not have access to this group'});
             }
 
-            var currentUserId = (ctx.user() && ctx.user().id);
+            var currentUser = ctx.user();
+            var currentUserId = (currentUser && currentUser.id);
             OaeUtil.invokeIfNecessary(currentUserId, AuthzAPI.hasAnyRole, currentUserId, group.id, function(err, hasAnyRole) {
                 if (err) {
                     return callback(err);
@@ -123,12 +124,17 @@ var getFullGroupProfile = module.exports.getFullGroupProfile = function(ctx, gro
                         });
 
                         PrincipalsEmitter.emit(PrincipalsConstants.events.GET_GROUP_PROFILE, ctx, group);
-                        PrincipalsDAO.setLatestVisit(ctx.user(), group, new Date(), function(err, results) {
-                            if (err) {
-                                return callback(err);
-                            }
+
+                        if(currentUser && PrincipalsUtil.isUser(currentUser)) {
+                            PrincipalsDAO.setLatestVisit(currentUser, group, new Date(), function(err, results) {
+                                if (err) {
+                                    return callback(err);
+                                }
+                                return callback(null, group);
+                            });
+                        } else {
                             return callback(null, group);
-                        });
+                        }
                     });
                 });
             });
@@ -435,14 +441,14 @@ var _getRecentGroupsForUserId = function(ctx, principalId, limit, callback) {
                 return callback(err);
             }
 
-            groups = _.chain(groupIds)
+            var results = _.chain(groupIds)
                 .map(function(groupId) {
                     return groups[groupId];
                 })
                 .compact()
                 .value();
 
-            return callback(null, groups);
+            return callback(null, results);
         });
     });
 };

--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -125,7 +125,7 @@ var getFullGroupProfile = module.exports.getFullGroupProfile = function(ctx, gro
 
                         PrincipalsEmitter.emit(PrincipalsConstants.events.GET_GROUP_PROFILE, ctx, group);
 
-                        if(currentUser && PrincipalsUtil.isUser(currentUser)) {
+                        if (currentUser && PrincipalsUtil.isUser(currentUserId)) {
                             PrincipalsDAO.setLatestVisit(currentUser, group, new Date(), function(err, results) {
                                 if (err) {
                                     return callback(err);

--- a/node_modules/oae-principals/lib/api.group.js
+++ b/node_modules/oae-principals/lib/api.group.js
@@ -123,7 +123,12 @@ var getFullGroupProfile = module.exports.getFullGroupProfile = function(ctx, gro
                         });
 
                         PrincipalsEmitter.emit(PrincipalsConstants.events.GET_GROUP_PROFILE, ctx, group);
-                        return callback(null, group);
+                        PrincipalsDAO.setLatestVisit(ctx.user(), group, new Date(), function(err, results) {
+                            if (err) {
+                                return callback(err);
+                            }
+                            return callback(null, group);
+                        });
                     });
                 });
             });
@@ -370,6 +375,74 @@ var _getMembershipsLibrary = function(ctx, principalId, visibility, start, limit
 
                 return callback(null, pagedItems, nextToken);
             }
+        });
+    });
+};
+
+/**
+ * Get the most recently visited groups for a user
+ *
+ * @param  {Context}     ctx                     Standard context object containing the current user and the current tenant
+ * @param  {String}      principalId             The user to retrieve recent groups for
+ * @param  {Number}      limit                   The maximum number of results to return. Default: 5
+ * @param  {Function}    callback                Standard callback function
+ * @param  {Object}      callback.err            An error that occurred, if any
+ * @param  {Group[]}     callback.groups         The user's most recently visited groups
+ */
+var getRecentGroupsForUserId = module.exports.getRecentGroupsForUserId = function(ctx, principalId, limit, callback) {
+    limit = OaeUtil.getNumberParam(limit, 5, 1);
+
+    var validator = new Validator();
+    validator.check(principalId, {'code': 400, 'msg': 'Must specify a valid principalId'}).isPrincipalId();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    if (!PrincipalsDAO.isUser(principalId)) {
+        return callback({'code': 400, 'msg': util.format('Couldn\'t find user: %s', principalId)});
+    }
+
+    PrincipalsDAO.getPrincipal(principalId, function(err, principal) {
+        if (err) {
+            return callback(err);
+        } else if (principal.deleted) {
+            return callback({'code': 404, 'msg': util.format('Couldn\'t find user: %s', principalId)});
+        }
+
+        return _getRecentGroupsForUserId(ctx, principalId, limit, callback);
+    });
+};
+
+/**
+ * Get the most recently visited groups of a user. 
+ *
+ * @param  {Context}     ctx                     Standard context object containing the current user and the current tenant
+ * @param  {String}      principalId             The user to retrieve recent groups for
+ * @param  {Number}      limit                   The maximum number of results to return
+ * @param  {Function}    callback                Standard callback function
+ * @param  {Object}      callback.err            An error that occurred, if any
+ * @param  {Group[]}     callback.groups         The user's recently visited groups
+ * @api private
+ */
+var _getRecentGroupsForUserId = function(ctx, principalId, limit, callback) {
+
+    PrincipalsDAO.getVisitedGroups(principalId, function(err, items) {
+        var sorted = _.sortBy(items, 'latestVisit').reverse().slice(0, 5);
+        var groupIds = _.pluck(sorted, 'groupId');
+
+        PrincipalsUtil.getPrincipals(ctx, groupIds, function(err, groups) {
+            if (err) {
+                return callback(err);
+            }
+
+            groups = _.chain(groupIds)
+                .map(function(groupId) {
+                    return groups[groupId];
+                })
+                .compact()
+                .value();
+
+            return callback(null, groups);
         });
     });
 };

--- a/node_modules/oae-principals/lib/constants.js
+++ b/node_modules/oae-principals/lib/constants.js
@@ -35,8 +35,7 @@ PrincipalsConstants.events = {
     'DELETED_USER': 'deletedUser',
     'RESTORED_GROUP': 'restoredGroup',
     'RESTORED_USER': 'restoredUser',
-    'VERIFIED_EMAIL': 'verifiedEmail',
-    'VISITED_GROUP': 'visitedGroup'
+    'VERIFIED_EMAIL': 'verifiedEmail'
 };
 
 PrincipalsConstants.picture = {};

--- a/node_modules/oae-principals/lib/constants.js
+++ b/node_modules/oae-principals/lib/constants.js
@@ -35,7 +35,8 @@ PrincipalsConstants.events = {
     'DELETED_USER': 'deletedUser',
     'RESTORED_GROUP': 'restoredGroup',
     'RESTORED_USER': 'restoredUser',
-    'VERIFIED_EMAIL': 'verifiedEmail'
+    'VERIFIED_EMAIL': 'verifiedEmail',
+    'VISITED_GROUP': 'visitedGroup'
 };
 
 PrincipalsConstants.picture = {};

--- a/node_modules/oae-principals/lib/init.js
+++ b/node_modules/oae-principals/lib/init.js
@@ -68,7 +68,10 @@ var _ensureSchema = function(callback) {
         'PrincipalsByEmail': 'CREATE TABLE "PrincipalsByEmail" ("email" text, "principalId" text, PRIMARY KEY ("email", "principalId"))',
 
         // Map a user id to a desired email address and verification token
-        'PrincipalsEmailToken': 'CREATE TABLE "PrincipalsEmailToken" ("principalId" text PRIMARY KEY, "email" text, "token" text)'
+        'PrincipalsEmailToken': 'CREATE TABLE "PrincipalsEmailToken" ("principalId" text PRIMARY KEY, "email" text, "token" text)',
+
+        // Track user visits to groups they are members of
+        'UsersGroupVisits': 'CREATE TABLE "UsersGroupVisits" ("userId" text, "groupId" text, "latestVisit" text, PRIMARY KEY ("userId", "groupId"))' 
     }, callback);
 };
 

--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -108,7 +108,7 @@ var createGroup = module.exports.createGroup = function(groupId, tenantAlias, di
  * @param  {String}        principalId         The id of the principal to query
  * @param  {Function}      callback            Standard callback function
  * @param  {Object}        callback.err        An error that occurred, if any
- * @param  {User|Group}    callback.prinicpal  The principal, either a user or a group, depending on the type of entity to which the id mapped. If the principal does not exist, this will be `null`
+ * @param  {User|Group}    callback.principal  The principal, either a user or a group, depending on the type of entity to which the id mapped. If the principal does not exist, this will be `null`
  */
 var getPrincipal = module.exports.getPrincipal = function(principalId, callback) {
     if (isUser(principalId)) {
@@ -869,4 +869,62 @@ var getRestrictedFields = module.exports.getRestrictedFields = function() {
  */
 var invalidateCachedUsers = module.exports.invalidateCachedUsers = function(userIds, callback) {
     Redis.getClient().del(userIds, callback);
+};
+
+/**
+ * Create or update a record of a user visiting a group in the database
+ *
+ * @param  {User}       user            The user that visited
+ * @param  {Group}      group           The group that was visited
+ * @param  {Date}       visit           The time of the last visit
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error object, if any
+ */
+var setLatestVisit = module.exports.setLatestVisit = function(user, group, visit, callback) {
+    var q = Cassandra.constructUpsertCQL('UsersGroupVisits', ['userId', 'groupId'], [user.id, group.id], {'latestVisit': visit.getTime().toString()});
+
+    return Cassandra.runQuery(q.query, q.parameters, callback);
+};
+
+/**
+ * Query IDs of all groups for a user and when they were visited.
+ *
+ * @param  {String}        userId              The id of the user to query
+ * @param  {Function}      callback            Standard callback function
+ * @param  {Object}        callback.err        An error that occurred, if any
+ * @param  [Group]         callback.groups     Groups the user has visited. If the user has visited no groups, an empty list will be returned
+ */
+var getVisitedGroups = module.exports.getVisitedGroups = function(userId, callback) {
+    if (isUser(userId)) {
+        return _getVisitedGroupsFromCassandra(userId, callback);
+    } else {
+        return callback({'code': 404, 'msg': 'Couldn\'t find user: ' + userId});
+    }
+};
+
+/**
+ * Get IDs of all groups for a user and when they were visited.
+ *
+ * @param  {String}         userId              The ID of the user whose groups should be retrieved.
+ * @param  {Function}       callback            Standard callback function
+ * @param  {Object}         callback.err        An error that occurred, if any
+ * @param  {Group|User}     callback.groups     The groups user has visited
+ * @api private
+ */
+var _getVisitedGroupsFromCassandra = function(userId, callback) {
+    Cassandra.runQuery('SELECT * FROM "UsersGroupVisits" WHERE "userId" = ?', [userId], function (err, rows) {
+        if (err) {
+            return callback(err);
+        } else if (_.isEmpty(rows)) {
+            return callback(null, []);
+        }
+
+        var groups = _.map(rows, function(row) {
+            var hash = Cassandra.rowToHash(row);
+            hash.latestVisit = OaeUtil.getNumberParam(hash.latestVisit);
+            return hash;
+        });
+
+        return callback(null, groups);
+    });
 };

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -774,7 +774,7 @@ var _getOptionalProfileParameters = function(parameters) {
  * @HttpResponse                401                         You do not have access to this principal's groups
  * @HttpResponse                404                         The specified user could not be found
  */
-OAE.tenantRouter.on('get', '/api/user/:userId/recent', function(req, res) {
+OAE.tenantRouter.on('get', '/api/user/:userId/recent/groups', function(req, res) {
     var limit = 5;
     PrincipalsAPI.getRecentGroupsForUserId(req.ctx, req.params.userId, limit, function(err, results) {
         if (err) {

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -776,11 +776,11 @@ var _getOptionalProfileParameters = function(parameters) {
  */
 OAE.tenantRouter.on('get', '/api/user/:userId/recent', function(req, res) {
     var limit = 5;
-    PrincipalsAPI.getRecentGroupsForUserId(req.ctx, req.params.userId, limit, function(err, groups) {
+    PrincipalsAPI.getRecentGroupsForUserId(req.ctx, req.params.userId, limit, function(err, results) {
         if (err) {
             return res.send(err.code, err.msg);
         }
 
-        return res.send(200, {'results': groups});
+        return res.send(200, {'results': results});
     });
 });

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -774,7 +774,7 @@ var _getOptionalProfileParameters = function(parameters) {
  * @HttpResponse                401                         You do not have access to this principal's groups
  * @HttpResponse                404                         The specified user could not be found
  */
-OAE.tenantRouter.on('get', '/api/user/:userId/recent/groups', function(req, res) {
+OAE.tenantRouter.on('get', '/api/user/:userId/groups/recent', function(req, res) {
     var limit = 5;
     PrincipalsAPI.getRecentGroupsForUserId(req.ctx, req.params.userId, limit, function(err, results) {
         if (err) {

--- a/node_modules/oae-principals/lib/rest.user.js
+++ b/node_modules/oae-principals/lib/rest.user.js
@@ -758,3 +758,29 @@ var _getOptionalProfileParameters = function(parameters) {
         'acceptedTC': (parameters.acceptedTC === 'true')
     };
 };
+
+/**
+ * @REST getRecentGroupsForUserId
+ *
+ * Get the recently visited groups of a principal
+ *
+ * @Server      tenant
+ * @Method      GET
+ * @Path        /user/{userId}/recent
+ * @PathParam   {string}        userId                      The id of the principal for which to get the recent groups
+ * @Return      {GroupsResponse}                            The principal's recently visited groups
+ * @HttpResponse                200                         Recent groups available
+ * @HttpResponse                400                         Must specify a valid principalId
+ * @HttpResponse                401                         You do not have access to this principal's groups
+ * @HttpResponse                404                         The specified user could not be found
+ */
+OAE.tenantRouter.on('get', '/api/user/:userId/recent', function(req, res) {
+    var limit = 5;
+    PrincipalsAPI.getRecentGroupsForUserId(req.ctx, req.params.userId, limit, function(err, groups) {
+        if (err) {
+            return res.send(err.code, err.msg);
+        }
+
+        return res.send(200, {'results': groups});
+    });
+});

--- a/node_modules/oae-principals/lib/restmodel.js
+++ b/node_modules/oae-principals/lib/restmodel.js
@@ -130,6 +130,13 @@
  */
 
 /**
+ * @RESTModel RecentGroupsResponse
+ *
+ * @Required    [results]
+ * @Property    {BasicGroup[]}  results                 The members of the entity
+ */
+
+/**
  * @RESTModel Principal
  *
  * @Required    []

--- a/node_modules/oae-principals/lib/restmodel.js
+++ b/node_modules/oae-principals/lib/restmodel.js
@@ -133,7 +133,7 @@
  * @RESTModel RecentGroupsResponse
  *
  * @Required    [results]
- * @Property    {BasicGroup[]}  results                 The members of the entity
+ * @Property    {BasicGroup[]}      results                 The users's recently visited groups
  */
 
 /**

--- a/node_modules/oae-principals/tests/test-groups.js
+++ b/node_modules/oae-principals/tests/test-groups.js
@@ -685,6 +685,48 @@ describe('Groups', function() {
                 });
             });
         });
+
+        /**
+         * Test that verifies that latest visit is updated when a group is visited
+         */
+        it('verify latest visit to group is recorded and can be fetched', function(callback) {
+            // Create our test user and put them in the rest context
+            TestsUtil.generateTestUsers(camAdminRestContext, 1, function(err, users, jane) {
+                assert.ok(!err);
+                jane.restContext.user = jane.user;
+                // Create the test groups
+                RestAPI.Group.createGroup(johnRestContext, 'Group title', 'Group description', 'public', 'yes', [], [jane.user.id], function(err, groupOne) {
+                    assert.ok(!err);
+                    RestAPI.Group.createGroup(johnRestContext, 'Other Group title', 'Other Group description', 'public', 'yes', [], [jane.user.id], function(err, groupTwo) {
+                        assert.ok(!err);
+                        // Get the group profile
+                        RestAPI.Group.getGroup(jane.restContext, groupOne.id, function(err, fetchedGroup) {
+                            assert.ok(!err);
+                            assert.equal(fetchedGroup.displayName, 'Group title');
+                            assert.equal(fetchedGroup.description, 'Group description');
+                            // Check that recently visited groups includes the test group
+                            RestAPI.User.getRecentlyVisitedGroups(jane.restContext, jane.user.id, function(err, recentGroups) {
+                                assert.ok(!err);
+                                assert.equal(recentGroups.results[0].id, groupOne.id);
+                                // Visit the second group
+                                RestAPI.Group.getGroup(jane.restContext, groupTwo.id, function(err, fetchedGroup) {
+                                    assert.ok(!err);
+                                    assert.equal(fetchedGroup.displayName, 'Other Group title');
+                                    assert.equal(fetchedGroup.description, 'Other Group description');
+                                    // Check that recently visited groups includes the second group as first item and previous group as second item
+                                    RestAPI.User.getRecentlyVisitedGroups(jane.restContext, jane.user.id, function(err, recentGroups) {
+                                        assert.ok(!err);
+                                        assert.equal(recentGroups.results[0].id, groupTwo.id);
+                                        assert.equal(recentGroups.results[1].id, groupOne.id);
+                                        return callback();
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
     });
 
 


### PR DESCRIPTION
Create a new API endpoint that lists the 5 most recent groups visited by the current user. The response format of this endpoint should be a standard OAE list output that contains standard OAE group profile outputs.

This will be displayed on the personal activity page in the right hand column as a shorthand to navigate to groups you've recently visited.
