### PR TITLE
Searching private tenant should only ever return results from that tenant

### DIFF
--- a/node_modules/oae-search/lib/constants.js
+++ b/node_modules/oae-search/lib/constants.js
@@ -41,8 +41,8 @@ SearchConstants.general = {
     'RESOURCE_TYPE_GROUP': 'group',
     'RESOURCE_TYPE_USER': 'user',
 
-    // A search scope that includes resources for all tenants, including private tenants / tenants
-    // outside of the current tenant's network
+    // For the global admin this search scope includes resources for all tenants (including private
+    // tenants), but for other users it works like the network scope
     'SCOPE_ALL': '_all',
 
     // A search scope that includes resources for tenants within the current tenant's network, as

--- a/node_modules/oae-search/lib/util.js
+++ b/node_modules/oae-search/lib/util.js
@@ -480,7 +480,7 @@ var filterResources = module.exports.filterResources = function(resourceTypes, d
  * can interact
  *
  * @param  {String}     tenantAlias     The alias of the tenant for which to filter interacting tenants
- * @return {Object}                     The filter that narrows results down to only tenants with which the specified tenant alias
+ * @return {Object}                     The filter that narrows results down to only tenants with which the specified tenant alias can interact with
  */
 var filterInteractingTenants = module.exports.filterInteractingTenants = function(tenantAlias) {
     if (TenantsUtil.isPrivate(tenantAlias)) {
@@ -519,10 +519,10 @@ var filterScopeAndAccess = module.exports.filterScopeAndAccess = function(ctx, s
     OaeUtil.invokeIfNecessary(needsFilterByExplicitAccess, filterExplicitAccess, ctx, function(err, explicitAccessFilter) {
         if (err) {
             return callback(err);
-        } else if (scope === SearchConstants.general.SCOPE_ALL) {
-            // When searching all, we only care about the access
+        } else if (user && user.isGlobalAdmin() && scope === SearchConstants.general.SCOPE_ALL) {
+            // Global admins can search all public resources, including private tenants'
             return callback(null, filterOr(implicitAccessFilter, explicitAccessFilter));
-        } else if (scope === SearchConstants.general.SCOPE_NETWORK) {
+        } else if (scope === SearchConstants.general.SCOPE_NETWORK || scope === SearchConstants.general.SCOPE_ALL) {
             // When searching network, we care about access and the scope of the tenant network (i.e.,
             // scope public tenants away from private). All resources outside the network that the
             // user has explicit access to are included as well

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -764,7 +764,7 @@ describe('General Search', function() {
         /**
          * Test that verifies that the _all scope searches everything from all tenants
          */
-        it('verify "all" search scope searches resources from both inside and outside the tenant network', function(callback) {
+        it('verify "all" search scope searches resources from inside and outside the tenant network (but not private tenants)', function(callback) {
             TestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant0, publicTenant1, privateTenant0, privateTenant1) {
 
                 // It should search everything in the system when searching as the global administrator
@@ -775,13 +775,13 @@ describe('General Search', function() {
                                 searchForResource(globalAdminRestContext, '_all', privateTenant0.loggedinUser.user, true, function() {
                                     searchForResource(globalAdminRestContext, '_all', privateTenant0.privateUser.user, true, function() {
 
-                                        // It should search public resources from all tenants (private and public) when searching
+                                        // It should search public resources from public tenants but not private tenants when searching
                                         // as a regular user
                                         TestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant0, publicTenant1, privateTenant0, privateTenant1) {
                                             searchForResource(publicTenant0.publicUser.restContext, '_all', publicTenant0.publicUser.user, true, function() {
                                                 searchForResource(publicTenant0.publicUser.restContext, '_all', publicTenant0.loggedinUser.user, true, function() {
                                                     searchForResource(publicTenant0.publicUser.restContext, '_all', publicTenant0.privateUser.user, false, function() {
-                                                        searchForResource(publicTenant0.publicUser.restContext, '_all', privateTenant0.publicUser.user, true, function() {
+                                                        searchForResource(publicTenant0.publicUser.restContext, '_all', privateTenant0.publicUser.user, false, function() {
                                                             searchForResource(publicTenant0.publicUser.restContext, '_all', privateTenant0.loggedinUser.user, false, function() {
                                                                 searchForResource(publicTenant0.publicUser.restContext, '_all', privateTenant0.privateUser.user, false, function() {
                                                                     return callback();

--- a/node_modules/oae-search/tests/test-general-search.js
+++ b/node_modules/oae-search/tests/test-general-search.js
@@ -784,8 +784,24 @@ describe('General Search', function() {
                                                         searchForResource(publicTenant0.publicUser.restContext, '_all', privateTenant0.publicUser.user, false, function() {
                                                             searchForResource(publicTenant0.publicUser.restContext, '_all', privateTenant0.loggedinUser.user, false, function() {
                                                                 searchForResource(publicTenant0.publicUser.restContext, '_all', privateTenant0.privateUser.user, false, function() {
-                                                                    return callback();
-                                                                });
+
+                                                                    // It should search public resources from private tenants when searching as a private tenant user
+                                                                    TestsUtil.setupMultiTenantPrivacyEntities(function(publicTenant0, publicTenant1, privateTenant0, privateTenant1) {
+                                                                        searchForResource(privateTenant0.publicUser.restContext, '_all', publicTenant0.publicUser.user, false, function() {
+                                                                            searchForResource(privateTenant0.publicUser.restContext, '_all', publicTenant0.loggedinUser.user, false, function() {
+                                                                                searchForResource(privateTenant0.publicUser.restContext, '_all', publicTenant0.privateUser.user, false, function() {
+                                                                                    searchForResource(privateTenant0.publicUser.restContext, '_all', privateTenant0.publicUser.user, true, function() {
+                                                                                        searchForResource(privateTenant0.publicUser.restContext, '_all', privateTenant0.loggedinUser.user, true, function() {
+                                                                                            searchForResource(privateTenant0.publicUser.restContext, '_all', privateTenant0.privateUser.user, false, function() {
+                                                                                                return callback();
+                                                                                            });
+                                                                                        });
+                                                                                    });
+                                                                                });
+                                                                            });
+                                                                        });
+                                                                    });
+                                                               });
                                                             });
                                                         });
                                                     });


### PR DESCRIPTION
A private tenant (e.g., The Fold) currently returns search results that are outside of that tenant. All searches on a private tenant should be limited to that tenant. The "this tenant only" checkbox in the UI should also be hidden for private tenants.

![screen shot 2016-07-06 at 06 17 46](https://cloud.githubusercontent.com/assets/109850/16619170/e624e21e-4341-11e6-83f1-736937231555.png)
