### PR TITLE
Investigate whether Google Apps intermediary page can be avoided (2)

### DIFF
--- a/node_modules/oae-authentication/lib/strategies/google/init.js
+++ b/node_modules/oae-authentication/lib/strategies/google/init.js
@@ -65,12 +65,6 @@ module.exports = function() {
             'callbackURL': AuthenticationUtil.constructCallbackUrl(tenant, AuthenticationConstants.providers.GOOGLE)
         };
 
-        // If there's only one allowed domain, add that to options as the hosted domain
-        // @see https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
-        if (domains.length === 1) {
-            options.hd = domains[0];
-        }
-
         var passportStrategy = new GoogleStrategy(options,  function(req, accessToken, refreshToken, profile, done) {
 
             log().trace({

--- a/node_modules/oae-authentication/lib/strategies/google/rest.js
+++ b/node_modules/oae-authentication/lib/strategies/google/rest.js
@@ -15,8 +15,10 @@
 
 var passport = require('passport');
 
+var ConfigAPI = require('oae-config');
 var OAE = require('oae-util/lib/oae');
 
+var AuthenticationConfig = ConfigAPI.config('oae-authentication');
 var AuthenticationConstants = require('oae-authentication/lib/constants').AuthenticationConstants;
 var AuthenticationUtil = require('oae-authentication/lib/util');
 
@@ -35,10 +37,17 @@ var AuthenticationUtil = require('oae-authentication/lib/util');
 OAE.tenantRouter.on('post', '/api/auth/google', function(req, res, next) {
     // Get the ID under which we registered this strategy for this tenant
     var strategyId = AuthenticationUtil.getStrategyId(req.tenant, AuthenticationConstants.providers.GOOGLE);
+
+    // If there's only one allowed domain, add that to options as the hosted domain
+    // @see https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
+    var domains = AuthenticationConfig.getValue(req.tenant.alias, AuthenticationConstants.providers.GOOGLE, 'domains').split(',');
+    var domain = domains.length === 1 ? domains[0] : '';
+
     var options = {
         // To avoid authenticating with the wrong Google account, we give the user the opportunity to select or add
         // the correct account during the OAuth authentication cycle
-        'prompt': 'select_account'
+        'prompt': 'select_account',
+        'hd': domain
     };
 
     // Perform the initial authentication step

--- a/node_modules/oae-authentication/lib/strategies/google/rest.js
+++ b/node_modules/oae-authentication/lib/strategies/google/rest.js
@@ -38,17 +38,19 @@ OAE.tenantRouter.on('post', '/api/auth/google', function(req, res, next) {
     // Get the ID under which we registered this strategy for this tenant
     var strategyId = AuthenticationUtil.getStrategyId(req.tenant, AuthenticationConstants.providers.GOOGLE);
 
-    // If there's only one allowed domain, add that to options as the hosted domain
-    // @see https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
-    var domains = AuthenticationConfig.getValue(req.tenant.alias, AuthenticationConstants.providers.GOOGLE, 'domains').split(',');
-    var domain = domains.length === 1 ? domains[0] : '';
-
     var options = {
         // To avoid authenticating with the wrong Google account, we give the user the opportunity to select or add
         // the correct account during the OAuth authentication cycle
-        'prompt': 'select_account',
-        'hd': domain
+        'prompt': 'select_account'
     };
+
+    // If there's only one allowed domain, add that to options as the hosted domain
+    // @see https://developers.google.com/identity/protocols/OpenIDConnect#authenticationuriparameters
+    var domains = AuthenticationConfig.getValue(req.tenant.alias, AuthenticationConstants.providers.GOOGLE, 'domains').split(',');
+
+    if (domains && domains.length === 1) {
+      options['hd'] = domains[0];
+    }
 
     // Perform the initial authentication step
     AuthenticationUtil.handleExternalSetup(strategyId, options, req, res, next);


### PR DESCRIPTION
This is a follow-up ticket for https://github.com/oaeproject/Hilary/pull/1273.

It seems that the intermediary page still lists all the user's accounts even if the tenant has been configured with an email domain.

This has been discussed in https://github.com/oaeproject/Hilary/issues/809 as well.