### PR TITLE
#1257 - Retrieve test log level from environment

### DIFF
--- a/local.js
+++ b/local.js
@@ -30,7 +30,7 @@ var config = module.exports.config = {};
  */
 config.test = {
     'timeout': 60000,
-    'level': process.env.OAE_TEST_LOG_LEVEL || 'info',
-    'path': process.env.OAE_TEST_LOG_PATH || './tests.log'
+    'level': 'info',
+    'path': './tests.log'
 };
 

--- a/local.js
+++ b/local.js
@@ -25,7 +25,12 @@ var config = module.exports.config = {};
  * Configuration namespace for the OAE tests.
  *
  * @param  {String}    timeout            The mocha timeout that should be used
+ * @param  {String}    level              The log level that should be used for testing
+ * @param  {String}    path               The log path that should be used for testing
  */
 config.test = {
-    'timeout': 60000
+    'timeout': 60000,
+    'level': process.env.OAE_TEST_LOG_LEVEL || 'info',
+    'path': process.env.OAE_TEST_LOG_PATH || './tests.log'
 };
+

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -983,8 +983,8 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
 
     // log everything (except mocha output) to tests.log
     config.log.streams = [{
-        'level': process.env.OAE_TEST_LOG_LEVEL || 'trace',
-        'path': process.env.OAE_TEST_LOG_PATH || './tests.log'
+        'level': config.test.level,
+        'path': config.test.path
     }];
 
     // Unit test will purge the rabbit mq queues when they're connected

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -983,8 +983,8 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
 
     // log everything (except mocha output) to tests.log
     config.log.streams = [{
-        'level': 'info',
-        'path': './tests.log'
+        'level': process.env.OAE_TEST_LOG_LEVEL || 'trace',
+        'path': process.env.OAE_TEST_LOG_PATH || './tests.log'
     }];
 
     // Unit test will purge the rabbit mq queues when they're connected

--- a/node_modules/oae-tests/lib/util.js
+++ b/node_modules/oae-tests/lib/util.js
@@ -983,8 +983,8 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
 
     // log everything (except mocha output) to tests.log
     config.log.streams = [{
-        'level': config.test.level,
-        'path': config.test.path
+        'level': config.test.level || 'info',
+        'path': config.test.path || './tests.log'
     }];
 
     // Unit test will purge the rabbit mq queues when they're connected


### PR DESCRIPTION
This is with reference to issue #1257 to make the test log level
configurable. If OAE_TEST_LOG_LEVEL or OAE_TEST_LOG_PATH are
not present in the environment, they would be defaulted to 'trace' and
'./test.log' respectively.