### PR TITLE
Changed reconnection and load balancing for Cassandra

### DIFF
--- a/node_modules/oae-util/lib/cassandra.js
+++ b/node_modules/oae-util/lib/cassandra.js
@@ -96,10 +96,9 @@ var _createNewClient = function (hosts, keyspace) {
         keyspace: keyspace,
         protocolOptions: { maxVersion: 3 },
         socketOptions: {
-            readTimeout: CONFIG.timeout,
             connectTimeout: CONFIG.timeout
         },
-        consistency: 'two'
+        consistency: cassandra.types.consistencies.quorum
     });
 };
 

--- a/node_modules/oae-util/lib/cassandra.js
+++ b/node_modules/oae-util/lib/cassandra.js
@@ -84,17 +84,22 @@ module.exports.init = function(config, callback) {
 };
 
 var _createNewClient = function (hosts, keyspace) {
+    const loadBalancingPolicy = new cassandra.policies.loadBalancing.RoundRobinPolicy();
+    const reconnectionPolicy = new cassandra.policies.reconnection.ConstantReconnectionPolicy(CONFIG.timeout);
     return new cassandra.Client({
         contactPoints: hosts,
         policies: {
-            timestampGeneration: null
+            timestampGeneration: null,
+            loadBalancing: loadBalancingPolicy,
+            reconnection: reconnectionPolicy
         },
         keyspace: keyspace,
         protocolOptions: { maxVersion: 3 },
         socketOptions: {
             readTimeout: CONFIG.timeout,
-            connectTimeout: CONFIG.timeout },
-        consistency: 2
+            connectTimeout: CONFIG.timeout
+        },
+        consistency: 'two'
     });
 };
 


### PR DESCRIPTION
What it says on the tin; this *may* help with the test issues. There's a couple of things here I'd like to check... Firstly I'm not sure if we want to have `consistency: 'two'` or if we should set it to some other value, or even not set it at all in the client and allow instances to specify it for themselves in cassandra.yaml... Secondly, I'm not sure if we want to keep the `readTimeout` value here - see comment in the [client options doc](http://docs.datastax.com/en/developer/nodejs-driver/3.3/api/type.ClientOptions/).