### PR TITLE
Adds check to not create `unreadNotifications` for deleted users

### DIFF
--- a/node_modules/oae-principals/lib/internal/dao.js
+++ b/node_modules/oae-principals/lib/internal/dao.js
@@ -756,7 +756,7 @@ var _getUserFromRedis = function(userId, callback) {
  * @api private
  */
 var _getPrincipalFromRow = function(row) {
-    if (row.count <= 1) {
+    if (row.count <= 1 || !row.tenantAlias || !row.displayName) {
         return null;
     }
 


### PR DESCRIPTION
So, the issue was that after records had been deleted from `Principals`, they were still members of groups and had activities created for them when something happened in those groups. This led to partial records being created in the `Principals` table, which then caused errors when Hilary tried to access those records (as they were missing required fields like `tenantAlias`). I've added a check to stop users from being collected if the records are invalid, which I think should stop the errors from happening; the other thing we need to do is to make sure we delete `AuthzRoles` records as well when deleting users manually. This should no longer be necessary when the task to permanently delete users is completed, but we should also keep an eye on the issue when reviewing that task.