### PR TITLE
Migrate (Cambridge) users from Google auth to Shibboleth

### DIFF
--- a/etc/migration/migrateUsersToShibboleth.js
+++ b/etc/migration/migrateUsersToShibboleth.js
@@ -94,7 +94,7 @@ function _writeErrorRow(userHash, message) {
     csvStream.write({
         'principal_id': userHash.principalId ? userHash.principalId : '',
         'email': userHash.email ? userHash.email : '',
-        'login_id': userHash.loginId ? userHash.loginId : '';,
+        'login_id': userHash.loginId ? userHash.loginId : '',
         'message': message ? message : ''
     });
     errors++;

--- a/etc/migration/migrateUsersToShibboleth.js
+++ b/etc/migration/migrateUsersToShibboleth.js
@@ -77,12 +77,27 @@ fileStream.on('error', function(err) {
     process.exit(1);
 });
 var csvStream = csv.stringify({
-    'columns': ['shib_principal_id', 'shib_email', 'shib_EPPN', 'old_principal_id', 'old_email', 'message'],
+    'columns': ['principal_id', 'email', 'message'],
     'header': true,
     'quoted': true
 });
 csvStream.pipe(fileStream);
 
+/**
+ * Write errors to a CSV file
+ *
+ * @param  {Object}     userHash                The existing user
+ * @param  {String}     message                 A short message detailing the issue
+ * @api private
+ */
+function _writeErrorRow(userHash, message) {
+    csvStream.write({
+        'principal_id': userHash.principalId ? userHash.principalId : '',
+        'email': userHash.email ? userHash.email : '',
+        'message': message ? message : ''
+    });
+    errors++;
+}
 
 // Spin up the application container. This will allow us to re-use existing APIs
 OAE.init(config, function(err) {
@@ -91,24 +106,26 @@ OAE.init(config, function(err) {
         return _exit(err.code);
     }
 
-    _getAllUsersForTenant(tenantAlias, function(err, users) {
-        _mapUsersToShibUsers(users, function(err, mappedUsers) {
-            if (err) {
-                log().error({'err':err}, 'Encountered error when migrating %s users to Shibboleth', tenantAlias);
-                return _exit(1);
-            }
+    _getAllUsersForTenant(tenantAlias, function(userHashes) {    
+        _getExternalIds(userHashes, function(usersWithIds) {
+            _mapUsersToShibLogin(usersWithIds, function(err, mappedUsers) {
+                if (err) {
+                    log().error({'err':err}, 'Encountered error when migrating %s users to Shibboleth', tenantAlias);
+                    return _exit(1);
+                }
 
-            if (_.isEmpty(mappedUsers)) {
-                util.format('No users were mapped for tenant %s', tenantAlias)
-            } else {
-                util.format('%s users were migrated to Shibboleth logins.', mappedUsers.length);
-            }
+                if (_.isEmpty(mappedUsers)) {
+                    util.format('No users were migrated for tenant %s', tenantAlias);
+                } else {
+                    util.format('%s users were migrated to Shibboleth logins.', mappedUsers.length);
+                }
 
-            if (errors > 0) {
-                log().warn('Some users were not mapped to Shibboleth users, check the CSV file for more information');
-            }
+                if (errors > 0) {
+                    log().warn('Some users could not be mapped to Shibboleth logins, check the CSV file for more information');
+                }
 
-            return _exit(0);
+                return _exit(0);
+            });
         });
     });
 });
@@ -118,24 +135,24 @@ OAE.init(config, function(err) {
  *
  * @param  {String}     tenantAlias             The tenant alias to filter by
  * @param  {Function}   callback                Invoked when users have been collected
- * @param  {Object}     callback.err            The error that occurred, if any
- * @param  {Object}     callback.userHashes     An array of user hashes
+ * @param  {Object[]}   callback.userHashes     An array of user hashes
  * @api private
  */
 var _getAllUsersForTenant = function(tenantAlias, callback) {
     var userHashes = [];
 
-    // Just get the fields we'll need later
     PrincipalsDAO.iterateAll(['principalId', 'tenantAlias', 'email'], 100, _aggregateUsers, function(err) {
         if (err) {
-            log().error({'err': err}, 'Failed to iterate all users for tenant %s', tenantAlias);
+            log().error({'err': err}, 'Failed to iterate all users');
             return _exit(1);
         }
 
         log().info('Found %s users for specified tenant', userHashes.length);
+
+        return callback(userHashes);
     });
 
-    /*
+    /*!
      * Filter users down to those that are part of the specified tenant. Then add them to the `userHashes` array
      *
      * @param  {Object[]}   principalHashes     The principals to filter and aggregate
@@ -143,7 +160,6 @@ var _getAllUsersForTenant = function(tenantAlias, callback) {
      */
     function _aggregateUsers(principalHashes, callback) {
         log().info('Checking %s principals for tenancy', principalHashes.length);
-
         _.chain(principalHashes)
             .filter(function(principalHash) {
                 return principalHash.tenantAlias === tenantAlias && PrincipalsDAO.isUser(principalHash.principalId) && principalHash.email;
@@ -155,13 +171,6 @@ var _getAllUsersForTenant = function(tenantAlias, callback) {
 
         return callback();
     }
-
-    _getExternalIds(userHashes, function(err, hashesWithId) {
-        if (err) {
-            return callback(err);
-        }
-        return callback(null, hashesWithId);
-    });
 };
 
 /**
@@ -173,25 +182,23 @@ var _getAllUsersForTenant = function(tenantAlias, callback) {
  * @api private
  */
 var _getExternalIds = function(userHashes, callback, _userHashes) {
-  _userHashes = _userHashes || [];
+    _userHashes = _userHashes || [];
 
-  if (_.isEmpty(userHashes)) {
-    return callback(null, _userHashes);
-  }
-
-  // Take the next principal hash from the collection
-  var principalHash = user.shift();
-  _findExternalId(principalHash, function(err, userHash) {
-    if (err) {
-      return callback(err);
+    if (_.isEmpty(userHashes)) {
+        return callback(_userHashes);
     }
 
-    // Accumulate the return information we want
-    _userHashes.push(userHash);
+    // Take the next principal hash from the collection
+    var principalHash = userHashes.shift();
+    _findExternalId(principalHash, function(err, userHash) {
+        if (!err && userHash) {
+            // Accumulate the return information we want
+            _userHashes.push(userHash);
+        }
 
-    // Our recursive step inside the callback for _findExternalId
-    return _getExternalIds(principalHashes, callback, _userHashes);
-  });
+        // Our recursive step inside the callback for _findExternalId
+        return _getExternalIds(userHashes, callback, _userHashes);
+    });
 };
 
 /**
@@ -208,6 +215,7 @@ function _findExternalId(userHash, callback) {
     Cassandra.runQuery('SELECT "loginId" FROM "AuthenticationUserLoginId" WHERE "userId" = ?', [userId], function(err, rows) {
         if (err) {
             log().error({'err': err}, 'Failed Cassandra query for user %s\'s loginId', userHash.email);
+            _writeErrorRow(user, 'Could not retrieve loginId for this user');
             return callback(err);
         }
 
@@ -222,29 +230,45 @@ function _findExternalId(userHash, callback) {
 }
 
 /**
- * Find all the users with Shibboleth credentials and match them to existing users on EPPN
+ * Create new authentication records linked to Shibboleth EPPN for all users within the tenant
  *
- * @param  {Array}      allUsers                The array of all the users for a tenancy
+ * @param  {Object[]}   allUsers                The array of all the users for a tenancy
  * @param  {Function}   callback                Standard callback function
  * @param  {Object}     callback.err            An error that occurred, if any
- * @param  {Array}      callback.mappedUsers    The Shibboleth users that were mapped to existing users
+ * @param  {Object[]}   callback.mappedUsers    The Shibboleth users that were mapped to existing users
  * @api private
  */
-var _mapUsersToShibUsers = function(allUsers, callback) {
-    var shibbolethUsers = _.filter(allUsers, function(user) {
-        return user.loginId && user.loginId.split(':')[1] === 'shibboleth';
-    });
+var _mapUsersToShibLogin = function(allUsers, callback) {
+    // Remove users with duplicate emails or invalid login IDs
+    var cleanedUsers = _.chain(allUsers)
+        .filter(function(user) {
+            var valid = user.loginId;
+            if (!valid) {
+                _writeErrorRow(user, 'This user has an invalid loginId');
+            }
+            return valid;
+        })
+        .groupBy(function(user) {
+            return user.email;
+        })
+        .map(function(grouped) {
+            if (grouped.length === 1) {
+                return grouped[0];
+            } else {
+                _.each(grouped, function(dupe) {
+                    _writeErrorRow(dupe, 'Found more than one user with this email');
+                });
+            }
+        })
+        .compact()
+        .value();
 
-    if (_.isEmpty(shibbolethUsers)) {
-        log().info('No Shibboleth users found for tenant %s', tenantAlias);
+    if (_.isEmpty(cleanedUsers)) {
+        log().info('No suitable users found for tenant %s', tenantAlias);
         callback(null, null);
     }
 
-    log().info('Found %s users with Shibboleth accounts', shibbolethUsers.length);
-
-    var nonShibUsers = _.difference(allUsers, shibbolethUsers);
-
-    _findMatchesAndMap(shibbolethUsers, nonShibUsers, function(err, mappedUsers) {
+    _createShibLoginRecords(cleanedUsers, function(err, mappedUsers) {
         if (err) {
             callback(err);
         }
@@ -253,164 +277,66 @@ var _mapUsersToShibUsers = function(allUsers, callback) {
     });
 };
 
-var _findMatchesAndMap = function(shibbolethUsers, nonShibUsers, callback, _mappedUsers) {
-    if (_.isEmpty(shibbolethUsers)) {
-        _.each(_.difference(nonShibUsers, _mappedUsers), function(user) {
-            _writeErrorRow(null, user, util.format('No matching Shibboleth user found for user %s', user.email));
-        });
+/**
+ * Create new authentication records linked to Shibboleth EPPN for all users within the tenant
+ *
+ * @param  {Object[]}   users                   The users to map
+ * @param  {Function}   callback                Standard callback function
+ * @param  {Object}     callback.err            An error that occurred, if any
+ * @param  {Object[]}   callback.mappedUsers    The Shibboleth users that were mapped to existing users
+ * @api private
+ */
+var _createShibLoginRecords = function(users, callback, _mappedUsers) {
+    _mappedUsers = _mappedUsers || [];
 
+    if (_.isEmpty(users)) {
         return callback(null, _mappedUsers);
     }
 
-    var userHash = shibbolethUsers.shift();
+    var userHash = users.shift();
 
     log().info('Processing user %s', userHash.email);
 
-    // Find Shibboleth EPPN for each user (if exists)
-    _findShibbolethEppn(userHash.loginId, function(err, eppn) {
-        if (!eppn) {
-            _writeErrorRow(userHash, null, 'This Shibboleth user has no EPPN');
-            _findMatchesAndMap(shibbolethUsers, nonShibUsers, _mappedUsers);
+    // Create a new login record for user
+    _createNewUserLogin(userHash, function(err) {
+        if (err) {
+            callback(err);
         }
 
-        // Extend the user object with the EPPN
-        var userWithEppn = _.extend(userHash, {'eppn': eppn});
-
-        // Find a non-Shibboleth user account with an email that matches the EPPN
-        _getUserMatches(nonShibUsers, userWithEppn, function(err, userMatch) {
-            if (err) {
-                log().warn(err);
-                _findMatchesAndMap(shibbolethUsers, nonShibUsers, _mappedUsers);
-            }
-
-            // Link the Shibboleth account to the old user account
-            _swapUserLogin(userMatch, userWithEppn, function(err) {
-                if (err) {
-                    _writeErrorRow(userWithEppn, userMatch, 'Failed to link Shibboleth login to existing user');
-                } else {
-                    _mappedUsers.push(userMatch);
-                }
-            });
-        });
+        _mappedUsers.push(userHash);
+        _createShibLoginRecords(users, callback, _mappedUsers);
     });
-
-    _findMatchesAndMap(shibbolethUsers, nonShibUsers, _mappedUsers);
 };
 
 /**
- * Write errors to a CSV file
+ * Create new Shibboleth login details for existing account
  *
- * @param  {Object}     shibUser                The Shibboleth user involved
- * @param  {Object}     oldUser                 The existing user we want to map to
- * @param  {String}     message                 A short message detailing the issue
- * @api private
- */
-function _writeErrorRow(shibUser, oldUser, message) {
-    csvStream.write({
-        'shib_principal_id': shibUser && shibUser.principalId ? shibUser.principalId : '',
-        'shib_email': shibUser && shibUser.email ? shibUser.email : '',
-        'shib_EPPN': shibUser && shibUser.eppn ? shibUser.eppn : '',
-        'old_principal_id': oldUser && oldUser.principalId ? oldUser.principalId : '',
-        'old_email': oldUser && oldUser.email ? oldUser.email : '',
-        'message': message ? message : ''
-    });
-    errors++;
-}
-
-/**
- * Find the Shibboleth EPPN of the user
- *
- * @param  {String}     loginId                 The loginId for the user
+ * @param  {Object}     userHash                The user account we want to keep
  * @param  {Function}   callback                Standard callback function
  * @param  {Object}     callback.err            An error that occurred, if any
- * @param  {String}     callback.eppn           The Shibboleth EPPN
  * @api private
  */
-function _findShibbolethEppn(loginId, callback) {
-    Cassandra.runQuery('SELECT "allAttributes" FROM "ShibbolethMetadata" WHERE "loginId" = ?', [loginId], function(err, rows) {
+var _createNewUserLogin = function(userHash, callback) {
+    var email = userHash.email;
+    var userId = userHash.principalId;
+    var newLoginId = util.format('%s:shibboleth:%s', tenantAlias, email);
+
+    Cassandra.runQuery('INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)', [newLoginId, userId, '1'], function(err, results) {
         if (err) {
-            log().error({'err': err}, 'Failed Cassandra query for Shibboleth metadata');
+            log().error({'err': err}, 'Failed to update AuthenticationUserLoginId table in Cassandra');
+            _writeErrorRow(userHash, 'Failed to update AuthenticationUserLoginId for this user');
             return callback(err);
         }
-
-        // Get the EPPN value from the Shibboleth metadata (stored as JSON)
-        var eppn = _.propertyOf(JSON.parse(rows[0].get('allAttributes').value))('eppn');
-
-        return callback(null, eppn);
-    });
-}
-
-/**
- * Get the matching user(s) for the Shibboleth user
- *
- * @param  {Array}      nonShibUsers            The users for this tenant without Shibboleth accounts
- * @param  {Object}     userWithEppn            The Shibboleth user that we are matching
- * @param  {Function}   callback                Standard callback function
- * @param  {Object}     callback.err            An error that occurred, if any
- * @param  {Object}     callback.userMatch      The user that matched the Shibboleth user
- * @api private
- */
-function _getUserMatches(nonShibUsers, userWithEppn, callback) {
-    var userMatches = _.where(nonShibUsers, {email: userWithEppn.eppn});
-
-    // If there's more than one match, we don't want to select one
-    if (userMatches.length > 1) {
-        _.each(userMatches, function(user) {
-            _writeErrorRow(userWithEppn, user, (userMatches.indexOf(user) + 1) + '. match');
-        });
-
-        return callback(util.format('Found several matches for user with EPPN %s', userWithEppn.eppn));
-    }
-
-    // If there are no matches, log the Shib user and move on
-    if (userMatches.length < 1) {
-        _writeErrorRow(userWithEppn, null, util.format('No matches found for user %s', userWithEppn.email));
-
-        return callback(util.format('Found no match for user %s'), userWithEppn.email);
-    }
-
-    var userMatch = userMatches[0];
-    log().info('Found match %s', userMatch.email);
-    return callback(null, userMatch);
-}
-
-/**
- * Link the existing account to the Shibboleth login details
- *
- * @param  {Object}     oldUser                 The old user account we want to keep
- * @param  {Object}     shibUser                The Shibboleth account that we want to link
- * @param  {Function}   callback                Standard callback function
- * @param  {Object}     callback.err            An error that occurred, if any
- * @api private
- */
-var _swapUserLogin = function(oldUser, shibUser, callback) {
-    if (!oldUser || !shibUser) {
-        callback();
-    }
-
-    var shibbolethLoginId = shibUser.loginId;
-    var shibbolethUserId = shibUser.principalId;
-    var oldUserId = oldUser.principalId;
-
-    Cassandra.runQuery('DELETE FROM "AuthenticationUserLoginId" WHERE "loginId" = ? AND "userId" = ?', [shibbolethLoginId, shibbolethUserId], function(err, results) {
-        if (err) {
-            log().error({'err': err}, 'Error removing Shibboleth user details from AuthenticationUserLoginId table in Cassandra');
-            callback(err);
-        }
-        Cassandra.runQuery('INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)', [shibbolethLoginId, oldUserId, '1'], function(err, results) {
+        Cassandra.runQuery('INSERT INTO "AuthenticationLoginId" ("loginId", "userId") VALUES (?, ?)', [newLoginId, userId], function(err, results) {
             if (err) {
-                log().error({'err': err}, 'Failed to update AuthenticationUserLoginId table in Cassandra');
-                callback(err);
+                log().error({'err': err}, 'Failed to update AuthenticationLoginId table in Cassandra');
+                _writeErrorRow(userHash, 'Failed to update AuthenticationLoginId for this user');
+                return callback(err);
             }
-            Cassandra.runQuery('UPDATE "AuthenticationLoginId" SET "userId" = ? WHERE "loginId" = ?', [oldUserId, shibbolethLoginId], function(err, results) {
-                if (err) {
-                    log().error({'err': err}, 'Failed to update AuthenticationLoginId table in Cassandra');
-                    callback(err);
-                }
-                log().info(util.format('Mapped user %s to user %s', shibUser.email, oldUser.email));
-                callback();
-             });
-        });
+
+            log().info('Created Shibboleth login record for user %s', email);
+            return callback();
+         });
     });
 };
 

--- a/etc/migration/migrateUsersToShibboleth.js
+++ b/etc/migration/migrateUsersToShibboleth.js
@@ -1,0 +1,388 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * Map user accounts created with Shibboleth to the earlier ones
+ * created with Google auth - Shibboleth EPPN should match email account.
+ */
+
+var _ = require('underscore');
+var bunyan = require('bunyan');
+var csv = require('csv');
+var fs = require('fs');
+var optimist = require('optimist');
+var path = require('path');
+var util = require('util');
+
+var Cassandra = require('oae-util/lib/cassandra');
+var log = require('oae-logger').logger('oae-script-main');
+var OAE = require('oae-util/lib/oae');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
+
+var argv = optimist.usage('$0 [-t cam] [--config <path/to/config.js>]')
+    .alias('t', 'tenant')
+    .describe('t', 'Specify the tenant alias of the tenant whose users who wish to migrate')
+
+    .alias('c', 'config')
+    .describe('c', 'Specify an alternate config file')
+    .default('c', 'config.js')
+
+    .alias('h', 'help')
+    .describe('h', 'Show usage information')
+    .argv;
+
+if (argv.help) {
+    optimist.showHelp();
+    return process.exit(1);
+}
+
+var errors = 0;
+
+// Get the config
+var configPath = path.resolve(process.cwd(), argv.config);
+var config = require(configPath).config;
+
+// ...and the tenant
+var tenantAlias = argv.tenant;
+
+// Ensure that this application server does NOT start processing any preview images
+config.previews.enabled = false;
+
+// Ensure that we're logging to standard out/err
+config.log = {
+    'streams': [
+        {
+            'level': 'info',
+            'stream': process.stdout
+        }
+    ]
+};
+
+// Set up the CSV file for errors
+var fileStream = fs.createWriteStream(tenantAlias + '-shibboleth-migration.csv');
+fileStream.on('error', function(err) {
+    log().error({'err': err}, 'Error occurred when writing to the warnings file');
+    process.exit(1);
+});
+var csvStream = csv.stringify({
+    'columns': ['shib_principal_id', 'shib_email', 'shib_EPPN', 'old_principal_id', 'old_email', 'message'],
+    'header': true,
+    'quoted': true
+});
+csvStream.pipe(fileStream);
+
+
+// Spin up the application container. This will allow us to re-use existing APIs
+OAE.init(config, function(err) {
+    if (err) {
+        log().error({'err': err}, 'Unable to spin up the application server');
+        return _exit(err.code);
+    }
+
+    _getAllUsersForTenant(tenantAlias, function(err, users) {
+        _mapUsersToShibUsers(users, function(err, mappedUsers) {
+            if (err) {
+                log().error({'err':err}, 'Encountered error when migrating %s users to Shibboleth', tenantAlias);
+                return _exit(1);
+            }
+
+            if (errors > 0) {
+                log().warn('Some users were not mapped to Shibboleth users, check the CSV file for more information');
+            }
+
+            log().info('%s users were migrated to Shibboleth login.', mappedUsers.length);
+            return _exit(0);
+        });
+    });
+});
+
+/**
+ * Page through all the users in the system, and filter them by tenant
+ *
+ * @param  {String}     tenantAlias             The tenant alias to filter by
+ * @param  {Function}   callback                Invoked when users have been collected
+ * @param  {Object}     callback.err            The error that occurred, if any
+ * @param  {Object}     callback.userHashes     An array of user hashes
+ * @api private
+ */
+var _getAllUsersForTenant = function(tenantAlias, callback) {
+    var userHashes = [];
+
+    // Just get the fields we'll need later
+    PrincipalsDAO.iterateAll(['principalId', 'tenantAlias', 'email'], 100, _aggregateUsers, function(err) {
+        if (err) {
+            log().error({'err': err}, 'Failed to iterate all users for tenant %s', tenantAlias);
+            return _exit(1);
+        }
+
+        log().info('Found %s users for specified tenant', userHashes.length);
+
+        return callback(null, userHashes);
+    });
+
+    /*
+     * Filter users down to those that are part of the specified tenant. Then add them to the `userHashes` array
+     *
+     * @param  {Object[]}   principalHashes     The principals to filter and aggregate
+     * @param  {Function}   callback            Will be invoked when the principals are aggregated
+     */
+    function _aggregateUsers(principalHashes, callback) {
+        log().info('Checking %s principals for tenancy', principalHashes.length);
+
+        _.chain(principalHashes)
+            .filter(function(principalHash) {
+                return principalHash.tenantAlias === tenantAlias && PrincipalsDAO.isUser(principalHash.principalId) && principalHash.email;
+            })
+            .each(function(userHash) {
+                // Add the external ID for each user
+                _findExternalId(userHash, function(err, userHash) {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    log().info('Adding user %s to tenant users', userHash.email);
+                    userHashes.push(userHash);
+                });
+            });
+
+        return callback();
+    }
+};
+
+/**
+ * Find the external login id for the user and add it to the user hash
+ *
+ * @param  {Object}     userHash                The user hash object
+ * @param  {Function}   callback                Standard callback function
+ * @param  {Object}     callback.err            An error that occurred, if any
+ * @param  {String}     callback.userHash       The user hash object including the external id
+ * @api private
+ */
+function _findExternalId(userHash, callback) {
+    var userId = userHash.principalId;
+    Cassandra.runQuery('SELECT "loginId" FROM "AuthenticationUserLoginId" WHERE "userId" = ?', [userId], function(err, rows) {
+        if (err) {
+            log().error({'err': err}, 'Failed Cassandra query for user %s\'s loginId', userHash.email);
+            return callback(err);
+        }
+
+        var loginId = _.chain(rows)
+            .map(Cassandra.rowToHash)
+            .pluck('loginId')
+            .first()
+            .value();
+
+        return callback(null, _.extend(userHash, {'loginId': loginId}));
+    });
+}
+
+/**
+ * Find all the users with Shibboleth credentials and match them to existing users on EPPN
+ *
+ * @param  {Array}      allUsers                The array of all the users for a tenancy
+ * @param  {Function}   callback                Standard callback function
+ * @param  {Object}     callback.err            An error that occurred, if any
+ * @param  {Array}      callback.mappedUsers    The Shibboleth users that were mapped to existing users
+ * @api private
+ */
+var _mapUsersToShibUsers = function(allUsers, callback) {
+    var shibbolethUsers = _.filter(allUsers, function(user) {
+        return user.loginId && user.loginId.split(':')[1] === 'shibboleth';
+    });
+
+    if (shibbolethUsers.length < 1) {
+        log().info('No Shibboleth users found for tenant %s', tenantAlias);
+        _exit(0);
+    }
+
+    log().info('Found %s users with Shibboleth accounts', shibbolethUsers.length);
+
+    var nonShibUsers = _.difference(allUsers, shibbolethUsers);
+
+    var mappedUsers = [];
+
+    _.each(shibbolethUsers, function(userHash) {
+        log().info('Processing user %s', userHash.email);
+
+        // Find Shibboleth EPPN for each user (if exists)
+        _findShibbolethEppn(userHash.loginId, function(err, eppn) {
+            if (!eppn) {
+                _writeErrorRow(userHash, null, 'This Shibboleth user has no EPPN');
+            }
+
+            // Extend the user object with the EPPN
+            var userWithEppn = _.extend(userHash, {'eppn': eppn});
+
+            // Find a non-Shibboleth user account with an email that matches the EPPN
+            _getUserMatches(nonShibUsers, userWithEppn, function(err, userMatch) {
+                if (err) {
+                    log().warn(err);
+                }
+
+                // Link the Shibboleth account to the old user account
+                _swapUserLogin(userMatch, userWithEppn, function(err) {
+                    if (err) {
+                        _writeErrorRow(userWithEppn, userMatch, 'Failed to link Shibboleth login to existing user');
+                    } else {
+                        mappedUsers.push(userMatch);
+                    }
+
+                    if ((shibbolethUsers.length -1) === shibbolethUsers.indexOf(userHash)) {
+                        _.each(_.difference(nonShibUsers, mappedUsers), function(user) {
+                            _writeErrorRow(null, user, util.format('No matching Shibboleth user found for user %s', user.email));
+                        });
+
+                        callback(null, mappedUsers);
+                    }
+                });
+            });
+        });
+    });
+};
+
+/**
+ * Write errors to a CSV file
+ *
+ * @param  {Object}     shibUser                The Shibboleth user involved
+ * @param  {Object}     oldUser                 The existing user we want to map to
+ * @param  {String}     message                 A short message detailing the issue
+ * @api private
+ */
+var _writeErrorRow = function(shibUser, oldUser, message) {
+    csvStream.write({
+        'shib_principal_id': shibUser && shibUser.principalId ? shibUser.principalId : '',
+        'shib_email': shibUser && shibUser.email ? shibUser.email : '',
+        'shib_EPPN': shibUser && shibUser.eppn ? shibUser.eppn : '',
+        'old_principal_id': oldUser && oldUser.principalId ? oldUser.principalId : '',
+        'old_email': oldUser && oldUser.email ? oldUser.email : '',
+        'message': message ? message : ''
+    });
+    errors++;
+};
+
+/**
+ * Find the Shibboleth EPPN of the user
+ *
+ * @param  {String}     loginId                 The loginId for the user
+ * @param  {Function}   callback                Standard callback function
+ * @param  {Object}     callback.err            An error that occurred, if any
+ * @param  {String}     callback.eppn           The Shibboleth EPPN
+ * @api private
+ */
+function _findShibbolethEppn(loginId, callback) {
+    Cassandra.runQuery('SELECT "allAttributes" FROM "ShibbolethMetadata" WHERE "loginId" = ?', [loginId], function(err, rows) {
+        if (err) {
+            log().error({'err': err}, 'Failed Cassandra query for Shibboleth metadata');
+            return callback(err);
+        }
+
+        // Get the EPPN value from the Shibboleth metadata (stored as JSON)
+        var eppn = _.propertyOf(JSON.parse(rows[0].get('allAttributes').value))('eppn');
+
+        return callback(null, eppn);
+    });
+}
+
+/**
+ * Get the matching user(s) for the Shibboleth user
+ *
+ * @param  {Array}      nonShibUsers            The users for this tenant without Shibboleth accounts
+ * @param  {Object}     userWithEppn            The Shibboleth user that we are matching
+ * @param  {Function}   callback                Standard callback function
+ * @param  {Object}     callback.err            An error that occurred, if any
+ * @param  {Object}     callback.userMatch      The user that matched the Shibboleth user
+ * @api private
+ */
+function _getUserMatches(nonShibUsers, userWithEppn, callback) {
+    var userMatches = _.where(nonShibUsers, {email: userWithEppn.eppn});
+
+    // If there's more than one match, we don't want to select one
+    if (userMatches.length > 1) {
+        _.each(userMatches, function(user) {
+            _writeErrorRow(userWithEppn, user, (userMatches.indexOf(user) + 1) + '. match');
+        });
+
+        return callback(util.format('Found several matches for user with EPPN %s', userWithEppn.eppn));
+    }
+
+    // If there are no matches, log the Shib user and move on
+    if (userMatches.length < 1) {
+        _writeErrorRow(userWithEppn, null, util.format('No matches found for user %s', userWithEppn.email));
+
+        return callback(util.format('Found no match for user %s'), userWithEppn.email);
+    }
+
+    var userMatch = userMatches[0];
+    log().info('Found match %s', userMatch.email);
+    return callback(null, userMatch);
+}
+
+/**
+ * Link the existing account to the Shibboleth login details
+ *
+ * @param  {Object}     oldUser                 The old user account we want to keep
+ * @param  {Object}     shibUser                The Shibboleth account that we want to link
+ * @param  {Function}   callback                Standard callback function
+ * @param  {Object}     callback.err            An error that occurred, if any
+ * @api private
+ */
+var _swapUserLogin = function(oldUser, shibUser, callback) {
+    if (!oldUser || !shibUser) {
+        callback();
+    }
+
+    var shibbolethLoginId = shibUser.loginId;
+    var shibbolethUserId = shibUser.principalId;
+    var oldUserId = oldUser.principalId;
+
+    Cassandra.runQuery('DELETE FROM "AuthenticationUserLoginId" WHERE "loginId" = ? AND "userId" = ?', [shibbolethLoginId, shibbolethUserId], function(err, results) {
+        if (err) {
+            log().error({'err': err}, 'Error removing Shibboleth user details from AuthenticationUserLoginId table in Cassandra');
+            callback(err);
+        }
+        Cassandra.runQuery('INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)', [shibbolethLoginId, oldUserId, '1'], function(err, results) {
+            if (err) {
+                log().error({'err': err}, 'Failed to update AuthenticationUserLoginId table in Cassandra');
+                callback(err);
+            }
+            Cassandra.runQuery('UPDATE "AuthenticationLoginId" SET "userId" = ? WHERE "loginId" = ?', [oldUserId, shibbolethLoginId], function(err, results) {
+                if (err) {
+                    log().error({'err': err}, 'Failed to update AuthenticationLoginId table in Cassandra');
+                    callback(err);
+                }
+                Cassandra.runQuery('DELETE FROM "Principals" WHERE "principalId" = ?', [shibbolethUserId], function(err, results) {
+                    if (err) {
+                        log().error({'err': err}, 'Failed to delete Shibboleth user from Principals in Cassandra');
+                        callback(err);
+                    }
+
+                    log().info(util.format('Mapped user %s to user %s', shibUser.email, oldUser.email));
+                    callback();
+                })
+             });
+        });
+    });
+};
+
+/**
+ * Exit the migration script, but wait until the CSV stream has been properly closed down
+ *
+ * @param  {Number}     code    The exit code that should be used to stop the process with
+ */
+var _exit = function(code) {
+    csvStream.end(function() {
+        process.exit(code);
+    });
+};

--- a/etc/migration/shibboleth_migration/1.migrateUsersToShibboleth.js
+++ b/etc/migration/shibboleth_migration/1.migrateUsersToShibboleth.js
@@ -1,0 +1,114 @@
+/*!
+ * Copyright 2015 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * Map user accounts created with Shibboleth to the earlier ones
+ * created with Google auth - Shibboleth EPPN should match email account.
+ */
+
+var _ = require('underscore');
+var bunyan = require('bunyan');
+var csv = require('csv');
+var fs = require('fs');
+var optimist = require('optimist');
+var path = require('path');
+
+var log = require('oae-logger').logger('oae-script-main');
+var OAE = require('oae-util/lib/oae');
+var ShibbolethMigrator = require('./migrateUsersToShibboleth');
+
+var argv = optimist.usage('$0 [-t cam] [--config <path/to/config.js>]')
+    .alias('t', 'tenant')
+    .describe('t', 'Specify the tenant alias of the tenant whose users who wish to migrate')
+
+    .alias('c', 'config')
+    .describe('c', 'Specify an alternate config file')
+    .default('c', 'config.js')
+
+    .alias('h', 'help')
+    .describe('h', 'Show usage information')
+    .argv;
+
+if (argv.help) {
+    optimist.showHelp();
+    return process.exit(0);
+}
+
+// Get the config
+var configPath = path.resolve(process.cwd(), argv.config);
+var config = require(configPath).config;
+
+// ...and the tenant
+var tenantAlias = argv.tenant;
+
+// Ensure that this application server does NOT start processing any preview images
+config.previews.enabled = false;
+
+// Ensure that we're logging to standard out/err
+config.log = {
+    'streams': [
+        {
+            'level': 'info',
+            'stream': process.stdout
+        }
+    ]
+};
+
+// Set up the CSV file for errors
+var fileStream = fs.createWriteStream(tenantAlias + '-shibboleth-migration.csv');
+fileStream.on('error', function(err) {
+    log().error({'err': err}, 'Error occurred when writing to the warnings file');
+    process.exit(1);
+});
+var csvStream = csv.stringify({
+    'columns': ['principal_id', 'email', 'display_name', 'login_id', 'message'],
+    'header': true,
+    'quoted': true
+});
+csvStream.pipe(fileStream);
+
+// Spin up the application container. This will allow us to re-use existing APIs
+OAE.init(config, function(err) {
+    if (err) {
+        log().error({'err': err}, 'Unable to spin up the application server');
+        return _exit(err.code);
+    }
+
+    ShibbolethMigrator.doMigration(tenantAlias, csvStream, function(err, errors) {
+        if (err) {
+            return _exit(err.code);
+        }
+
+        if (errors > 0) {
+            log().warn('Some users could not be mapped to Shibboleth logins, check the CSV file for more information');
+
+        } else {
+            log().info('All users were succesfully migrated to Shibboleth');
+        }
+
+        _exit(0);
+    });
+});
+
+/**
+ * Exit the migration script, but wait until the CSV stream has been properly closed down
+ *
+ * @param  {Number}     code    The exit code that should be used to stop the process with
+ */
+var _exit = function(code) {
+    csvStream.end(function() {
+        process.exit(code);
+    });
+};

--- a/node_modules/oae-authentication/tests/test-shibboleth-migration.js
+++ b/node_modules/oae-authentication/tests/test-shibboleth-migration.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 Apereo Foundation (AF) Licensed under the
+ * Educational Community License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+var _ = require('underscore');
+var assert = require('assert');
+var csv = require('csv');
+var fs = require('fs');
+var util = require('util');
+
+var AuthzTestUtil = require('oae-authz/lib/test/util');
+var Cassandra = require('oae-util/lib/cassandra');
+var PrincipalsDAO = require('oae-principals/lib/internal/dao');
+var RestAPI = require('oae-rest');
+var ShibbolethMigrator = require('../../../etc/migration/shibboleth_migration/migrateUsersToShibboleth.js');
+var TestsUtil = require('oae-tests');
+
+var csvStream = {};
+
+describe('Shibboleth Migration', function() {
+    var camAdminRestContext = null;
+    var gtAdminRestContext = null;
+
+    before(function(callback) {
+        camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
+        gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
+
+        // Set up the CSV file for errors
+        var fileStream = fs.createWriteStream('shibboleth-migration-test.csv');
+        fileStream.on('error', function(err) {
+            log().error({'err': err}, 'Error occurred when writing to the warnings file');
+            process.exit(1);
+        });
+        csvStream = csv.stringify({
+            'columns': ['principal_id', 'email', 'display_name', 'login_id', 'message'],
+            'header': true,
+            'quoted': true
+        });
+        csvStream.pipe(fileStream);
+
+        return callback();
+    });
+
+    /**
+     * Test that verifies emails are made case insensitive
+     */
+    it('verify new Shibboleth logins are created', function(callback) {
+        TestsUtil.generateTestUsers(camAdminRestContext, 500, function(err, users) {
+            assert.ok(!err);
+
+            users = _.chain(users)
+                .values()
+                .pluck('user')
+                .value();
+
+            RestAPI.Tenants.getTenant(camAdminRestContext, null, function(err, tenant) {
+                assert.ok(!err);
+                var tenantAlias = tenant.alias;
+
+                // Create Google logins for all users
+                var googleLoginIds = _.map(users, function(user) {
+                        return {
+                            userId: user.id,
+                            loginId: util.format('%s:google:%s', tenantAlias, user.email)
+                        };
+                    });
+
+                var queries = _.chain(googleLoginIds)
+                    .map(function(googleLoginId) {
+                        var userId = googleLoginId.userId;
+                        var loginId = googleLoginId.loginId;
+                        return [
+                            {
+                                'query': 'INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)',
+                                'parameters': [loginId, userId, '1']
+                            },
+                            {
+                                'query': 'INSERT INTO "AuthenticationLoginId" ("loginId", "userId") VALUES (?, ?)',
+                                'parameters': [loginId, userId]
+                            }
+                        ];
+                    })
+                    .flatten()
+                    .value();
+
+                Cassandra.runBatchQuery(queries, function(err) {
+                    assert.ok(!err);
+
+                    // Run the migration
+                    ShibbolethMigrator.doMigration(tenantAlias, csvStream, function(err, errors) {
+                        assert.ok(!err);
+
+                        var sampleUser = _.sample(users);
+                        var shibLogin = util.format('%s:shibboleth:%s', tenantAlias, sampleUser.email);
+
+                        Cassandra.runQuery('SELECT "loginId" FROM "AuthenticationLoginId" WHERE "loginId" = ?', [shibLogin], function(err, rows) {
+                            assert.ok(!err);
+
+                            var result = _.chain(rows)
+                                .map(Cassandra.rowToHash)
+                                .pluck('loginId')
+                                .first()
+                                .value();
+
+                            assert.strictEqual(result, shibLogin);
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/node_modules/oae-authentication/tests/test-shibboleth-migration.js
+++ b/node_modules/oae-authentication/tests/test-shibboleth-migration.js
@@ -27,11 +27,10 @@ var RestAPI = require('oae-rest');
 var ShibbolethMigrator = require('../../../etc/migration/shibboleth_migration/migrateUsersToShibboleth.js');
 var TestsUtil = require('oae-tests');
 
-var csvStream = {};
-
 describe('Shibboleth Migration', function() {
     var camAdminRestContext = null;
     var gtAdminRestContext = null;
+    var csvStream = null;
 
     before(function(callback) {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
@@ -54,9 +53,11 @@ describe('Shibboleth Migration', function() {
     });
 
     after(function(callback) {
+        // Make sure we close the CSV stream...
         csvStream.end(function() {
+            // ...and remove the file
             rimraf('shibboleth-migration-test.csv', function() {
-                callback();
+                return callback();
             });
         });
     });
@@ -70,7 +71,7 @@ describe('Shibboleth Migration', function() {
      * @throws {AssertionError}                     Thrown if the assertions fail
      */
     var _assertHaveShibbolethLoginIds = function(tenantAlias, users, callback) {
-        if(_.isEmpty(users)) {
+        if (_.isEmpty(users)) {
             return callback();
         }
 
@@ -99,8 +100,8 @@ describe('Shibboleth Migration', function() {
      * @param  {Function}       callback            Invoked when assertions are complete
      * @throws {AssertionError}                     Thrown if the assertions fail
      */
-    var _assertNoShibbolethLoginIds = function(tenantAlias, users, callback) {
-        if(_.isEmpty(users)) {
+    var _assertHaveNoShibbolethLoginIds = function(tenantAlias, users, callback) {
+        if (_.isEmpty(users)) {
             return callback();
         }
 
@@ -109,12 +110,46 @@ describe('Shibboleth Migration', function() {
 
         Cassandra.runQuery('SELECT "loginId" FROM "AuthenticationLoginId" WHERE "loginId" = ?', [shibLogin], function(err, rows) {
             assert.ok(!err);
-
             var result = _.map(rows, Cassandra.rowToHash);
 
             assert.ok(_.isEmpty(result));
-            return _assertNoShibbolethLoginIds(tenantAlias, users, callback);
+            return _assertHaveNoShibbolethLoginIds(tenantAlias, users, callback);
         });
+    };
+
+    /*!
+     * Create Google authentication records for a set of users
+     *
+     * @param  String           tenantAlias         The tenant we are testing
+     * @param  {Object[]}       users               The users we want to check login for
+     * @return {Object[]}       queries             The Cassandra queries to create the records
+     */
+    var _createGoogleLogins = function(tenantAlias, users) {
+        // Create Google logins for users
+        var googleLoginIds = _.map(users, function(user) {
+                return {
+                    userId: user.id,
+                    loginId: util.format('%s:google:%s', tenantAlias, user.email)
+                };
+            });
+
+        var queries = _.chain(googleLoginIds)
+            .map(function(googleLoginId) {
+                return [
+                    {
+                        'query': 'INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)',
+                        'parameters': [googleLoginId.loginId, googleLoginId.userId, '1']
+                    },
+                    {
+                        'query': 'INSERT INTO "AuthenticationLoginId" ("loginId", "userId") VALUES (?, ?)',
+                        'parameters': [googleLoginId.loginId, googleLoginId.userId]
+                    }
+                ];
+            })
+            .flatten()
+            .value();
+
+        return queries;
     };
 
     /**
@@ -132,32 +167,7 @@ describe('Shibboleth Migration', function() {
             RestAPI.Tenants.getTenant(camAdminRestContext, null, function(err, tenant) {
                 assert.ok(!err);
                 var tenantAlias = tenant.alias;
-
-                // Create Google logins for all users
-                var googleLoginIds = _.map(users, function(user) {
-                        return {
-                            userId: user.id,
-                            loginId: util.format('%s:google:%s', tenantAlias, user.email)
-                        };
-                    });
-
-                var queries = _.chain(googleLoginIds)
-                    .map(function(googleLoginId) {
-                        var userId = googleLoginId.userId;
-                        var loginId = googleLoginId.loginId;
-                        return [
-                            {
-                                'query': 'INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)',
-                                'parameters': [loginId, userId, '1']
-                            },
-                            {
-                                'query': 'INSERT INTO "AuthenticationLoginId" ("loginId", "userId") VALUES (?, ?)',
-                                'parameters': [loginId, userId]
-                            }
-                        ];
-                    })
-                    .flatten()
-                    .value();
+                var queries = _createGoogleLogins(tenantAlias, users);
 
                 Cassandra.runBatchQuery(queries, function(err) {
                     assert.ok(!err);
@@ -187,38 +197,14 @@ describe('Shibboleth Migration', function() {
                 .pluck('user')
                 .value();
 
+            // Split the users into a group with and a group without Google IDs
             var googleUsers = _.sample(users, 25);
             var nonGoogleUsers = _.difference(users, googleUsers);
 
             RestAPI.Tenants.getTenant(gtAdminRestContext, null, function(err, tenant) {
                 assert.ok(!err);
                 var tenantAlias = tenant.alias;
-
-                // Create Google logins for some users
-                var googleLoginIds = _.map(googleUsers, function(user) {
-                        return {
-                            userId: user.id,
-                            loginId: util.format('%s:google:%s', tenantAlias, user.email)
-                        };
-                    });
-
-                var queries = _.chain(googleLoginIds)
-                    .map(function(googleLoginId) {
-                        var userId = googleLoginId.userId;
-                        var loginId = googleLoginId.loginId;
-                        return [
-                            {
-                                'query': 'INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)',
-                                'parameters': [loginId, userId, '1']
-                            },
-                            {
-                                'query': 'INSERT INTO "AuthenticationLoginId" ("loginId", "userId") VALUES (?, ?)',
-                                'parameters': [loginId, userId]
-                            }
-                        ];
-                    })
-                    .flatten()
-                    .value();
+                var queries = _createGoogleLogins(tenantAlias, googleUsers);
 
                 Cassandra.runBatchQuery(queries, function(err) {
                     assert.ok(!err);
@@ -228,7 +214,7 @@ describe('Shibboleth Migration', function() {
                         assert.ok(!err);
 
                         _assertHaveShibbolethLoginIds(tenantAlias, googleUsers, function() {
-                            _assertNoShibbolethLoginIds(tenantAlias, nonGoogleUsers, function() {
+                            _assertHaveNoShibbolethLoginIds(tenantAlias, nonGoogleUsers, function() {
                                 return callback();
                             });
                         });

--- a/node_modules/oae-authentication/tests/test-shibboleth-migration.js
+++ b/node_modules/oae-authentication/tests/test-shibboleth-migration.js
@@ -17,6 +17,7 @@ var _ = require('underscore');
 var assert = require('assert');
 var csv = require('csv');
 var fs = require('fs');
+var rimraf = require('rimraf');
 var util = require('util');
 
 var AuthzTestUtil = require('oae-authz/lib/test/util');
@@ -52,6 +53,14 @@ describe('Shibboleth Migration', function() {
         return callback();
     });
 
+    after(function(callback) {
+        csvStream.end(function() {
+            rimraf('shibboleth-migration-test.csv', function() {
+                callback();
+            });
+        });
+    });
+
     /*!
      * Check that Shibboleth login ID records were created for all users with Google login
      * 
@@ -60,7 +69,7 @@ describe('Shibboleth Migration', function() {
      * @param  {Function}       callback            Invoked when assertions are complete
      * @throws {AssertionError}                     Thrown if the assertions fail
      */
-    var _assertShibbolethLoginIds = function(tenantAlias, users, callback) {
+    var _assertHaveShibbolethLoginIds = function(tenantAlias, users, callback) {
         if(_.isEmpty(users)) {
             return callback();
         }
@@ -78,12 +87,38 @@ describe('Shibboleth Migration', function() {
                 .value();
 
             assert.strictEqual(result, shibLogin);
-            return _assertShibbolethLoginIds(tenantAlias, users, callback);
+            return _assertHaveShibbolethLoginIds(tenantAlias, users, callback);
+        });
+    };
+
+    /*!
+     * Check that no Shibboleth login ID records were created for users without a Google login ID
+     * 
+     * @param  String           tenantAlias         The tenant we are testing
+     * @param  {Object[]}       users               The users we want to check login for
+     * @param  {Function}       callback            Invoked when assertions are complete
+     * @throws {AssertionError}                     Thrown if the assertions fail
+     */
+    var _assertNoShibbolethLoginIds = function(tenantAlias, users, callback) {
+        if(_.isEmpty(users)) {
+            return callback();
+        }
+
+        var user = users.shift();
+        var shibLogin = util.format('%s:shibboleth:%s', tenantAlias, user.email);
+
+        Cassandra.runQuery('SELECT "loginId" FROM "AuthenticationLoginId" WHERE "loginId" = ?', [shibLogin], function(err, rows) {
+            assert.ok(!err);
+
+            var result = _.map(rows, Cassandra.rowToHash);
+
+            assert.ok(_.isEmpty(result));
+            return _assertNoShibbolethLoginIds(tenantAlias, users, callback);
         });
     };
 
     /**
-     * Test that verifies emails are made case insensitive
+     * Test that verifies Shibboleth logins are created for a tenant
      */
     it('verify new Shibboleth logins are created', function(callback) {
         TestsUtil.generateTestUsers(camAdminRestContext, 500, function(err, users) {
@@ -131,8 +166,71 @@ describe('Shibboleth Migration', function() {
                     ShibbolethMigrator.doMigration(tenantAlias, csvStream, function(err, errors) {
                         assert.ok(!err);
 
-                        _assertShibbolethLoginIds(tenantAlias, users, function() {
+                        _assertHaveShibbolethLoginIds(tenantAlias, users, function() {
                             return callback();
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    /**
+     * Test that verifies no logins are created for users without Google login IDs
+     */
+    it('verify no Shibboleth logins are created for users without Google IDs', function(callback) {
+        TestsUtil.generateTestUsers(gtAdminRestContext, 50, function(err, users) {
+            assert.ok(!err);
+
+            users = _.chain(users)
+                .values()
+                .pluck('user')
+                .value();
+
+            var googleUsers = _.sample(users, 25);
+            var nonGoogleUsers = _.difference(users, googleUsers);
+
+            RestAPI.Tenants.getTenant(gtAdminRestContext, null, function(err, tenant) {
+                assert.ok(!err);
+                var tenantAlias = tenant.alias;
+
+                // Create Google logins for some users
+                var googleLoginIds = _.map(googleUsers, function(user) {
+                        return {
+                            userId: user.id,
+                            loginId: util.format('%s:google:%s', tenantAlias, user.email)
+                        };
+                    });
+
+                var queries = _.chain(googleLoginIds)
+                    .map(function(googleLoginId) {
+                        var userId = googleLoginId.userId;
+                        var loginId = googleLoginId.loginId;
+                        return [
+                            {
+                                'query': 'INSERT INTO "AuthenticationUserLoginId" ("loginId", "userId", "value") VALUES (?, ?, ?)',
+                                'parameters': [loginId, userId, '1']
+                            },
+                            {
+                                'query': 'INSERT INTO "AuthenticationLoginId" ("loginId", "userId") VALUES (?, ?)',
+                                'parameters': [loginId, userId]
+                            }
+                        ];
+                    })
+                    .flatten()
+                    .value();
+
+                Cassandra.runBatchQuery(queries, function(err) {
+                    assert.ok(!err);
+
+                    // Run the migration
+                    ShibbolethMigrator.doMigration(tenantAlias, csvStream, function(err, errors) {
+                        assert.ok(!err);
+
+                        _assertHaveShibbolethLoginIds(tenantAlias, googleUsers, function() {
+                            _assertNoShibbolethLoginIds(tenantAlias, nonGoogleUsers, function() {
+                                return callback();
+                            });
                         });
                     });
                 });

--- a/node_modules/oae-authentication/tests/test-shibboleth-migration.js
+++ b/node_modules/oae-authentication/tests/test-shibboleth-migration.js
@@ -16,13 +16,10 @@
 var _ = require('underscore');
 var assert = require('assert');
 var csv = require('csv');
-var fs = require('fs');
-var rimraf = require('rimraf');
+var temp = require('temp');
 var util = require('util');
 
-var AuthzTestUtil = require('oae-authz/lib/test/util');
 var Cassandra = require('oae-util/lib/cassandra');
-var PrincipalsDAO = require('oae-principals/lib/internal/dao');
 var RestAPI = require('oae-rest');
 var ShibbolethMigrator = require('../../../etc/migration/shibboleth_migration/migrateUsersToShibboleth.js');
 var TestsUtil = require('oae-tests');
@@ -36,29 +33,25 @@ describe('Shibboleth Migration', function() {
         camAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.cam.host);
         gtAdminRestContext = TestsUtil.createTenantAdminRestContext(global.oaeTests.tenants.gt.host);
 
-        // Set up the CSV file for errors
-        var fileStream = fs.createWriteStream('shibboleth-migration-test.csv');
-        fileStream.on('error', function(err) {
+        // Set up the fake CSV file for errors
+        var fakeStream = temp.createWriteStream();
+        fakeStream.on('error', function(err) {
             log().error({'err': err}, 'Error occurred when writing to the warnings file');
-            process.exit(1);
         });
         csvStream = csv.stringify({
             'columns': ['principal_id', 'email', 'display_name', 'login_id', 'message'],
             'header': true,
             'quoted': true
         });
-        csvStream.pipe(fileStream);
+        csvStream.pipe(fakeStream);
 
         return callback();
     });
 
     after(function(callback) {
-        // Make sure we close the CSV stream...
+        // Make sure we close the CSV stream and remove the file
         csvStream.end(function() {
-            // ...and remove the file
-            rimraf('shibboleth-migration-test.csv', function() {
-                return callback();
-            });
+            return callback();
         });
     });
 

--- a/node_modules/oae-authentication/tests/test-shibboleth-migration.js
+++ b/node_modules/oae-authentication/tests/test-shibboleth-migration.js
@@ -52,6 +52,36 @@ describe('Shibboleth Migration', function() {
         return callback();
     });
 
+    /*!
+     * Check that Shibboleth login ID records were created for all users with Google login
+     * 
+     * @param  String           tenantAlias         The tenant we are testing
+     * @param  {Object[]}       users               The users we want to check login for
+     * @param  {Function}       callback            Invoked when assertions are complete
+     * @throws {AssertionError}                     Thrown if the assertions fail
+     */
+    var _assertShibbolethLoginIds = function(tenantAlias, users, callback) {
+        if(_.isEmpty(users)) {
+            return callback();
+        }
+
+        var user = users.shift();
+        var shibLogin = util.format('%s:shibboleth:%s', tenantAlias, user.email);
+
+        Cassandra.runQuery('SELECT "loginId" FROM "AuthenticationLoginId" WHERE "loginId" = ?', [shibLogin], function(err, rows) {
+            assert.ok(!err);
+
+            var result = _.chain(rows)
+                .map(Cassandra.rowToHash)
+                .pluck('loginId')
+                .first()
+                .value();
+
+            assert.strictEqual(result, shibLogin);
+            return _assertShibbolethLoginIds(tenantAlias, users, callback);
+        });
+    };
+
     /**
      * Test that verifies emails are made case insensitive
      */
@@ -101,19 +131,7 @@ describe('Shibboleth Migration', function() {
                     ShibbolethMigrator.doMigration(tenantAlias, csvStream, function(err, errors) {
                         assert.ok(!err);
 
-                        var sampleUser = _.sample(users);
-                        var shibLogin = util.format('%s:shibboleth:%s', tenantAlias, sampleUser.email);
-
-                        Cassandra.runQuery('SELECT "loginId" FROM "AuthenticationLoginId" WHERE "loginId" = ?', [shibLogin], function(err, rows) {
-                            assert.ok(!err);
-
-                            var result = _.chain(rows)
-                                .map(Cassandra.rowToHash)
-                                .pluck('loginId')
-                                .first()
-                                .value();
-
-                            assert.strictEqual(result, shibLogin);
+                        _assertShibbolethLoginIds(tenantAlias, users, function() {
                             return callback();
                         });
                     });


### PR DESCRIPTION
The Cambridge tenancy is set up with Google auth, and we would like to migrate it to Shibboleth

If we change the authentication method then we need a way to link newly created accounts (using Shib) to the one's belonging to the same users (using GA) so they still have all he same content and access.

We have established that we should be able to link the accounts using EPPN. A node.js script needs to be written to copy user emails for Cambridge from the user profile to a shibboleth login id entry associated to the user.
